### PR TITLE
Update bot name and enhance markdown output in walkthrough feature

### DIFF
--- a/src/mira/cli.py
+++ b/src/mira/cli.py
@@ -219,7 +219,7 @@ def review(
     required=True,
     help="Webhook secret from GitHub App settings",
 )
-@click.option("--bot-name", envvar="MIRA_BOT_NAME", default="mira-bot", help="Bot @mention name")
+@click.option("--bot-name", envvar="MIRA_BOT_NAME", default="miracodeai", help="Bot @mention name")
 @click.option(
     "--posthog-api-key",
     envvar="POSTHOG_API_KEY",

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -65,6 +65,14 @@ class ReviewEngine:
             except Exception as exc:
                 logger.warning("Failed to post walkthrough comment: %s", exc)
 
+        # Resolve outdated review threads before posting new ones
+        try:
+            resolved = await self.provider.resolve_outdated_review_threads(pr_info)
+            if resolved:
+                logger.info("Resolved %d outdated review thread(s) on PR %s", resolved, pr_info.url)
+        except Exception as exc:
+            logger.warning("Failed to resolve outdated review threads: %s", exc)
+
         # Only post if there are comments
         if result.comments:
             await self.provider.post_review(pr_info, result)

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -34,10 +34,12 @@ class ReviewEngine:
         config: MiraConfig,
         llm: LLMProvider,
         provider: BaseProvider | None = None,
+        bot_name: str = "miracodeai",
     ) -> None:
         self.config = config
         self.llm = llm
         self.provider = provider
+        self.bot_name = bot_name
 
     async def review_pr(self, pr_url: str) -> ReviewResult:
         """Full pipeline: fetch PR -> review -> post results."""
@@ -56,7 +58,7 @@ class ReviewEngine:
         # Post walkthrough comment before inline review (upsert: edit if exists)
         if result.walkthrough:
             try:
-                markdown = result.walkthrough.to_markdown()
+                markdown = result.walkthrough.to_markdown(bot_name=self.bot_name)
                 existing_id = await self.provider.find_bot_comment(pr_info, WALKTHROUGH_MARKER)
                 if existing_id is not None:
                     await self.provider.update_comment(pr_info, existing_id, markdown)

--- a/src/mira/github_app/handlers.py
+++ b/src/mira/github_app/handlers.py
@@ -20,7 +20,10 @@ _REVIEW_KEYWORDS = {"review", "review this", "review this pr"}
 
 
 async def handle_pull_request(
-    payload: dict[str, Any], app_auth: GitHubAppAuth, metrics: Metrics | None = None
+    payload: dict[str, Any],
+    app_auth: GitHubAppAuth,
+    bot_name: str,
+    metrics: Metrics | None = None,
 ) -> None:
     """Handle a pull_request event by running a full review."""
     installation_id: int = payload.get("installation", {}).get("id", 0)
@@ -37,7 +40,7 @@ async def handle_pull_request(
         config = load_config()
         llm = LLMProvider(config.llm)
         provider = GitHubProvider(token)
-        engine = ReviewEngine(config=config, llm=llm, provider=provider)
+        engine = ReviewEngine(config=config, llm=llm, provider=provider, bot_name=bot_name)
 
         logger.info("Reviewing PR %s", pr_url)
         result = await engine.review_pr(pr_url)
@@ -89,7 +92,7 @@ async def handle_comment(
 
         is_review = question.lower() in _REVIEW_KEYWORDS
         if is_review:
-            engine = ReviewEngine(config=config, llm=llm, provider=provider)
+            engine = ReviewEngine(config=config, llm=llm, provider=provider, bot_name=bot_name)
             logger.info("Re-review triggered for PR %s by @%s", pr_url, comment_user)
             await engine.review_pr(pr_url)
             logger.info("Re-review complete for PR %s", pr_url)

--- a/src/mira/github_app/webhooks.py
+++ b/src/mira/github_app/webhooks.py
@@ -74,7 +74,7 @@ def create_app(
                     installation_id=installation_id,
                     properties={"event_type": event, "action": action, "status": "processing"},
                 )
-            background_tasks.add_task(handle_pull_request, payload, app_auth, metrics)
+            background_tasks.add_task(handle_pull_request, payload, app_auth, bot_name, metrics)
             return Response(
                 content='{"status": "processing"}',
                 status_code=200,

--- a/src/mira/llm/prompts/templates/review.jinja2
+++ b/src/mira/llm/prompts/templates/review.jinja2
@@ -8,6 +8,7 @@ You are Mira, an expert AI code reviewer. Your job is to review pull request dif
 - Each comment must be specific, actionable, and tied to a specific file and line number.
 - Only comment on lines that are **changed** (added or modified) in the diff.
 - Be confident — only flag issues you are reasonably sure about.
+- For each comment, write an `agent_prompt`: a concise imperative instruction for an AI coding agent to apply the fix. Reference the file path, line range, specific code elements, and describe the exact changes needed. Write it as a single paragraph in plain text (no markdown).
 - Set confidence to reflect how certain you are (0.0–1.0). Only include comments with confidence >= {{ confidence_threshold }}.
 - Aim for **{{ max_comments }} or fewer** comments. Quality over quantity.
 - You only see changed code segments (diff hunks), not the entire codebase. Do not suggest changes that might duplicate existing functionality or question elements (variables, imports) that may be defined elsewhere.
@@ -43,7 +44,8 @@ Respond with a JSON object (no markdown fences) matching this schema:
       "body": "Detailed explanation of the issue and how to fix it.",
       "confidence": 0.85,
       "existing_code": "The exact line(s) of code this comment refers to (copy from diff)",
-      "suggestion": "Optional code suggestion to fix the issue, or null"
+      "suggestion": "Optional code suggestion to fix the issue, or null",
+      "agent_prompt": "Concise imperative instruction for AI coding agents to apply this fix."
     }
   ],
   "summary": "Brief overall summary of the review.",

--- a/src/mira/llm/prompts/templates/walkthrough.jinja2
+++ b/src/mira/llm/prompts/templates/walkthrough.jinja2
@@ -12,7 +12,7 @@ You are Mira, an expert AI code reviewer. Produce a high-level walkthrough of th
   - **Participants** must be actual code components: classes, modules, services, API endpoints, middleware, hooks, or functions. Use real names from the diff (e.g. `participant R as RootLayout`, `participant AS as AuthService`, `participant MW as RateLimitMiddleware`).
   - **Arrows** represent function calls, HTTP requests, event emissions, or data flow between components. Label arrows with actual method/function names from the code (e.g. `->>+AS: authenticate(token)`, `->>DB: INSERT INTO sessions`).
   - **Do NOT** use abstract actors like "Developer", "User", "PR", "Reviewer", or "Ready for review". Do not create process/workflow diagrams — only code-level runtime or build-time interactions.
-  - **Return `null`** for the sequence_diagram field when there are no meaningful inter-component interactions — for example: single-file additions, config-only changes, documentation updates, test-only changes, or pure refactors within one module.
+  - **Set sequence_diagram to null** (JSON null, not the string "null") when there are no meaningful inter-component interactions — for example: single-file additions, config-only changes, documentation updates, test-only changes, or pure refactors within one module.
 {% endif %}
 
 ## Output Format
@@ -35,7 +35,7 @@ Respond with a JSON object (no markdown fences) matching this schema:
     }
   ],
   "effort": {"level": 3, "label": "Moderate", "minutes": 20}{% if include_sequence_diagram %},
-  "sequence_diagram": "sequenceDiagram\n    participant C as ComponentA\n    participant S as ServiceB\n    C->>+S: methodName(args)\n    S-->>-C: result" // or null if no meaningful interactions{% endif %}
+  "sequence_diagram": "sequenceDiagram\n    participant C as ComponentA\n    participant S as ServiceB\n    C->>+S: methodName(args)\n    S-->>-C: result"{% endif %}
 
 }
 ```

--- a/src/mira/llm/prompts/templates/walkthrough.jinja2
+++ b/src/mira/llm/prompts/templates/walkthrough.jinja2
@@ -8,7 +8,11 @@ You are Mira, an expert AI code reviewer. Produce a high-level walkthrough of th
 - Use the file metadata below (paths, change types, languages, line counts, and hunk headers) to understand the scope.
 - Estimate the review effort on a scale of 1-5 (1=trivial, 2=simple, 3=moderate, 4=complex, 5=major) and an approximate time in minutes.
 {% if include_sequence_diagram %}
-- Include a Mermaid sequence diagram showing the key interactions introduced or modified by this PR.
+- Include a Mermaid sequence diagram showing **code-level component interactions** introduced or modified by this PR.
+  - **Participants** must be actual code components: classes, modules, services, API endpoints, middleware, hooks, or functions. Use real names from the diff (e.g. `participant R as RootLayout`, `participant AS as AuthService`, `participant MW as RateLimitMiddleware`).
+  - **Arrows** represent function calls, HTTP requests, event emissions, or data flow between components. Label arrows with actual method/function names from the code (e.g. `->>+AS: authenticate(token)`, `->>DB: INSERT INTO sessions`).
+  - **Do NOT** use abstract actors like "Developer", "User", "PR", "Reviewer", or "Ready for review". Do not create process/workflow diagrams — only code-level runtime or build-time interactions.
+  - **Return `null`** for the sequence_diagram field when there are no meaningful inter-component interactions — for example: single-file additions, config-only changes, documentation updates, test-only changes, or pure refactors within one module.
 {% endif %}
 
 ## Output Format
@@ -31,7 +35,7 @@ Respond with a JSON object (no markdown fences) matching this schema:
     }
   ],
   "effort": {"level": 3, "label": "Moderate", "minutes": 20}{% if include_sequence_diagram %},
-  "sequence_diagram": "sequenceDiagram\n    participant A as ...\n    ..."{% endif %}
+  "sequence_diagram": "sequenceDiagram\n    participant RL as RootLayout\n    participant AP as AuthProvider\n    participant AS as AuthService\n    RL->>+AP: wrap(children)\n    AP->>+AS: validateSession()\n    AS-->>-AP: session\n    AP-->>-RL: context"{% endif %}
 
 }
 ```

--- a/src/mira/llm/prompts/templates/walkthrough.jinja2
+++ b/src/mira/llm/prompts/templates/walkthrough.jinja2
@@ -35,7 +35,7 @@ Respond with a JSON object (no markdown fences) matching this schema:
     }
   ],
   "effort": {"level": 3, "label": "Moderate", "minutes": 20}{% if include_sequence_diagram %},
-  "sequence_diagram": "sequenceDiagram\n    participant C as ComponentA\n    participant S as ServiceB\n    C->>+S: methodName(args)\n    S-->>-C: result" or null{% endif %}
+  "sequence_diagram": "sequenceDiagram\n    participant C as ComponentA\n    participant S as ServiceB\n    C->>+S: methodName(args)\n    S-->>-C: result" // or null if no meaningful interactions{% endif %}
 
 }
 ```

--- a/src/mira/llm/prompts/templates/walkthrough.jinja2
+++ b/src/mira/llm/prompts/templates/walkthrough.jinja2
@@ -35,7 +35,7 @@ Respond with a JSON object (no markdown fences) matching this schema:
     }
   ],
   "effort": {"level": 3, "label": "Moderate", "minutes": 20}{% if include_sequence_diagram %},
-  "sequence_diagram": "sequenceDiagram\n    participant RL as RootLayout\n    participant AP as AuthProvider\n    participant AS as AuthService\n    RL->>+AP: wrap(children)\n    AP->>+AS: validateSession()\n    AS-->>-AP: session\n    AP-->>-RL: context"{% endif %}
+  "sequence_diagram": "sequenceDiagram\n    participant C as ComponentA\n    participant S as ServiceB\n    C->>+S: methodName(args)\n    S-->>-C: result" or null{% endif %}
 
 }
 ```

--- a/src/mira/llm/prompts/templates/walkthrough.jinja2
+++ b/src/mira/llm/prompts/templates/walkthrough.jinja2
@@ -35,7 +35,10 @@ Respond with a JSON object (no markdown fences) matching this schema:
     }
   ],
   "effort": {"level": 3, "label": "Moderate", "minutes": 20}{% if include_sequence_diagram %},
-  "sequence_diagram": "sequenceDiagram\n    participant C as ComponentA\n    participant S as ServiceB\n    C->>+S: methodName(args)\n    S-->>-C: result"{% endif %}
+  "sequence_diagram": "sequenceDiagram\n    participant C as ComponentA\n    participant S as ServiceB\n    C->>+S: methodName(args)\n    S-->>-C: result"
+
+  // When there are no meaningful inter-component interactions, use:
+  // "sequence_diagram": null{% endif %}
 
 }
 ```

--- a/src/mira/llm/response_parser.py
+++ b/src/mira/llm/response_parser.py
@@ -30,6 +30,7 @@ class LLMComment(BaseModel):
     body: str = ""
     confidence: float = Field(default=0.5, ge=0.0, le=1.0)
     suggestion: str | None = None
+    agent_prompt: str | None = None
     existing_code: str = ""
 
 
@@ -125,6 +126,7 @@ def convert_to_review_comments(
                 body=c.body,
                 confidence=c.confidence,
                 suggestion=suggestion,
+                agent_prompt=c.agent_prompt,
             )
         )
 

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -141,7 +141,7 @@ class WalkthroughResult:
     effort: WalkthroughEffort | None = None
     sequence_diagram: str | None = None
 
-    def to_markdown(self) -> str:
+    def to_markdown(self, bot_name: str = "miracodeai") -> str:
         """Render as a markdown PR comment."""
         parts = ["## Mira PR Walkthrough", ""]
         parts.append(self.summary)
@@ -193,6 +193,13 @@ class WalkthroughResult:
             parts.append("```mermaid")
             parts.append(self.sequence_diagram)
             parts.append("```")
+
+        parts.append("")
+        parts.append("---")
+        parts.append(
+            f"> Comment `@{bot_name} help` to get the list of"
+            " available commands and usage tips."
+        )
 
         return "\n".join(parts)
 

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -113,6 +113,7 @@ class ReviewComment:
     body: str
     confidence: float
     suggestion: str | None = None
+    agent_prompt: str | None = None
 
 
 @dataclass

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import enum
 from dataclasses import dataclass, field
 
+WALKTHROUGH_MARKER = "<!-- mira-walkthrough -->"
+
 
 class FileChangeType(enum.Enum):
     ADDED = "added"
@@ -143,7 +145,7 @@ class WalkthroughResult:
 
     def to_markdown(self, bot_name: str = "miracodeai") -> str:
         """Render as a markdown PR comment."""
-        parts = ["## Mira PR Walkthrough", ""]
+        parts = [WALKTHROUGH_MARKER, "## Mira PR Walkthrough", ""]
         parts.append(self.summary)
 
         if self.effort:

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -199,8 +199,7 @@ class WalkthroughResult:
         parts.append("")
         parts.append("---")
         parts.append(
-            f"> Comment `@{bot_name} help` to get the list of"
-            " available commands and usage tips."
+            f"> Comment `@{bot_name} help` to get the list of available commands and usage tips."
         )
 
         return "\n".join(parts)

--- a/src/mira/providers/base.py
+++ b/src/mira/providers/base.py
@@ -29,3 +29,11 @@ class BaseProvider(abc.ABC):
     @abc.abstractmethod
     async def post_comment(self, pr_info: PRInfo, body: str) -> None:
         """Post a top-level comment on a pull request."""
+
+    @abc.abstractmethod
+    async def find_bot_comment(self, pr_info: PRInfo, marker: str) -> int | None:
+        """Find an existing comment containing the marker. Returns comment ID or None."""
+
+    @abc.abstractmethod
+    async def update_comment(self, pr_info: PRInfo, comment_id: int, body: str) -> None:
+        """Edit an existing comment by its ID."""

--- a/src/mira/providers/base.py
+++ b/src/mira/providers/base.py
@@ -37,3 +37,7 @@ class BaseProvider(abc.ABC):
     @abc.abstractmethod
     async def update_comment(self, pr_info: PRInfo, comment_id: int, body: str) -> None:
         """Edit an existing comment by its ID."""
+
+    @abc.abstractmethod
+    async def resolve_outdated_review_threads(self, pr_info: PRInfo) -> int:
+        """Resolve all unresolved review threads authored by this bot. Returns count resolved."""

--- a/src/mira/providers/github.py
+++ b/src/mira/providers/github.py
@@ -281,7 +281,7 @@ class GitHubProvider(BaseProvider):
                 headers=headers,
             )
             resp.raise_for_status()
-            data = resp.json()
+            data: dict[str, Any] = resp.json()
         if "errors" in data:
             raise ProviderError(f"GraphQL error: {data['errors']}")
         return data
@@ -362,5 +362,16 @@ def _format_comment_body(comment: ReviewComment) -> str:
         parts.append("```suggestion")
         parts.append(comment.suggestion)
         parts.append("```")
+
+    if comment.agent_prompt:
+        parts.append("")
+        parts.append("<details>")
+        parts.append("<summary>🤖 Prompt for AI Agents</summary>")
+        parts.append("")
+        parts.append("```text")
+        parts.append(comment.agent_prompt)
+        parts.append("```")
+        parts.append("")
+        parts.append("</details>")
 
     return "\n".join(parts)

--- a/src/mira/providers/github.py
+++ b/src/mira/providers/github.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from typing import Any
 
 import httpx
 from github import Github, GithubException
@@ -41,6 +42,36 @@ _SEVERITY_BADGE: dict[Severity, str] = {
 _PR_URL_PATTERN = re.compile(
     r"(?:https?://github\.com/)?(?P<owner>[^/\s]+)/(?P<repo>[^/\s#]+)(?:/pull/|#)(?P<number>\d+)"
 )
+
+_GRAPHQL_URL = "https://api.github.com/graphql"
+
+_REVIEW_THREADS_QUERY = """
+query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+  viewer { login }
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes { author { login } }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+_RESOLVE_THREAD_MUTATION = """
+mutation($threadId: ID!) {
+  resolveReviewThread(input: {threadId: $threadId}) {
+    thread { id isResolved }
+  }
+}
+"""
 
 
 def parse_pr_url(pr_url: str) -> tuple[str, str, int]:
@@ -239,6 +270,77 @@ class GitHubProvider(BaseProvider):
             raise
         except Exception as e:
             raise ProviderError(f"Failed to update comment: {e}") from e
+
+    async def _graphql_request(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        """Execute a GraphQL request against the GitHub API."""
+        headers = {"Authorization": f"bearer {self._token}"}
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                _GRAPHQL_URL,
+                json={"query": query, "variables": variables},
+                headers=headers,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        if "errors" in data:
+            raise ProviderError(f"GraphQL error: {data['errors']}")
+        return data
+
+    async def resolve_outdated_review_threads(self, pr_info: PRInfo) -> int:
+        @retry(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=1, min=2, max=30),
+            retry=retry_if_exception_type(_RETRYABLE),
+            reraise=True,
+        )
+        async def _resolve() -> int:
+            # Phase 1: Paginate through review threads and collect bot-authored unresolved ones
+            bot_login: str | None = None
+            thread_ids: list[str] = []
+            cursor: str | None = None
+
+            while True:
+                variables: dict[str, Any] = {
+                    "owner": pr_info.owner,
+                    "repo": pr_info.repo,
+                    "number": pr_info.number,
+                    "cursor": cursor,
+                }
+                data = await self._graphql_request(_REVIEW_THREADS_QUERY, variables)
+
+                if bot_login is None:
+                    bot_login = data["data"]["viewer"]["login"]
+
+                threads = data["data"]["repository"]["pullRequest"]["reviewThreads"]
+                for node in threads["nodes"]:
+                    if node["isResolved"]:
+                        continue
+                    comments = node["comments"]["nodes"]
+                    if not comments:
+                        continue
+                    author = comments[0].get("author")
+                    if author is None:
+                        continue
+                    if author["login"] == bot_login:
+                        thread_ids.append(node["id"])
+
+                page_info = threads["pageInfo"]
+                if not page_info["hasNextPage"]:
+                    break
+                cursor = page_info["endCursor"]
+
+            # Phase 2: Resolve each collected thread
+            for thread_id in thread_ids:
+                await self._graphql_request(_RESOLVE_THREAD_MUTATION, {"threadId": thread_id})
+
+            return len(thread_ids)
+
+        try:
+            return await _resolve()
+        except ProviderError:
+            raise
+        except Exception as e:
+            raise ProviderError(f"Failed to resolve outdated review threads: {e}") from e
 
 
 def _format_comment_body(comment: ReviewComment) -> str:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -78,7 +78,7 @@ async def test_handle_pr_event(
     mock_engine.review_pr = AsyncMock(return_value=ReviewResult(summary="ok"))
     mock_engine_cls.return_value = mock_engine
 
-    await handle_pull_request(_make_pr_payload(), mock_app_auth)
+    await handle_pull_request(_make_pr_payload(), mock_app_auth, "mira-bot")
 
     mock_app_auth.get_installation_token.assert_awaited_once_with(1)
     mock_provider_cls.assert_called_once_with("ghs_test_token")
@@ -178,6 +178,6 @@ async def test_handler_exception_logged_not_raised(
 
     with caplog.at_level(logging.ERROR):
         # Should not raise
-        await handle_pull_request(_make_pr_payload(), mock_app_auth)
+        await handle_pull_request(_make_pr_payload(), mock_app_auth, "mira-bot")
 
     assert "boom" in caplog.text

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -255,6 +255,54 @@ class TestNoOpSuggestionCheck:
         assert comments[0].suggestion == "count = 1"
 
 
+class TestAgentPrompt:
+    def test_agent_prompt_parsed(self):
+        data = json.dumps(
+            {
+                "comments": [
+                    {
+                        "path": "a.py",
+                        "line": 2,
+                        "title": "Problem",
+                        "body": "Explaining the issue",
+                        "severity": "warning",
+                        "confidence": 0.9,
+                        "agent_prompt": "In a.py at line 2, replace the call to foo() with bar().",
+                    }
+                ],
+                "summary": "",
+                "metadata": {"reviewed_files": 1},
+            }
+        )
+        response = parse_llm_response(data)
+        comments = convert_to_review_comments(response, valid_paths={"a.py"})
+        assert len(comments) == 1
+        expected = "In a.py at line 2, replace the call to foo() with bar()."
+        assert comments[0].agent_prompt == expected
+
+    def test_agent_prompt_missing_defaults_to_none(self):
+        data = json.dumps(
+            {
+                "comments": [
+                    {
+                        "path": "a.py",
+                        "line": 2,
+                        "title": "Problem",
+                        "body": "Explaining the issue",
+                        "severity": "warning",
+                        "confidence": 0.9,
+                    }
+                ],
+                "summary": "",
+                "metadata": {"reviewed_files": 1},
+            }
+        )
+        response = parse_llm_response(data)
+        comments = convert_to_review_comments(response, valid_paths={"a.py"})
+        assert len(comments) == 1
+        assert comments[0].agent_prompt is None
+
+
 class TestSuggestionWithoutBody:
     def test_skips_suggestion_without_body(self):
         data = json.dumps(

--- a/tests/test_walkthrough.py
+++ b/tests/test_walkthrough.py
@@ -104,7 +104,10 @@ class TestBuildWalkthroughPrompt:
         assert "sequence diagram" in system.lower() or "sequence_diagram" in system
         # Prompt must instruct the LLM to use actual code components, not generic actors
         assert "code-level component interactions" in system
-        assert "Developer" in system  # mentioned in the "Do NOT" instruction
+        # Verify the prohibition is explicit — template renders bold markdown
+        assert "**Do NOT**" in system
+        assert "**Do NOT** use abstract actors" in system
+        assert "Developer" in system
         assert "null" in system  # instruction to omit when no interactions
 
     def test_hunk_headers_extracted(self):
@@ -258,7 +261,10 @@ class TestWalkthroughToMarkdown:
         assert "| `src/utils.py` | Added | New utils |" in md
         assert "**Tests**" in md
         assert "| `tests/test_utils.py` | Added | Tests for utils |" in md
-        assert "@miracodeai help" in md
+        lines = md.split("\n")
+        separator_idx = lines.index("---")
+        footer_text = "\n".join(lines[separator_idx:])
+        assert "@miracodeai help" in footer_text
 
     def test_flat_fallback_when_no_groups(self):
         result = WalkthroughResult(
@@ -318,9 +324,11 @@ class TestWalkthroughToMarkdown:
     def test_help_footer(self):
         result = WalkthroughResult(summary="Footer test.")
         md = result.to_markdown()
-        assert "---" in md
-        assert "`@miracodeai help`" in md
-        assert "available commands and usage tips" in md
+        lines = md.split("\n")
+        separator_idx = lines.index("---")
+        footer_text = "\n".join(lines[separator_idx:])
+        assert "`@miracodeai help`" in footer_text
+        assert "available commands and usage tips" in footer_text
 
     def test_help_footer_custom_bot_name(self):
         result = WalkthroughResult(summary="Footer test.")

--- a/tests/test_walkthrough.py
+++ b/tests/test_walkthrough.py
@@ -13,6 +13,7 @@ from mira.llm.response_parser import (
     parse_walkthrough_response,
 )
 from mira.models import (
+    WALKTHROUGH_MARKER,
     FileChangeType,
     FileDiff,
     HunkInfo,
@@ -335,3 +336,9 @@ class TestWalkthroughToMarkdown:
         md = result.to_markdown(bot_name="mybot")
         assert "`@mybot help`" in md
         assert "@miracodeai" not in md
+
+    def test_contains_walkthrough_marker(self):
+        result = WalkthroughResult(summary="Test.")
+        md = result.to_markdown()
+        assert md.startswith(WALKTHROUGH_MARKER)
+        assert md.count(WALKTHROUGH_MARKER) == 1

--- a/tests/test_walkthrough.py
+++ b/tests/test_walkthrough.py
@@ -263,6 +263,7 @@ class TestWalkthroughToMarkdown:
         assert "**Tests**" in md
         assert "| `tests/test_utils.py` | Added | Tests for utils |" in md
         lines = md.split("\n")
+        assert "---" in lines, "Expected separator '---' in markdown output"
         separator_idx = len(lines) - 1 - lines[::-1].index("---")
         footer_text = "\n".join(lines[separator_idx:])
         assert "@miracodeai help" in footer_text
@@ -326,6 +327,7 @@ class TestWalkthroughToMarkdown:
         result = WalkthroughResult(summary="Footer test.")
         md = result.to_markdown()
         lines = md.split("\n")
+        assert "---" in lines, "Expected separator '---' in markdown output"
         separator_idx = len(lines) - 1 - lines[::-1].index("---")
         footer_text = "\n".join(lines[separator_idx:])
         assert "`@miracodeai help`" in footer_text

--- a/tests/test_walkthrough.py
+++ b/tests/test_walkthrough.py
@@ -263,7 +263,7 @@ class TestWalkthroughToMarkdown:
         assert "**Tests**" in md
         assert "| `tests/test_utils.py` | Added | Tests for utils |" in md
         lines = md.split("\n")
-        separator_idx = lines.index("---")
+        separator_idx = len(lines) - 1 - lines[::-1].index("---")
         footer_text = "\n".join(lines[separator_idx:])
         assert "@miracodeai help" in footer_text
 
@@ -326,7 +326,7 @@ class TestWalkthroughToMarkdown:
         result = WalkthroughResult(summary="Footer test.")
         md = result.to_markdown()
         lines = md.split("\n")
-        separator_idx = lines.index("---")
+        separator_idx = len(lines) - 1 - lines[::-1].index("---")
         footer_text = "\n".join(lines[separator_idx:])
         assert "`@miracodeai help`" in footer_text
         assert "available commands and usage tips" in footer_text


### PR DESCRIPTION
- Changed the default bot name from "mira-bot" to "miracodeai" in the CLI.
- Modified the `to_markdown` method in `WalkthroughResult` to accept a custom bot name and include a help footer with usage instructions.
- Updated the walkthrough template to specify code-level component interactions for sequence diagrams and clarified instructions for generating them.
- Added tests to verify the new help footer and ensure the correct bot name is used in markdown output.