### PR TITLE
Code Reviewer Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,12 @@ data/
 report.txt
 *.tmp
 
+# Benchmark reports — produced by local eval runs, not part of the release.
+BENCHMARK_REPORT*.md
+
+# Local eval-regression fixtures — repo-specific PR URLs and history.
+tests/eval_regressions/
+
 # Frontend
 ui/mira/node_modules/
 ui/mira/dist/

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ pip install -e ".[dev,serve]"
 # Run tests
 pytest tests/ -v
 
+# Run the regression suite (hits real GitHub + LLM, ~$1, ~3 min).
+# Pinned PRs whose findings have flickered across iterations — run before
+# merging changes that touch prompts, the noise filter, or the engine.
+OPENROUTER_API_KEY=... GITHUB_TOKEN=... pytest -m eval -v
+
 # Lint
 ruff check src/ tests/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "AI-powered PR reviewer with low-noise filtering"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
-authors = [{ name = "Mira Contributors" }]
+authors = [{ name = "Mira Contributors", email = "support@miracode.ai" }]
 keywords = ["ai", "code-review", "pull-request", "llm"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -69,6 +69,10 @@ packages = ["src/mira"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "eval: regression suite that hits real GitHub + LLM APIs (skipped by default; opt-in with `-m eval`)",
+]
+addopts = "-m 'not eval'"
 
 [tool.ruff]
 target-version = "py311"

--- a/src/mira/analysis/noise_filter.py
+++ b/src/mira/analysis/noise_filter.py
@@ -89,7 +89,10 @@ def filter_noise(
     2. Drop below minimum severity (escalates per ``review_round``)
     3. Sort by severity (desc) then confidence (desc)
     4. Deduplicate (first occurrence = highest quality)
-    5. Cap at max_comments
+    5. Apply the cap **only to suggestions and nitpicks** — every blocker
+       and warning that survives the floor gets posted, no matter how
+       many. Real bugs deserve to be flagged; the cap is a noise control
+       for low-priority findings, not a quality cap on real ones.
 
     ``review_round`` is the 1-indexed count of bot reviews on this PR.
     Round 1 uses ``config`` defaults; round 2+ raise the floor so the bot
@@ -113,4 +116,9 @@ def filter_noise(
     result = [c for c in result if c.severity >= min_severity]
     result.sort(key=lambda c: (c.severity, c.confidence), reverse=True)
     result = _deduplicate(result)
-    return result[: config.max_comments]
+
+    # Split: blockers + warnings always post; suggestions + nitpicks share
+    # the cap so they can't drown out real findings.
+    urgent = [c for c in result if c.severity >= Severity.WARNING]
+    low_priority = [c for c in result if c.severity < Severity.WARNING]
+    return urgent + low_priority[: config.max_comments]

--- a/src/mira/cli.py
+++ b/src/mira/cli.py
@@ -132,6 +132,12 @@ def main() -> None:
 @click.option("--output", "output_format", type=click.Choice(["text", "json"]), default="text")
 @click.option("--verbose", is_flag=True, help="Enable verbose logging")
 @click.option("--config", "config_path", default=None, help="Path to .mira.yml")
+@click.option(
+    "--no-walkthrough",
+    is_flag=True,
+    help="Skip walkthrough generation. Useful in dry-run loops where only the "
+    "inline review is needed and the extra LLM call should be saved.",
+)
 def review(
     pr_url: str | None,
     use_stdin: bool,
@@ -143,6 +149,7 @@ def review(
     output_format: str,
     verbose: bool,
     config_path: str | None,
+    no_walkthrough: bool,
 ) -> None:
     """Review a pull request or diff."""
     logging.basicConfig(
@@ -161,6 +168,8 @@ def review(
         overrides["filter.max_comments"] = max_comments
     if confidence is not None:
         overrides["filter.confidence_threshold"] = confidence
+    if no_walkthrough:
+        overrides["review.walkthrough"] = False
 
     try:
         config = load_config(config_path, overrides)

--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -85,27 +85,32 @@ class ReviewConfig(BaseModel):
     # Run a second-pass LLM critique on each draft comment before posting.
     # The critic asks "is this analysis actually correct? Cite specific
     # lines that prove it." Comments that fail the critique are dropped.
-    # Catches confident-but-wrong findings; uses the cheap indexing-tier
-    # model (~$0.001 per review). Disable for faster reviews on small PRs
-    # where the extra ~5-10s wall time matters.
+    # Disable for faster reviews where the extra wall-clock time matters
+    # more than catching confident-but-wrong findings.
     self_critique: bool = True
 
     # Run a dedicated security review pass in parallel with the main review.
-    # Uses the same review-tier LLM with a security-focused prompt (XSS,
-    # injection, auth bypass, CSRF, SSRF, origin validation, deserialization,
-    # crypto). Findings are merged into the main review's comments list and
-    # go through the same noise filter (dedup against overlapping main-pass
-    # findings). Adds ~one main-tier LLM call per PR; disable on cost-
-    # sensitive deployments.
+    # Uses the review LLM with a security-focused prompt (XSS, injection,
+    # auth bypass, CSRF, SSRF, origin validation, deserialization, crypto).
+    # Findings are merged into the main review's comments list and go
+    # through the same noise filter (dedup against overlapping main-pass
+    # findings).
     security_pass: bool = True
 
     # When the repo is not indexed, give the reviewer LLM tools (`read_file`,
     # `grep_repo`) it can call to fetch cross-file context on demand. Closes
     # the gap on Java/Go cross-file findings that JIT pre-fetch can't reach
-    # (those languages need build-system parsing to resolve imports). Adds
-    # 1-3 extra LLM hops per chunk on unindexed reviews; no effect when the
-    # repo is indexed.
+    # (those languages need build-system parsing to resolve imports).
+    # No effect when the repo is indexed.
     agentic_tools: bool = True
+
+    # Whether the JIT cross-file resolver should attempt Java + Go imports.
+    # Resolution for those languages is heuristic (we can't see the build
+    # system), and a wrong-file pick pollutes the prompt with off-topic
+    # symbols. Toggle off when measuring whether Java/Go JIT is helping vs
+    # hurting on a given codebase. The agentic loop still covers cross-file
+    # needs for Java/Go on the unindexed path when this is False.
+    jit_java_go: bool = True
 
 
 class ProviderConfig(BaseModel):

--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -90,6 +90,15 @@ class ReviewConfig(BaseModel):
     # where the extra ~5-10s wall time matters.
     self_critique: bool = True
 
+    # Run a dedicated security review pass in parallel with the main review.
+    # Uses the same review-tier LLM with a security-focused prompt (XSS,
+    # injection, auth bypass, CSRF, SSRF, origin validation, deserialization,
+    # crypto). Findings are merged into the main review's comments list and
+    # go through the same noise filter (dedup against overlapping main-pass
+    # findings). Adds ~one main-tier LLM call per PR; disable on cost-
+    # sensitive deployments.
+    security_pass: bool = True
+
 
 class ProviderConfig(BaseModel):
     type: str = "github"

--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -99,6 +99,14 @@ class ReviewConfig(BaseModel):
     # sensitive deployments.
     security_pass: bool = True
 
+    # When the repo is not indexed, give the reviewer LLM tools (`read_file`,
+    # `grep_repo`) it can call to fetch cross-file context on demand. Closes
+    # the gap on Java/Go cross-file findings that JIT pre-fetch can't reach
+    # (those languages need build-system parsing to resolve imports). Adds
+    # 1-3 extra LLM hops per chunk on unindexed reviews; no effect when the
+    # repo is indexed.
+    agentic_tools: bool = True
+
 
 class ProviderConfig(BaseModel):
     type: str = "github"

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -17,7 +17,10 @@ from mira.core.priority import rank_files
 from mira.exceptions import ResponseParseError
 from mira.index.context import build_code_context
 from mira.index.store import IndexStore
-from mira.llm.prompts.review import build_review_prompt, build_walkthrough_prompt
+from mira.llm.prompts.review import (
+    build_review_prompt,
+    build_walkthrough_prompt,
+)
 from mira.llm.prompts.verify_fixes import build_verify_fixes_prompt, parse_verify_fixes_response
 from mira.llm.provider import LLMProvider
 from mira.llm.response_parser import (
@@ -90,6 +93,81 @@ def _clamp_confidence_to_findings(
 
 _MAX_FULL_FILE_LINES = 500
 _LARGE_FILE_CONTEXT_LINES = 50  # ±50 lines = 100-line window
+
+
+# Path patterns where security findings are extremely unlikely. Used to
+# narrow the dedicated security pass — see _security_review_pass. We keep
+# this conservative: every excluded category is "shouldn't house auth /
+# crypto / origin / injection logic." When uncertain, keep the file.
+_SECURITY_PASS_SKIP_PATTERNS = (
+    # DB migrations: schema changes, indexes — no request handling.
+    "db/migrate/",
+    "/migrations/",
+    # Tests: assertions about behavior, not the behavior itself.
+    "spec/",
+    "/__tests__/",
+    "/__fixtures__/",
+    "/fixtures/",
+    # Docs and changelogs.
+    ".md",
+    ".rst",
+    ".txt",
+    "CHANGELOG",
+    "LICENSE",
+    # Pure styles: extremely rare attack surface; XSS through CSS would
+    # show up in the embedded JS or template, not the .scss.
+    ".css",
+    ".scss",
+    ".less",
+    ".sass",
+    # Lockfiles: package manager output, not application code.
+    ".lock",
+    "package-lock.json",
+    "yarn.lock",
+    "Pipfile.lock",
+    # Common build / vendor output, in case file_filter let it through.
+    "/dist/",
+    "/build/",
+    "/vendor/",
+    "/node_modules/",
+)
+
+_SECURITY_TEST_SUFFIXES = (
+    "_test.go",
+    "_test.py",
+    "_spec.rb",
+    "_spec.js",
+    "_spec.ts",
+    ".test.js",
+    ".test.jsx",
+    ".test.ts",
+    ".test.tsx",
+    ".spec.js",
+    ".spec.jsx",
+    ".spec.ts",
+    ".spec.tsx",
+)
+
+
+def _security_relevant_files(files: list) -> list:
+    """Return the subset of files plausibly containing security findings.
+
+    The dedicated security pass runs as one LLM call across the entire
+    diff. When the diff is dominated by migrations / specs / lockfiles,
+    those non-code files dilute attention away from the actual vulnerable
+    code. This filter trims the obvious-no-finding cases so the model can
+    focus.
+    """
+    keep = []
+    for f in files:
+        path = f.path
+        lower = path.lower()
+        if any(p in lower for p in _SECURITY_PASS_SKIP_PATTERNS):
+            continue
+        if any(lower.endswith(s) for s in _SECURITY_TEST_SUFFIXES):
+            continue
+        keep.append(f)
+    return keep
 
 
 def _select_files_by_priority(
@@ -779,6 +857,7 @@ class ReviewEngine:
                                 source_fetcher=source_fetcher,
                                 repo_tree=tree_paths,
                                 char_budget=(self.config.review.context_token_budget * 4),
+                                enable_java_go=self.config.review.jit_java_go,
                             )
                             if jit:
                                 ctx = ctx + "\n\n" + jit
@@ -978,10 +1057,10 @@ class ReviewEngine:
                     )
                     return [], [], ""
 
-        # Run main chunked review and the dedicated security pass in
-        # parallel. Security findings get merged into all_comments and go
-        # through the same noise filter (dedup catches any overlap with
-        # main-pass findings on the same line).
+        # Run the main chunked review and the security pass in parallel.
+        # Security findings get merged into all_comments and go through the
+        # same noise filter (dedup catches any overlap with main-pass
+        # findings on the same line).
         review_task = _asyncio.gather(*[_review_chunk(i, c) for i, c in enumerate(chunks)])
         security_task = _asyncio.create_task(
             self._security_review_pass(filtered, pr_title)
@@ -1013,8 +1092,7 @@ class ReviewEngine:
         # Self-critique pass — re-verify each draft comment before posting.
         # Catches confident-but-wrong claims (the LLM's own analysis errors)
         # that the noise filter can't catch because confidence scores are
-        # also LLM-generated. Uses the cheap indexing-tier model so the
-        # added cost is ~$0.001 per review.
+        # also LLM-generated. Runs on the configured indexing model.
         if final_comments and self.config.review.self_critique:
             try:
                 final_comments = await self._self_critique(final_comments)
@@ -1169,11 +1247,23 @@ class ReviewEngine:
         if not files:
             return []
 
+        # Narrow input to files where security findings are plausible.
+        # On large diffs, migrations / lockfiles / fixtures / tests drown
+        # out the actual vulnerable code. With them in the prompt the model
+        # can miss explicit patterns (`X-Frame-Options: "ALLOWALL"`) that
+        # the prompt's category list calls out by name.
+        narrowed = _security_relevant_files(files)
+        if not narrowed:
+            # All files were filtered out — fall back to the original set
+            # rather than skip the pass entirely. A PR that's purely
+            # migrations / specs CAN still introduce auth/permission bugs.
+            narrowed = files
+
         from mira.llm.prompts.review import build_security_review_prompt
         from mira.llm.provider import SUBMIT_REVIEW_TOOL
 
         try:
-            messages = build_security_review_prompt(files=files, pr_title=pr_title)
+            messages = build_security_review_prompt(files=narrowed, pr_title=pr_title)
             raw = await self.llm.complete_with_tools(
                 messages=messages,
                 tools=[SUBMIT_REVIEW_TOOL],
@@ -1209,9 +1299,9 @@ class ReviewEngine:
         prove this is a real, actionable issue?* Comments without verifiable
         citations or with confidently-wrong analysis get dropped.
 
-        Uses the cheap indexing-tier model (Haiku-class) — the critic is a
-        verification step, not a generation step. Returns the kept comments
-        in their original order.
+        Uses the configured indexing model — the critic is a verification
+        step, not a generation step. Returns the kept comments in their
+        original order.
         """
         import json as _json
 
@@ -1235,6 +1325,7 @@ class ReviewEngine:
                 f"    Body:  {(c.body or '').strip()[:500]}\n"
                 f"    Cites: {cited or '(no code citation)'}\n"
             )
+
         critic_prompt = (
             "You are reviewing draft PR comments produced by another reviewer. "
             "Your job is to filter out confidently-wrong analyses, speculation, "
@@ -1253,7 +1344,7 @@ class ReviewEngine:
             "## Draft comments\n\n" + "\n".join(draft_lines)
         )
 
-        # Use the indexing-tier (cheap) model — critique is a verification
+        # Use the configured indexing model — critique is a verification
         # task, not generation. Falls back to the review model if no
         # indexing model is configured.
         try:
@@ -1306,8 +1397,8 @@ class ReviewEngine:
         mention issues that never got filed (LLM put them in prose only) or
         that were later dropped by noise filter / self-critique / orphan
         filter. Regenerate from the surviving structured outputs using the
-        cheap indexing-tier model so the prose can't lie about what's in the
-        Key Issues table or the inline comments.
+        configured indexing model so the prose stays grounded in the Key
+        Issues table and inline comments that actually shipped.
         """
         if not comments and not key_issues:
             return "No issues found."

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -249,6 +249,11 @@ class ReviewEngine:
         self.provider = provider
         self.bot_name = bot_name
         self.dry_run = dry_run
+        # Set during _build_context: True when the repo has no prior index,
+        # so cross-file context came from JIT lookup (less complete than
+        # a full pre-built index). Drives the walkthrough nudge that tells
+        # the user reviews will be more accurate after indexing.
+        self._index_was_empty = False
 
     async def _post_placeholder_comment(self, pr_info: PRInfo) -> int | None:
         """Post an immediate 'Reviewing this PR...' comment and return its ID.
@@ -361,6 +366,52 @@ class ReviewEngine:
         except Exception as exc:
             logger.warning("Failed to compute review round: %s", exc)
 
+        # Incremental diff for round 2+: if we have a stored last-reviewed
+        # SHA, fetch only what's been pushed since then. This prevents the
+        # bot from "discovering" issues in untouched files between rounds —
+        # which feels to authors like the bot withheld findings on round 1.
+        # Falls back silently to the full diff if anything goes wrong.
+        if review_round >= 2 and pr_info.head_sha:
+            try:
+                from mira.dashboard.api import _app_db
+
+                last_sha = _app_db.get_last_reviewed_sha(
+                    pr_info.owner,
+                    pr_info.repo,
+                    pr_info.number,
+                )
+                if last_sha and last_sha != pr_info.head_sha:
+                    incremental = await self.provider.get_compare_diff(
+                        pr_info,
+                        last_sha,
+                        pr_info.head_sha,
+                    )
+                    if incremental.strip():
+                        logger.info(
+                            "Round %d incremental diff %s..%s on PR %s (was %d chars, now %d)",
+                            review_round,
+                            last_sha[:8],
+                            pr_info.head_sha[:8],
+                            pr_info.url,
+                            len(diff_text),
+                            len(incremental),
+                        )
+                        diff_text = incremental
+                    else:
+                        # Same head SHA or empty diff — nothing new to review.
+                        logger.info(
+                            "Round %d: no new commits since %s on PR %s, skipping review",
+                            review_round,
+                            last_sha[:8],
+                            pr_info.url,
+                        )
+                        diff_text = ""
+            except Exception as exc:
+                logger.warning(
+                    "Incremental diff fetch failed, falling back to full diff: %s",
+                    exc,
+                )
+
         # Pull the team conventions text the indexer extracted from
         # CONTRIBUTING.md / AGENTS.md / STYLE.md so the LLM knows
         # repo-specific style rules.
@@ -430,6 +481,8 @@ class ReviewEngine:
                     except Exception:
                         pass
 
+                    import os as _os
+
                     markdown = result.walkthrough.to_markdown(
                         bot_name=self.bot_name,
                         review_stats=stats,
@@ -440,6 +493,8 @@ class ReviewEngine:
                         key_issues=result.key_issues or None,
                         skipped_paths=result.skipped_paths or None,
                         total_paths=result.total_paths or None,
+                        index_was_empty=getattr(self, "_index_was_empty", False),
+                        dashboard_url=_os.environ.get("MIRA_DASHBOARD_URL", ""),
                     )
                     # Prefer the known placeholder ID. Fall back to marker-based
                     # lookup if the placeholder never posted (network blip, etc.).
@@ -547,6 +602,23 @@ class ReviewEngine:
         except Exception as exc:
             logger.debug("Failed to record review event: %s", exc)
 
+        # Always anchor the SHA after a successful review — including rounds
+        # that found zero comments. Otherwise round 2 has no SHA to diff
+        # against and falls back to a full review, which is the bug we're
+        # trying to avoid.
+        if pr_info.head_sha:
+            try:
+                from mira.dashboard.api import _app_db
+
+                _app_db.set_last_reviewed_sha(
+                    pr_info.owner,
+                    pr_info.repo,
+                    pr_info.number,
+                    pr_info.head_sha,
+                )
+            except Exception as exc:
+                logger.debug("Failed to record last reviewed SHA: %s", exc)
+
         return result
 
     async def review_diff(self, diff_text: str) -> ReviewResult:
@@ -653,8 +725,9 @@ class ReviewEngine:
                         source_fetcher = ProviderSourceFetcher(
                             self.provider, pr_info, pr_info.head_branch
                         )
+                    changed_paths = [f.path for f in filtered]
                     ctx = await build_code_context(
-                        changed_paths=[f.path for f in filtered],
+                        changed_paths=changed_paths,
                         store=store,
                         token_budget=self.config.review.context_token_budget,
                         source_fetcher=source_fetcher,
@@ -662,6 +735,44 @@ class ReviewEngine:
                     doc_context = store.get_all_review_context_text()
                     if doc_context:
                         ctx = ctx + "\n\n" + doc_context
+
+                    # Detect "empty index" — no summaries for any changed file
+                    # means the indexer hasn't run for this repo. Fall back to
+                    # JIT cross-file lookup: parse imports in the changed
+                    # files, fetch the imported files from HEAD, extract their
+                    # symbols, and inline. Works without a pre-built index.
+                    index_has_data = bool(store.get_summaries(changed_paths))
+                    self._index_was_empty = not index_has_data
+                    if not index_has_data and source_fetcher is not None:
+                        try:
+                            from mira.index.jit_context import (
+                                build_jit_cross_file_context,
+                            )
+
+                            tree_paths: set[str] | None = None
+                            if hasattr(self.provider, "get_repo_tree"):
+                                try:
+                                    tree_paths = set(
+                                        await self.provider.get_repo_tree(
+                                            pr_info,
+                                            pr_info.head_branch,
+                                        )
+                                    )
+                                except Exception as exc:
+                                    logger.debug(
+                                        "JIT: tree fetch failed: %s",
+                                        exc,
+                                    )
+                            jit = await build_jit_cross_file_context(
+                                changed_files=filtered,
+                                source_fetcher=source_fetcher,
+                                repo_tree=tree_paths,
+                                char_budget=(self.config.review.context_token_budget * 4),
+                            )
+                            if jit:
+                                ctx = ctx + "\n\n" + jit
+                        except Exception as exc:
+                            logger.debug("JIT context build failed: %s", exc)
 
                     # Append cross-repo impact so inline reviews know about
                     # other repositories that depend on the changed code.
@@ -837,7 +948,17 @@ class ReviewEngine:
                     )
                     return [], [], ""
 
-        chunk_results = await _asyncio.gather(*[_review_chunk(i, c) for i, c in enumerate(chunks)])
+        # Run main chunked review and the dedicated security pass in
+        # parallel. Security findings get merged into all_comments and go
+        # through the same noise filter (dedup catches any overlap with
+        # main-pass findings on the same line).
+        review_task = _asyncio.gather(*[_review_chunk(i, c) for i, c in enumerate(chunks)])
+        security_task = _asyncio.create_task(
+            self._security_review_pass(filtered, pr_title)
+            if self.config.review.security_pass
+            else _asyncio.sleep(0, result=[])
+        )
+        chunk_results, security_comments = await _asyncio.gather(review_task, security_task)
 
         all_comments: list[ReviewComment] = []
         all_key_issues: list[KeyIssue] = []
@@ -847,6 +968,7 @@ class ReviewEngine:
             all_key_issues.extend(key_issues)
             if summary_text:
                 summaries.append(summary_text)
+        all_comments.extend(security_comments)
 
         # Classify severity
         all_comments = [classify_severity(c) for c in all_comments]
@@ -906,6 +1028,56 @@ class ReviewEngine:
             skipped_paths=skipped_paths_only,
             total_paths=all_paths,
         )
+
+    async def _security_review_pass(
+        self,
+        files: list,
+        pr_title: str = "",
+    ) -> list[ReviewComment]:
+        """Dedicated security review using the same review-tier LLM.
+
+        Runs in parallel with the main review. The output is a list of
+        ``ReviewComment`` to merge into ``all_comments`` before noise
+        filtering — overlapping findings dedupe naturally.
+
+        Returns ``[]`` and logs (debug) on any failure so a transient
+        LLM/API error doesn't kill the main review.
+        """
+        if not files:
+            return []
+
+        from mira.llm.prompts.review import build_security_review_prompt
+        from mira.llm.provider import SUBMIT_REVIEW_TOOL
+
+        try:
+            messages = build_security_review_prompt(files=files, pr_title=pr_title)
+            raw = await self.llm.complete_with_tools(
+                messages=messages,
+                tools=[SUBMIT_REVIEW_TOOL],
+                temperature=0.0,
+            )
+        except Exception as exc:
+            logger.warning("Security review pass failed: %s", exc)
+            return []
+
+        try:
+            parsed = parse_llm_response(raw)
+            comments = convert_to_review_comments(parsed, diff_files=files)
+        except ResponseParseError as exc:
+            logger.warning("Security review pass parse error: %s", exc)
+            return []
+        except Exception as exc:
+            logger.warning("Security review pass conversion failed: %s", exc)
+            return []
+
+        # Force category=security so the badge renders correctly even if the
+        # LLM put something else.
+        for c in comments:
+            if not c.category or c.category != "security":
+                c.category = "security"
+        if comments:
+            logger.info("Security pass produced %d candidate comment(s)", len(comments))
+        return comments
 
     async def _self_critique(self, comments: list[ReviewComment]) -> list[ReviewComment]:
         """Run a second-pass critique on each draft comment.

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -254,6 +254,12 @@ class ReviewEngine:
         # a full pre-built index). Drives the walkthrough nudge that tells
         # the user reviews will be more accurate after indexing.
         self._index_was_empty = False
+        # Captured during _build_context for the agentic tool-use path: a
+        # source fetcher and the repo tree at PR head. Both already needed
+        # for JIT, so reusing them is free. None when no provider/PR is
+        # attached (CLI / dry-run).
+        self._agentic_source_fetcher: object | None = None
+        self._agentic_repo_tree: list[str] = []
 
     async def _post_placeholder_comment(self, pr_info: PRInfo) -> int | None:
         """Post an immediate 'Reviewing this PR...' comment and return its ID.
@@ -763,6 +769,11 @@ class ReviewEngine:
                                         "JIT: tree fetch failed: %s",
                                         exc,
                                     )
+                            # Stash for the agentic tool-use path so
+                            # _review_chunk can give the LLM read_file /
+                            # grep_repo without re-fetching the tree.
+                            self._agentic_source_fetcher = source_fetcher
+                            self._agentic_repo_tree = sorted(tree_paths) if tree_paths else []
                             jit = await build_jit_cross_file_context(
                                 changed_files=filtered,
                                 source_fetcher=source_fetcher,
@@ -927,7 +938,26 @@ class ReviewEngine:
                         resolved_threads=resolved_threads,
                         team_conventions=team_conventions,
                     )
-                    raw_response = await self.llm.review(messages)
+                    raw_response = ""
+                    # Agentic tool-use path: only on unindexed repos, where
+                    # the static context block is necessarily thin. Indexed
+                    # reviews already have the full picture, so the extra
+                    # hops would just slow things down.
+                    use_agentic = (
+                        self.config.review.agentic_tools
+                        and getattr(self, "_index_was_empty", False)
+                        and self._agentic_source_fetcher is not None
+                    )
+                    if use_agentic:
+                        from mira.llm.agentic_tools import AgenticToolExecutor
+
+                        executor = AgenticToolExecutor(
+                            source_fetcher=self._agentic_source_fetcher,  # type: ignore[arg-type]
+                            repo_tree=list(self._agentic_repo_tree),
+                        )
+                        raw_response = await self._agentic_review_loop(messages, executor)
+                    if not raw_response:
+                        raw_response = await self.llm.review(messages)
                     parsed = parse_llm_response(raw_response)
                     comments = convert_to_review_comments(
                         parsed,
@@ -1028,6 +1058,99 @@ class ReviewEngine:
             skipped_paths=skipped_paths_only,
             total_paths=all_paths,
         )
+
+    async def _agentic_review_loop(
+        self,
+        messages: list[dict],
+        executor: object,
+    ) -> str:
+        """Run an agentic tool-use loop until the LLM submits a review.
+
+        Hands the model `read_file` and `grep_repo` alongside the terminal
+        `submit_review` tool. Each hop: call the model, dispatch any
+        non-terminal tool calls, append results, repeat. Caps at 6 hops so
+        a confused model can't burn unbounded tokens.
+
+        Returns the JSON args of the final `submit_review` call (same
+        shape `self.llm.review` returns), or "" if the loop exited without
+        one — caller falls back to a forced single-tool call.
+        """
+        import json as _json
+
+        from mira.llm.agentic_tools import AGENTIC_TOOLS
+        from mira.llm.provider import SUBMIT_REVIEW_TOOL
+
+        tools = [*AGENTIC_TOOLS, SUBMIT_REVIEW_TOOL]
+        # Augment the existing system message with a brief note on tool use.
+        # Putting it inline keeps prompt structure intact for the rest of
+        # the flow (parsing, summary regen, etc.).
+        convo: list[dict] = [dict(m) for m in messages]
+        if convo and convo[0].get("role") == "system":
+            convo[0]["content"] = (
+                convo[0]["content"] + "\n\n## Tools\n\n"
+                "This repo isn't indexed, so you have two helpers for "
+                "cross-file checks: `read_file(path)` and "
+                "`grep_repo(pattern, path_glob?, path_only?)`. Use them when, "
+                "and ONLY when, you need to verify a cross-file claim before "
+                "filing a comment (e.g. *does the called function actually "
+                "raise X?*, *is this symbol defined elsewhere?*). Don't browse — "
+                "fetch what you specifically need. Skip the tools entirely if "
+                "the diff alone is enough. Once you're ready, call "
+                "`submit_review` with all your findings."
+            )
+
+        max_hops = 6
+        for hop in range(max_hops):
+            try:
+                msg = await self.llm.complete_agentic(convo, tools=tools)
+            except Exception as exc:
+                logger.warning("Agentic hop %d failed: %s", hop + 1, exc)
+                return ""
+
+            tool_calls = msg.get("tool_calls") or []
+            content = msg.get("content") or ""
+
+            if not tool_calls:
+                # The model ended without calling submit_review — fall back.
+                logger.debug(
+                    "Agentic loop exited at hop %d without submit_review (content=%d chars)",
+                    hop + 1,
+                    len(content),
+                )
+                return ""
+
+            # Append the assistant message verbatim so tool_call_ids resolve.
+            convo.append(
+                {
+                    "role": "assistant",
+                    "content": content,
+                    "tool_calls": tool_calls,
+                }
+            )
+
+            for call in tool_calls:
+                fn = call.get("function") or {}
+                name = fn.get("name") or ""
+                if name == "submit_review":
+                    return fn.get("arguments") or ""
+
+                raw_args = fn.get("arguments") or "{}"
+                try:
+                    args = _json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+                except Exception:
+                    args = {}
+
+                tool_result = await executor.execute(name, args)  # type: ignore[attr-defined]
+                convo.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call.get("id") or "",
+                        "content": tool_result,
+                    }
+                )
+
+        logger.debug("Agentic loop hit %d-hop cap without submit_review", max_hops)
+        return ""
 
     async def _security_review_pass(
         self,

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -1772,9 +1772,9 @@ async def trigger_index(owner: str, repo: str, full: bool = False) -> dict:
 
             tracker.start(full_name)
             config = load_config()
-            # Use the configured indexing model (typically Haiku) — without
-            # this swap we'd silently fall back to the review model (Sonnet),
-            # ~3× slower and ~3× more expensive per token.
+            # Use the configured indexing model — without this swap we'd
+            # silently fall back to the review model, which is slower and
+            # more expensive per token.
             llm = LLMProvider(llm_config_for("indexing", config.llm))
             store = IndexStore.open(owner, repo)
             if full:

--- a/src/mira/dashboard/db.py
+++ b/src/mira/dashboard/db.py
@@ -84,6 +84,10 @@ CREATE TABLE IF NOT EXISTS pr_review_progress (
     reviewed_paths TEXT NOT NULL DEFAULT '[]',  -- JSON array of paths reviewed so far
     skipped_paths TEXT NOT NULL DEFAULT '[]',   -- JSON array of paths intentionally skipped (low priority)
     chunk_index INTEGER NOT NULL DEFAULT 0,
+    -- Head SHA of the most recent review on this PR. Round 2+ uses this
+    -- as the base for an incremental diff so unchanged files aren't
+    -- re-flagged after a new push.
+    last_reviewed_sha TEXT NOT NULL DEFAULT '',
     updated_at REAL NOT NULL DEFAULT 0,
     PRIMARY KEY (owner, repo, pr_number)
 );
@@ -152,6 +156,7 @@ CREATE TABLE IF NOT EXISTS pr_review_progress (
     reviewed_paths TEXT NOT NULL DEFAULT '[]',
     skipped_paths TEXT NOT NULL DEFAULT '[]',
     chunk_index INTEGER NOT NULL DEFAULT 0,
+    last_reviewed_sha TEXT NOT NULL DEFAULT '',
     updated_at TIMESTAMPTZ DEFAULT NOW(),
     PRIMARY KEY (owner, repo, pr_number)
 );
@@ -271,6 +276,14 @@ class AppDatabase:
             self._sqlite_conn.execute(
                 "ALTER TABLE repos ADD COLUMN conventions TEXT NOT NULL DEFAULT ''"
             )
+        progress_cols = {
+            r[1]
+            for r in self._sqlite_conn.execute("PRAGMA table_info(pr_review_progress)").fetchall()
+        }
+        if "last_reviewed_sha" not in progress_cols:
+            self._sqlite_conn.execute(
+                "ALTER TABLE pr_review_progress ADD COLUMN last_reviewed_sha TEXT NOT NULL DEFAULT ''"
+            )
         self._sqlite_conn.commit()
         logger.info("App database: SQLite at %s", db_path)
 
@@ -289,6 +302,10 @@ class AppDatabase:
                 )
                 cur.execute(
                     "ALTER TABLE repos ADD COLUMN IF NOT EXISTS conventions TEXT NOT NULL DEFAULT ''"
+                )
+                cur.execute(
+                    "ALTER TABLE pr_review_progress ADD COLUMN IF NOT EXISTS "
+                    "last_reviewed_sha TEXT NOT NULL DEFAULT ''"
                 )
             logger.info("App database: PostgreSQL")
         except ImportError:
@@ -1036,6 +1053,74 @@ class AppDatabase:
             chunk_index=int(row[3]),
             updated_at=float(row[4] or 0),
         )
+
+    def get_last_reviewed_sha(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+    ) -> str:
+        """Return the head SHA at the time of the last review on this PR.
+
+        Empty string if there is no prior review (first round, or progress
+        row never written) — callers should treat empty as "no previous SHA,
+        do a full review."
+        """
+        if self._backend == "sqlite":
+            assert self._sqlite_conn is not None
+            row = self._sqlite_conn.execute(
+                "SELECT last_reviewed_sha FROM pr_review_progress "
+                "WHERE owner=? AND repo=? AND pr_number=?",
+                (owner, repo, pr_number),
+            ).fetchone()
+        else:
+            assert self._pg_conn is not None
+            with self._pg_conn.cursor() as cur:
+                cur.execute(
+                    "SELECT last_reviewed_sha FROM pr_review_progress "
+                    "WHERE owner=%s AND repo=%s AND pr_number=%s",
+                    (owner, repo, pr_number),
+                )
+                row = cur.fetchone()
+        return str(row[0]) if row and row[0] else ""
+
+    def set_last_reviewed_sha(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        sha: str,
+    ) -> None:
+        """Record the head SHA we just reviewed against. Round 2+ uses this
+        as the base for the incremental diff.
+        """
+        if not sha:
+            return
+        now = time.time()
+        if self._backend == "sqlite":
+            assert self._sqlite_conn is not None
+            self._sqlite_conn.execute(
+                "INSERT INTO pr_review_progress "
+                "(owner, repo, pr_number, last_reviewed_sha, updated_at) "
+                "VALUES (?, ?, ?, ?, ?) "
+                "ON CONFLICT(owner, repo, pr_number) DO UPDATE SET "
+                "last_reviewed_sha=excluded.last_reviewed_sha, "
+                "updated_at=excluded.updated_at",
+                (owner, repo, pr_number, sha, now),
+            )
+            self._sqlite_conn.commit()
+        else:
+            assert self._pg_conn is not None
+            with self._pg_conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO pr_review_progress "
+                    "(owner, repo, pr_number, last_reviewed_sha, updated_at) "
+                    "VALUES (%s, %s, %s, %s, NOW()) "
+                    "ON CONFLICT (owner, repo, pr_number) DO UPDATE SET "
+                    "last_reviewed_sha=EXCLUDED.last_reviewed_sha, "
+                    "updated_at=NOW()",
+                    (owner, repo, pr_number, sha),
+                )
 
     def delete_pr_review_progress(self, owner: str, repo: str, pr_number: int) -> None:
         if self._backend == "sqlite":

--- a/src/mira/github_app/handlers.py
+++ b/src/mira/github_app/handlers.py
@@ -93,6 +93,7 @@ async def handle_pull_request(
                     number=number,
                     owner=owner,
                     repo=repo,
+                    head_sha=pr["head"].get("sha") or "",
                 )
                 dashboard_url = os.environ.get("MIRA_DASHBOARD_URL", "http://localhost:5173")
                 note = (
@@ -490,6 +491,7 @@ async def handle_pr_merged(
             number=number,
             owner=owner,
             repo=repo,
+            head_sha=pr["head"].get("sha") or "",
         )
 
         from mira.providers.github import parse_bot_comment_metadata

--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -114,9 +114,9 @@ _SKIP_PATTERNS = [
 ]
 
 _FILE_FETCH_SEMAPHORE = 10
-# Concurrent LLM summarization batches per repo. Haiku handles 6-8
-# comfortably on OpenRouter; bumping from 3 nearly halves file-phase wall
-# time without changing quality.
+# Concurrent LLM summarization batches per repo. The indexing model
+# typically handles 6-8 comfortably on OpenRouter; bumping from 3 nearly
+# halves file-phase wall time without changing quality.
 _LLM_SEMAPHORE = 8
 # Smaller batches → faster individual calls → better wave parallelism.
 # Empirically a 5-file batch with one large file bloated to 7k output

--- a/src/mira/index/jit_context.py
+++ b/src/mira/index/jit_context.py
@@ -38,6 +38,62 @@ _RUBY_REQUIRE_RE = re.compile(
     re.MULTILINE,
 )
 
+# Java: `import com.foo.bar.Baz;` or `import static com.foo.bar.Baz.method;`.
+# We capture the dotted FQN; wildcard imports (`import com.foo.*`) are
+# captured but yield no useful single-file candidate (we drop them downstream).
+_JAVA_IMPORT_RE = re.compile(
+    r"^\s*import\s+(?:static\s+)?([\w.]+(?:\.\*)?)\s*;",
+    re.MULTILINE,
+)
+
+# Go imports come in two shapes:
+#   import "single/path"
+#   import (
+#       "first"
+#       aliased "second"
+#   )
+# A regex over the whole file is too broad (it matches any quoted string,
+# which is everywhere in Go — struct tags, error messages, format strings).
+# Instead we walk lines and only treat quoted strings as imports when we're
+# inside an `import (` block or on an `import "..."` line.
+_GO_SINGLE_IMPORT_RE = re.compile(r'^\s*import\s+(?:(?:[A-Za-z_]\w*|\.)\s+)?"([^"]+)"\s*$')
+_GO_BLOCK_PATH_RE = re.compile(r'^\s*(?:(?:[A-Za-z_]\w*|\.)\s+)?"([^"]+)"\s*$')
+
+# Standard-library Go packages: short single-word paths and well-known
+# multi-word paths. Cheap heuristic to avoid even trying to resolve them.
+_GO_STDLIB_HINTS = (
+    "net/",
+    "encoding/",
+    "crypto/",
+    "io/",
+    "os/",
+    "path/",
+    "text/",
+    "html/",
+    "log/",
+    "regexp/",
+    "compress/",
+    "container/",
+    "database/",
+    "debug/",
+    "go/",
+    "image/",
+    "math/",
+    "mime/",
+    "runtime/",
+    "sync/",
+    "syscall/",
+    "testing/",
+    "unicode/",
+    "archive/",
+    "hash/",
+    "index/",
+    "reflect/",
+    "sort/",
+    "strconv/",
+    "time/",
+)
+
 _EXT_TO_LANG = {
     "py": "python",
     "js": "javascript",
@@ -45,10 +101,51 @@ _EXT_TO_LANG = {
     "ts": "typescript",
     "tsx": "typescript",
     "rb": "ruby",
+    "java": "java",
+    "go": "go",
 }
 
 _MAX_FILES = 8
 _MAX_PER_FILE_CHARS = 1500
+# Java/Go resolution is heuristic — picking the wrong file pollutes the
+# prompt with off-topic symbols and hurts more than it helps. Cap at 1
+# candidate so we either find the right file or skip cleanly.
+_MAX_CANDIDATES_PER_IMPORT = 1
+
+
+def _extract_go_import_paths(source: str) -> list[str]:
+    """Pull every imported package path from a Go source file.
+
+    Handles both forms:
+        import "foo"
+        import (
+            "first"
+            aliased "second"
+            // a comment
+        )
+    """
+    paths: list[str] = []
+    in_block = False
+    for raw in source.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("//"):
+            continue
+        if line.startswith("import"):
+            if "(" in line and ")" not in line:
+                in_block = True
+                continue
+            m = _GO_SINGLE_IMPORT_RE.match(raw)
+            if m:
+                paths.append(m.group(1))
+            continue
+        if in_block:
+            if line == ")":
+                in_block = False
+                continue
+            m = _GO_BLOCK_PATH_RE.match(raw)
+            if m:
+                paths.append(m.group(1))
+    return paths
 
 
 def _ext(path: str) -> str:
@@ -113,12 +210,112 @@ def _candidates_ruby(import_path: str, source_path: str) -> list[str]:
     return [base if base.endswith(".rb") else f"{base}.rb"]
 
 
+def _candidates_java(fqn: str, repo_tree: set[str] | None) -> list[str]:
+    """Resolve a Java FQN like `com.foo.bar.Baz` to candidate file paths.
+
+    Java doesn't tell us where in the source tree a class lives — Maven and
+    Gradle layouts vary, and a sub-project may have its own `src/main/java`.
+    We use the class name from the FQN and ask the repo tree for any file
+    ending in `/<ClassName>.java`. With a unique class name the answer is
+    one or two files; with collisions we cap at 2.
+    """
+    if not fqn or fqn.endswith(".*") or repo_tree is None:
+        return []
+    parts = fqn.split(".")
+    # `import static com.foo.Bar.method` — drop the trailing lowercase
+    # method/field name so we resolve the enclosing class instead.
+    while parts and parts[-1] and parts[-1][0].islower():
+        parts = parts[:-1]
+    if len(parts) < 2:
+        return []
+    class_name = parts[-1]
+    if not class_name or not class_name[0].isupper():
+        return []
+    suffix = f"/{class_name}.java"
+    matches = [p for p in repo_tree if p.endswith(suffix) or p == f"{class_name}.java"]
+    # Prefer matches whose path also contains the package segment — that
+    # disambiguates `Util.java` files when there are several. Sort: more
+    # package-segment overlap first.
+    pkg_path = ".".join(parts[:-1])
+    matches.sort(key=lambda p: (-_path_overlap(p, pkg_path), len(p)))
+    return matches[:_MAX_CANDIDATES_PER_IMPORT]
+
+
+def _path_overlap(file_path: str, pkg_path: str) -> int:
+    """How many segments of pkg_path appear in file_path, in order."""
+    if not pkg_path:
+        return 0
+    fp_parts = file_path.split("/")
+    pkg_parts = pkg_path.split(".")
+    if not pkg_parts:
+        return 0
+    score = 0
+    j = 0
+    for seg in fp_parts:
+        if j < len(pkg_parts) and seg == pkg_parts[j]:
+            score += 1
+            j += 1
+    return score
+
+
+def _candidates_go(import_path: str, repo_tree: set[str] | None) -> list[str]:
+    """Resolve a Go import path like `github.com/grafana/grafana/pkg/x` to files.
+
+    Go imports are full module paths. We don't know this repo's module
+    name without parsing `go.mod`, so we use a tail-match heuristic: take
+    the path's last 2-3 segments and look for a directory in the repo
+    whose path ends with them. Then return up to N `.go` files in that
+    directory (skipping `*_test.go`).
+    """
+    if not import_path or repo_tree is None:
+        return []
+    # Drop quotes / spaces just in case.
+    p = import_path.strip().strip('"').strip()
+    if not p or p.startswith("."):
+        return []
+    # Skip common stdlib paths so we don't burn cycles.
+    if "/" not in p:
+        return []  # single-segment imports are stdlib (`strings`, `fmt`)
+    if p.startswith(_GO_STDLIB_HINTS):
+        return []
+
+    segs = p.split("/")
+    # Try progressively longer tail matches: last 3 segments first, then 2.
+    for tail_len in (3, 2):
+        if tail_len > len(segs):
+            continue
+        suffix = "/".join(segs[-tail_len:])
+        match_dir = f"/{suffix}/"
+        files = [
+            f
+            for f in repo_tree
+            if (match_dir in f"/{f}" or f"/{f}".endswith(f"/{suffix}"))
+            and f.endswith(".go")
+            and not f.endswith("_test.go")
+        ]
+        if files:
+            files.sort(key=len)
+            return files[:_MAX_CANDIDATES_PER_IMPORT]
+    return []
+
+
 def extract_import_candidates(
     source: str,
     language: str,
     source_path: str,
+    repo_tree: set[str] | None = None,
+    enable_java_go: bool = True,
 ) -> list[str]:
-    """Return candidate file paths referenced by imports in ``source``."""
+    """Return candidate file paths referenced by imports in ``source``.
+
+    ``repo_tree`` is required for Java and Go (their imports don't encode
+    enough information to reconstruct a path algorithmically — we have to
+    look at what files actually exist). Optional for the other languages.
+
+    ``enable_java_go`` lets the caller A/B disable the Java + Go resolvers
+    without pulling them out of the dispatch table; their resolution is
+    heuristic enough that it sometimes hurts on noisy repos.
+    """
     seen: set[str] = set()
     out: list[str] = []
 
@@ -140,6 +337,14 @@ def extract_import_candidates(
         for m in _RUBY_REQUIRE_RE.finditer(source):
             for c in _candidates_ruby(m.group(1), source_path):
                 add(c)
+    elif language == "java" and enable_java_go:
+        for m in _JAVA_IMPORT_RE.finditer(source):
+            for c in _candidates_java(m.group(1), repo_tree):
+                add(c)
+    elif language == "go" and enable_java_go:
+        for path in _extract_go_import_paths(source):
+            for c in _candidates_go(path, repo_tree):
+                add(c)
     return out
 
 
@@ -160,6 +365,7 @@ async def build_jit_cross_file_context(
     source_fetcher,  # SourceFetcher
     repo_tree: set[str] | None,
     char_budget: int = 12_000,
+    enable_java_go: bool = True,
 ) -> str:
     """Fetch source for files imported by the changed files and inline symbols.
 
@@ -202,7 +408,13 @@ async def build_jit_cross_file_context(
         if not source:
             continue
 
-        candidates = extract_import_candidates(source, lang, changed_file.path)
+        candidates = extract_import_candidates(
+            source,
+            lang,
+            changed_file.path,
+            repo_tree=repo_tree,
+            enable_java_go=enable_java_go,
+        )
 
         for cand in candidates:
             if files_added >= _MAX_FILES or chars_used >= char_budget:

--- a/src/mira/index/jit_context.py
+++ b/src/mira/index/jit_context.py
@@ -1,0 +1,261 @@
+"""Just-in-time cross-file context for unindexed repos.
+
+When a review runs on a repo that hasn't been indexed yet (CLI usage, fresh
+GitHub App install before the indexer has finished), ``build_code_context``
+falls through with empty summaries and blast radius — silently. This module
+fetches imported files from HEAD on demand using the existing ``source_fetcher``
+and inlines their symbols as context, so the LLM has cross-file knowledge
+without waiting for a multi-minute indexing pass first.
+
+Designed to be cheap: one tree call (1 API request) tells us which import
+candidates exist, then we only fetch contents for files we know are real.
+Capped at ``_MAX_FILES`` fetched files per review and a hard char budget.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import PurePosixPath
+
+from mira.index.extract import extract_symbols
+from mira.models import FileDiff
+
+logger = logging.getLogger(__name__)
+
+
+_PY_IMPORT_RE = re.compile(
+    r"^\s*(?:from\s+([\w.]+)\s+import|import\s+([\w.]+))",
+    re.MULTILINE,
+)
+
+_JS_IMPORT_RE = re.compile(
+    r"""(?:from|require\s*\()\s*['"]([^'"]+)['"]""",
+)
+
+_RUBY_REQUIRE_RE = re.compile(
+    r"""^\s*require(?:_relative)?\s+['"]([^'"]+)['"]""",
+    re.MULTILINE,
+)
+
+_EXT_TO_LANG = {
+    "py": "python",
+    "js": "javascript",
+    "jsx": "javascript",
+    "ts": "typescript",
+    "tsx": "typescript",
+    "rb": "ruby",
+}
+
+_MAX_FILES = 8
+_MAX_PER_FILE_CHARS = 1500
+
+
+def _ext(path: str) -> str:
+    return PurePosixPath(path).suffix.lstrip(".")
+
+
+def _candidates_python(module: str, source_path: str) -> list[str]:
+    """Resolve a Python dotted import to candidate file paths."""
+    if not module:
+        return []
+    rel = "/".join(module.split("."))
+    cands = [f"{rel}.py", f"{rel}/__init__.py"]
+    src_dir = str(PurePosixPath(source_path).parent)
+    if src_dir not in (".", ""):
+        cands += [f"{src_dir}/{rel}.py", f"{src_dir}/{rel}/__init__.py"]
+    for root in ("src", "lib"):
+        cands += [f"{root}/{rel}.py", f"{root}/{rel}/__init__.py"]
+    return cands
+
+
+def _normalize_relative(src_dir: str, rel: str) -> str:
+    """Resolve a relative import (`./foo`, `../bar/baz`) against ``src_dir``.
+
+    PurePosixPath doesn't collapse ``..`` segments on its own — we need
+    to walk the path manually to get a clean filesystem-style path.
+    """
+    if rel.startswith("/"):
+        return rel.lstrip("/")
+    parts = [p for p in src_dir.split("/") if p and p != "."]
+    for seg in rel.split("/"):
+        if seg in ("", "."):
+            continue
+        if seg == "..":
+            if parts:
+                parts.pop()
+            continue
+        parts.append(seg)
+    return "/".join(parts)
+
+
+def _candidates_js(import_path: str, source_path: str) -> list[str]:
+    """Resolve a JS/TS import string to candidate file paths."""
+    if not import_path or not import_path.startswith("."):
+        return []  # bare imports (npm packages) — skip
+    src_dir = str(PurePosixPath(source_path).parent)
+    base = _normalize_relative(src_dir, import_path)
+    if PurePosixPath(base).suffix in (".ts", ".tsx", ".js", ".jsx", ".mjs"):
+        return [base]
+    cands = []
+    for ext in (".ts", ".tsx", ".js", ".jsx", ".mjs"):
+        cands.append(f"{base}{ext}")
+    for ext in (".ts", ".tsx", ".js", ".jsx"):
+        cands.append(f"{base}/index{ext}")
+    return cands
+
+
+def _candidates_ruby(import_path: str, source_path: str) -> list[str]:
+    if not import_path:
+        return []
+    src_dir = str(PurePosixPath(source_path).parent)
+    base = _normalize_relative(src_dir, import_path)
+    return [base if base.endswith(".rb") else f"{base}.rb"]
+
+
+def extract_import_candidates(
+    source: str,
+    language: str,
+    source_path: str,
+) -> list[str]:
+    """Return candidate file paths referenced by imports in ``source``."""
+    seen: set[str] = set()
+    out: list[str] = []
+
+    def add(path: str) -> None:
+        if path and path not in seen:
+            seen.add(path)
+            out.append(path)
+
+    if language == "python":
+        for m in _PY_IMPORT_RE.finditer(source):
+            module = m.group(1) or m.group(2) or ""
+            for c in _candidates_python(module, source_path):
+                add(c)
+    elif language in ("javascript", "typescript"):
+        for m in _JS_IMPORT_RE.finditer(source):
+            for c in _candidates_js(m.group(1), source_path):
+                add(c)
+    elif language == "ruby":
+        for m in _RUBY_REQUIRE_RE.finditer(source):
+            for c in _candidates_ruby(m.group(1), source_path):
+                add(c)
+    return out
+
+
+def _trim_symbol(source: str, max_chars: int) -> str:
+    """Keep the symbol's signature + first lines; drop the rest if too long."""
+    if len(source) <= max_chars:
+        return source
+    # Prefer ending on a line boundary near the budget.
+    truncated = source[:max_chars]
+    last_nl = truncated.rfind("\n")
+    if last_nl > 0:
+        truncated = truncated[:last_nl]
+    return truncated + "\n    # ... (truncated)"
+
+
+async def build_jit_cross_file_context(
+    changed_files: list[FileDiff],
+    source_fetcher,  # SourceFetcher
+    repo_tree: set[str] | None,
+    char_budget: int = 12_000,
+) -> str:
+    """Fetch source for files imported by the changed files and inline symbols.
+
+    Args:
+        changed_files: files modified in this PR.
+        source_fetcher: ``ProviderSourceFetcher``-compatible object.
+        repo_tree: set of all blob paths in the repo (from a tree API call).
+            Used to filter import-resolution candidates so we only attempt
+            content fetches for paths we know exist. ``None`` means
+            "filter disabled — try every candidate" (slower).
+        char_budget: hard cap on total context size.
+
+    Returns:
+        Markdown block ready to inject into the review prompt. Empty string
+        if no usable cross-file context could be assembled.
+    """
+    if source_fetcher is None or char_budget <= 0:
+        return ""
+
+    parts: list[str] = []
+    chars_used = 0
+    files_added = 0
+    seen_imports: set[str] = set()
+    changed_paths = {f.path for f in changed_files}
+
+    for changed_file in changed_files:
+        if files_added >= _MAX_FILES or chars_used >= char_budget:
+            break
+
+        ext = _ext(changed_file.path)
+        lang = _EXT_TO_LANG.get(ext)
+        if not lang:
+            continue
+
+        try:
+            source = await source_fetcher.fetch(changed_file.path)
+        except Exception as exc:
+            logger.debug("JIT: source fetch failed for %s: %s", changed_file.path, exc)
+            continue
+        if not source:
+            continue
+
+        candidates = extract_import_candidates(source, lang, changed_file.path)
+
+        for cand in candidates:
+            if files_added >= _MAX_FILES or chars_used >= char_budget:
+                break
+            if cand in seen_imports or cand in changed_paths:
+                continue
+            # Only fetch candidates that exist in the repo.
+            if repo_tree is not None and cand not in repo_tree:
+                continue
+            seen_imports.add(cand)
+
+            try:
+                imported_source = await source_fetcher.fetch(cand)
+            except Exception as exc:
+                logger.debug("JIT: import fetch failed for %s: %s", cand, exc)
+                continue
+            if not imported_source:
+                continue
+
+            cand_lang = _EXT_TO_LANG.get(_ext(cand), lang)
+            symbols = extract_symbols(imported_source, cand_lang)
+            if not symbols:
+                continue
+
+            block_lines = [
+                f"#### `{cand}` (imported by `{changed_file.path}`)",
+                f"```{cand_lang}",
+            ]
+            file_chars = 0
+            for sym in symbols:
+                trimmed = _trim_symbol(sym.source, _MAX_PER_FILE_CHARS - file_chars)
+                if not trimmed.strip():
+                    continue
+                block_lines.append(trimmed)
+                block_lines.append("")
+                file_chars += len(trimmed)
+                if file_chars >= _MAX_PER_FILE_CHARS:
+                    break
+            block_lines.append("```")
+            block = "\n".join(block_lines)
+
+            if chars_used + len(block) > char_budget:
+                break
+            parts.append(block)
+            chars_used += len(block)
+            files_added += 1
+
+    if not parts:
+        return ""
+
+    return (
+        "### Imported Files (fetched on-demand)\n\n"
+        "Source code from files imported by the changed files. Use this to "
+        "verify call signatures, type contracts, and downstream behaviour "
+        "instead of speculating about what these symbols do.\n\n" + "\n\n".join(parts)
+    )

--- a/src/mira/llm/agentic_tools.py
+++ b/src/mira/llm/agentic_tools.py
@@ -1,0 +1,275 @@
+"""Tools the reviewer LLM can call when the repo isn't indexed.
+
+When a repo has no pre-built index, JIT cross-file context covers Python /
+JS / TS / Ruby (parseable imports) but leaves Java and Go gaps because their
+import resolution needs build-system context. To close that gap, give the
+reviewer two tools — `read_file` and `grep_repo` — and let it pull the
+specific cross-file context it actually needs to verify a candidate finding.
+
+This module owns the tool *schemas* and a per-review *executor* that
+dispatches calls, caches results, and hard-caps total output. The agentic
+loop itself lives in `engine.py:_review_chunk`.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import re
+from dataclasses import dataclass, field
+
+from mira.index.context import SourceFetcher
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas (OpenAI function-calling format)
+# ---------------------------------------------------------------------------
+
+READ_FILE_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "read_file",
+        "description": (
+            "Read a file from the repository at the PR head. Use this to verify "
+            "cross-file claims (does function X exist? what does the caller pass?) "
+            "before filing a comment. Prefer reading specific files over guessing. "
+            "Returns the file content with line numbers."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": (
+                        "Repo-relative path of the file to read, e.g. `src/auth/middleware.py`."
+                    ),
+                },
+            },
+            "required": ["path"],
+        },
+    },
+}
+
+
+GREP_REPO_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "grep_repo",
+        "description": (
+            "Search the repo for files whose path or content matches a pattern. "
+            "Use this to find where a symbol is defined or called when you don't "
+            "already know the file path. Returns up to 30 matching paths (path "
+            "search) or up to 30 line-level hits (content search)."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": (
+                        "What to look for. Treated as a regex against file content "
+                        "unless `path_only` is true. Keep it specific — short or "
+                        "common patterns return too many matches and get capped."
+                    ),
+                },
+                "path_glob": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Optional glob to restrict the search, e.g. `**/*.java` "
+                        "or `src/auth/*`. Defaults to all files."
+                    ),
+                },
+                "path_only": {
+                    "type": ["boolean", "null"],
+                    "description": (
+                        "If true, only match paths (don't read file contents). "
+                        "Faster and cheaper. Use when you're hunting for a file "
+                        "by name."
+                    ),
+                },
+            },
+            "required": ["pattern"],
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Executor
+# ---------------------------------------------------------------------------
+
+# Hard caps to keep tool output from blowing up the prompt or the API budget.
+_MAX_FILE_BYTES = 12_000  # ~3k tokens of source; truncate larger files
+_MAX_GREP_HITS = 30
+_MAX_GREP_BYTES_PER_HIT = 240
+_MAX_TOTAL_OUTPUT_BYTES = 50_000  # all tool calls in one review combined
+
+
+@dataclass
+class AgenticToolExecutor:
+    """Per-review tool dispatcher with caching and an output-size budget.
+
+    Construct one per chunk review. The `repo_tree` is captured once
+    (already fetched for JIT) so `grep_repo` doesn't keep re-listing the
+    repo. The `source_fetcher` already has its own per-path cache, so
+    repeated `read_file` calls don't re-hit GitHub.
+    """
+
+    source_fetcher: SourceFetcher
+    repo_tree: list[str]
+    bytes_used: int = 0
+    _content_cache: dict[str, str | None] = field(default_factory=dict)
+
+    async def execute(self, name: str, args: dict) -> str:
+        """Dispatch a tool call. Returns the tool result as a string.
+
+        Always returns *something* — errors are reported back to the LLM
+        rather than raised, so the model can recover (e.g. by trying a
+        different path). The string is what gets fed back into the next
+        LLM hop as a `tool` message.
+        """
+        if self.bytes_used >= _MAX_TOTAL_OUTPUT_BYTES:
+            return "[tool budget exhausted — no more tool calls accepted; submit your review now]"
+
+        try:
+            if name == "read_file":
+                path = (args or {}).get("path") or ""
+                if not path:
+                    return "[error: missing `path` argument]"
+                result = await self._read_file(path)
+            elif name == "grep_repo":
+                pattern = (args or {}).get("pattern") or ""
+                if not pattern:
+                    return "[error: missing `pattern` argument]"
+                path_glob = (args or {}).get("path_glob") or None
+                path_only = bool((args or {}).get("path_only") or False)
+                result = await self._grep_repo(pattern, path_glob, path_only)
+            else:
+                return f"[error: unknown tool `{name}`]"
+        except Exception as exc:
+            logger.debug("Tool %s failed: %s", name, exc)
+            return f"[error executing `{name}`: {exc}]"
+
+        self.bytes_used += len(result)
+        return result
+
+    async def _read_file(self, path: str) -> str:
+        # Don't waste tokens hunting for files we know don't exist.
+        if self.repo_tree and path not in self.repo_tree:
+            close = [p for p in self.repo_tree if path.lower() in p.lower()][:5]
+            hint = f" Did you mean: {', '.join(close)}?" if close else ""
+            return f"[file not found at PR head: `{path}`.{hint}]"
+
+        if path in self._content_cache:
+            content = self._content_cache[path]
+        else:
+            content = await self.source_fetcher.fetch(path)
+            self._content_cache[path] = content
+
+        if content is None:
+            return f"[failed to read `{path}`]"
+
+        truncated = False
+        if len(content) > _MAX_FILE_BYTES:
+            content = content[:_MAX_FILE_BYTES]
+            truncated = True
+
+        # Number lines so the LLM can cite them by number when filing comments.
+        numbered = "\n".join(f"{i + 1:>5}  {line}" for i, line in enumerate(content.split("\n")))
+        suffix = (
+            f"\n... [truncated; file is longer than {_MAX_FILE_BYTES} bytes]" if truncated else ""
+        )
+        return f"`{path}`:\n```\n{numbered}{suffix}\n```"
+
+    async def _grep_repo(self, pattern: str, path_glob: str | None, path_only: bool) -> str:
+        if not self.repo_tree:
+            return "[grep unavailable: repo tree not loaded]"
+
+        # Path filter
+        candidates: list[str]
+        if path_glob:
+            candidates = [p for p in self.repo_tree if fnmatch.fnmatch(p, path_glob)]
+        else:
+            candidates = list(self.repo_tree)
+
+        if path_only:
+            try:
+                rx = re.compile(pattern)
+            except re.error:
+                # Treat as substring on regex error.
+                hits = [p for p in candidates if pattern in p][:_MAX_GREP_HITS]
+            else:
+                hits = [p for p in candidates if rx.search(p)][:_MAX_GREP_HITS]
+            if not hits:
+                return f"[no path matches for `{pattern}`]"
+            return "Path matches:\n" + "\n".join(f"- `{p}`" for p in hits)
+
+        try:
+            rx = re.compile(pattern)
+        except re.error as exc:
+            return f"[invalid regex `{pattern}`: {exc}]"
+
+        # Skip giant binaries / lockfiles / vendored dirs we'd never want to read.
+        skip_exts = (
+            ".png",
+            ".jpg",
+            ".jpeg",
+            ".gif",
+            ".pdf",
+            ".zip",
+            ".gz",
+            ".tar",
+            ".woff",
+            ".woff2",
+            ".ttf",
+            ".eot",
+            ".ico",
+            ".svg",
+            ".map",
+            ".lock",
+        )
+        skip_dirs = ("node_modules/", "vendor/", "dist/", "build/", ".git/")
+
+        hits: list[str] = []
+        files_scanned = 0
+        # Keep this small — we're scanning files via the source_fetcher so
+        # each file is a network call. The intent is to find a known signal,
+        # not crawl the whole repo.
+        max_files_to_scan = 60
+
+        for cand in candidates:
+            if len(hits) >= _MAX_GREP_HITS or files_scanned >= max_files_to_scan:
+                break
+            if any(cand.endswith(ext) for ext in skip_exts):
+                continue
+            if any(d in cand for d in skip_dirs):
+                continue
+
+            files_scanned += 1
+            content = self._content_cache.get(cand)
+            if content is None and cand not in self._content_cache:
+                content = await self.source_fetcher.fetch(cand)
+                self._content_cache[cand] = content
+            if not content:
+                continue
+
+            for lineno, line in enumerate(content.split("\n"), start=1):
+                if rx.search(line):
+                    snippet = line.strip()
+                    if len(snippet) > _MAX_GREP_BYTES_PER_HIT:
+                        snippet = snippet[:_MAX_GREP_BYTES_PER_HIT] + "…"
+                    hits.append(f"{cand}:{lineno}: {snippet}")
+                    if len(hits) >= _MAX_GREP_HITS:
+                        break
+
+        if not hits:
+            return f"[no content matches for `{pattern}` (scanned {files_scanned} files)]"
+        prefix = f"Content matches (scanned {files_scanned} files):"
+        if len(hits) == _MAX_GREP_HITS:
+            prefix += f" showing first {_MAX_GREP_HITS}"
+        return prefix + "\n" + "\n".join(hits)
+
+
+AGENTIC_TOOLS = [READ_FILE_TOOL, GREP_REPO_TOOL]

--- a/src/mira/llm/prompts/footguns.py
+++ b/src/mira/llm/prompts/footguns.py
@@ -117,24 +117,54 @@ _UNIVERSAL: list[str] = [
 ]
 
 
-def get_footguns_for_files(files: list[FileDiff]) -> str:
+def _primary_language(files: list[FileDiff]) -> str | None:
+    """Pick the diff's primary language by total lines changed.
+
+    Multi-language PRs are rare; when they happen, packing every language's
+    footguns into the prompt dilutes attention. Picking the dominant
+    language and skipping the rest keeps the section focused.
+    """
+    score: dict[str, int] = {}
+    for f in files:
+        ext = f.path.rsplit(".", 1)[-1].lower() if "." in f.path else ""
+        lang = _EXT_TO_LANG.get(ext)
+        if not lang:
+            continue
+        score[lang] = score.get(lang, 0) + f.total_changes
+    if not score:
+        return None
+    # Sort: most changes wins; alphabetical break for determinism.
+    return sorted(score.items(), key=lambda kv: (-kv[1], kv[0]))[0][0]
+
+
+def get_footguns_for_files(files: list[FileDiff], primary_only: bool = True) -> str:
     """Return a markdown block of footgun rules for the languages in ``files``.
+
+    By default, only the diff's primary language (most lines changed) is
+    included — multi-language packing crowds the prompt and dilutes
+    attention. Pass ``primary_only=False`` to include every detected
+    language.
 
     Returns an empty string if no relevant languages are detected, so the
     review prompt's `{% if footguns %}` branch can skip the section cleanly.
     """
-    langs: set[str] = set()
-    for f in files:
-        ext = f.path.rsplit(".", 1)[-1].lower() if "." in f.path else ""
-        lang = _EXT_TO_LANG.get(ext)
-        if lang:
-            langs.add(lang)
+    if primary_only:
+        primary = _primary_language(files)
+        langs: list[str] = [primary] if primary else []
+    else:
+        seen: set[str] = set()
+        for f in files:
+            ext = f.path.rsplit(".", 1)[-1].lower() if "." in f.path else ""
+            lang = _EXT_TO_LANG.get(ext)
+            if lang:
+                seen.add(lang)
+        langs = sorted(seen)
 
     if not langs and not _UNIVERSAL:
         return ""
 
     parts: list[str] = []
-    for lang in sorted(langs):
+    for lang in langs:
         rules = _FOOTGUNS.get(lang)
         if not rules:
             continue

--- a/src/mira/llm/prompts/footguns.py
+++ b/src/mira/llm/prompts/footguns.py
@@ -1,0 +1,152 @@
+"""Language-keyed framework footgun knowledge injected into the review prompt.
+
+Static knowledge that an LLM trained on a snapshot of the world reliably
+benefits from being reminded of: subtle bugs that are easy to miss because
+they look correct at a glance. Keep entries terse and copy-paste-able into
+a single prompt section.
+
+To extend: add an entry under the relevant language. Each rule should
+describe the bug, not the fix — the model is good at fixes once it
+recognises the pattern.
+"""
+
+from __future__ import annotations
+
+from mira.models import FileDiff
+
+_EXT_TO_LANG = {
+    "py": "python",
+    "js": "javascript",
+    "jsx": "javascript",
+    "ts": "typescript",
+    "tsx": "typescript",
+    "go": "go",
+    "rb": "ruby",
+    "java": "java",
+    "kt": "kotlin",
+    "rs": "rust",
+}
+
+# Each language's footguns is a list of bullet rules. Keep concise — the
+# model just needs the recognition trigger, not paragraphs of context.
+_FOOTGUNS: dict[str, list[str]] = {
+    "python": [
+        "**Negative slicing on Django QuerySets** raises `AssertionError` — `qs[-1]` and "
+        "`qs[:-1]` are not supported. Order with `.order_by()` and use `.first()` / `.last()`.",
+        "**`is` for value comparisons** — use `==` for ints/strs. `is` only works on identity "
+        "(small-int caching is an implementation detail).",
+        "**`{}.fromkeys(keys, [])`** — every key shares the same list. Use a comprehension.",
+        "**Mutable default arguments** (`def f(x=[]):`) — the list is shared across calls.",
+        "**`async`/`await` with sync code in `forEach`-style helpers** — `for x in items: await ...` "
+        "is correct; passing an async function to a sync helper is not.",
+        "**`hash()` for cache keys** is non-deterministic across processes (PYTHONHASHSEED). "
+        "Use `hashlib` for cache keys that must be stable.",
+        "**Blanket `except Exception`** — swallows `KeyboardInterrupt`/`SystemExit` if you used "
+        "bare `except:`, and hides bugs in normal control flow either way. Prefer specific exceptions.",
+    ],
+    "javascript": [
+        "**`forEach` with async callback** — `array.forEach(async x => await ...)` does NOT wait. "
+        "Use `for...of` with `await`, or `Promise.all(array.map(...))`.",
+        "**Falsy-zero bug** — `if (count) {...}` skips when `count === 0`. Use `count != null` "
+        "or explicit `count > 0` for numeric values.",
+        "**Missing `await` on a Promise** — calling an async function without `await` returns a "
+        "Promise object, which is always truthy and never throws — silent bug.",
+        "**`Object.keys(x)` order** is insertion order for string keys, but **integer-like keys "
+        "are sorted numerically first**. Don't rely on declaration order with mixed keys.",
+        "**`==` vs `===`** — `==` does type coercion (`'0' == false`, `null == undefined`). "
+        "Always `===` unless you specifically want coercion.",
+    ],
+    "typescript": [
+        "**`forEach` with async callback** — does NOT wait. Use `for...of` with `await` or "
+        "`Promise.all(array.map(...))`.",
+        "**`as` casts bypass type-checking** — `x as Foo` doesn't validate, it asserts. If `x` "
+        "isn't actually a `Foo`, you'll get runtime errors with no warning.",
+        "**Non-null assertion (`x!`)** silences the type checker but doesn't prevent `null`/`undefined` "
+        "at runtime — flag whenever it's used on values that might genuinely be nullish.",
+        "**`Promise.all` rejects on first failure** but doesn't cancel the others. If you need "
+        "all-or-nothing behaviour with cleanup, use `Promise.allSettled` or explicit cancellation.",
+    ],
+    "go": [
+        "**Loop-variable capture** — `for _, v := range xs { go func() { use(v) }() }` captures "
+        "the same `v` in every goroutine pre-Go-1.22. Pass `v` as a parameter.",
+        "**`nil` interface vs `nil` concrete type** — `var p *T = nil; var i interface{} = p; i == nil` "
+        "is FALSE. Returning a typed-nil pointer through an `error` return is a classic bug.",
+        "**`defer` evaluates args at call site, runs at return** — `defer log.Print(time.Now())` "
+        "captures the *current* time, not the time at defer execution.",
+        "**Unchecked errors from deferred `Close()`** — `defer f.Close()` discards the error. "
+        "If `Close()` flushes data, that error matters.",
+        "**Slices share underlying arrays** — `b := a[2:5]; b[0] = 99` mutates `a[2]`. "
+        "Use `append([]T{}, a[2:5]...)` to copy.",
+        "**Method receivers: `func (p T)` vs `func (p *T)`** — value receivers can't mutate the "
+        "receiver, and a value receiver on a struct with a sync.Mutex makes the mutex useless (copies it).",
+    ],
+    "java": [
+        "**Boxed-int equality** — `Integer a = 1000; Integer b = 1000; a == b` is FALSE (outside "
+        "the cached -128..127 range). Use `.equals()` for boxed types.",
+        "**`String.split()` returns empty array if regex matches** — empty string at position 0 "
+        "is dropped silently. Pass `-1` as second arg to keep them.",
+        "**`SimpleDateFormat` is not thread-safe** — use `DateTimeFormatter` (Java 8+).",
+        "**`Iterator.remove()` is the only safe way to mutate during iteration** — modifying the "
+        "collection directly throws `ConcurrentModificationException`.",
+        "**`equals()` without `hashCode()`** — breaks every hash-based collection silently.",
+    ],
+    "ruby": [
+        "**`||=` doesn't short-circuit on `false`** — `x ||= compute_default()` calls `compute_default` "
+        "every time `x` is `false` (not just `nil`). Use `x = compute_default() if x.nil?` if you need "
+        "to distinguish.",
+        "**`map` with side effects** — use `each`. `map`/`collect` build a new array; if you discard "
+        "the result you're allocating for nothing.",
+        "**Regex anchoring** — `^...$` matches **line** boundaries (multiline by default). For "
+        "string boundaries use `\\A...\\z`. `'foo\\nbar'.match(/^bar$/)` succeeds.",
+        "**`.send` vs `.public_send`** — `.send` ignores `private`/`protected` access. Use "
+        "`public_send` unless you specifically intend to bypass.",
+    ],
+}
+
+# Universal rules that aren't language-keyed.
+_UNIVERSAL: list[str] = [
+    "**Regex anchoring against full strings** — `pattern.match(s)` may match a substring. "
+    "Verify the pattern uses anchors (`^...$` / `\\A...\\z`) when comparing whole values "
+    "(domain validation, ID matching, origin checks).",
+    "**Origin / hostname validation via `indexOf` or substring contains** — bypassable with "
+    "lookalike domains (`indexOf('example.com')` matches `evil-example.com.attacker.tld`). "
+    "Parse the URL and compare hostnames exactly.",
+    "**TOCTOU (Time-of-Check-to-Time-of-Use)** — counting/checking a value then writing it "
+    "is a race. Two concurrent requests can both pass the check before either writes. Use "
+    "atomic upsert / unique constraint / advisory lock.",
+]
+
+
+def get_footguns_for_files(files: list[FileDiff]) -> str:
+    """Return a markdown block of footgun rules for the languages in ``files``.
+
+    Returns an empty string if no relevant languages are detected, so the
+    review prompt's `{% if footguns %}` branch can skip the section cleanly.
+    """
+    langs: set[str] = set()
+    for f in files:
+        ext = f.path.rsplit(".", 1)[-1].lower() if "." in f.path else ""
+        lang = _EXT_TO_LANG.get(ext)
+        if lang:
+            langs.add(lang)
+
+    if not langs and not _UNIVERSAL:
+        return ""
+
+    parts: list[str] = []
+    for lang in sorted(langs):
+        rules = _FOOTGUNS.get(lang)
+        if not rules:
+            continue
+        parts.append(f"### {lang.title()}")
+        for rule in rules:
+            parts.append(f"- {rule}")
+        parts.append("")
+
+    if _UNIVERSAL:
+        parts.append("### Cross-language")
+        for rule in _UNIVERSAL:
+            parts.append(f"- {rule}")
+        parts.append("")
+
+    return "\n".join(parts).rstrip()

--- a/src/mira/llm/prompts/review.py
+++ b/src/mira/llm/prompts/review.py
@@ -121,15 +121,9 @@ def build_security_review_prompt(
     """
     env = _get_template_env()
     template = env.get_template("security_review.jinja2")
-
     file_contexts = [build_file_context_string(f) for f in files]
     file_paths = [f.path for f in files]
-
-    system_content = template.render(
-        pr_title=pr_title,
-        file_paths=file_paths,
-    )
-
+    system_content = template.render(pr_title=pr_title, file_paths=file_paths)
     return [
         {"role": "system", "content": system_content},
         {"role": "user", "content": "\n\n".join(file_contexts)},

--- a/src/mira/llm/prompts/review.py
+++ b/src/mira/llm/prompts/review.py
@@ -9,6 +9,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from mira.config import MiraConfig
 from mira.core.context import build_file_context_string
+from mira.llm.prompts.footguns import get_footguns_for_files
 from mira.llm.prompts.verify_fixes import _extract_issue_description
 from mira.models import FileDiff, UnresolvedThread
 
@@ -75,6 +76,8 @@ def build_review_prompt(
             if entries
         ]
 
+    footguns = get_footguns_for_files(files)
+
     system_content = template.render(
         pr_title=pr_title,
         pr_description=pr_description,
@@ -91,6 +94,7 @@ def build_review_prompt(
         review_round=review_round,
         resolved_threads=resolved_threads,
         team_conventions=team_conventions,
+        footguns=footguns,
     )
 
     # Build user message with optional code context before diffs
@@ -102,6 +106,33 @@ def build_review_prompt(
     return [
         {"role": "system", "content": system_content},
         {"role": "user", "content": "\n\n".join(user_parts)},
+    ]
+
+
+def build_security_review_prompt(
+    files: list[FileDiff],
+    pr_title: str = "",
+) -> list[dict[str, str]]:
+    """Build the security-focused review prompt messages for the LLM.
+
+    Runs in parallel with the main review pass. Output is merged into the
+    main review's comments list and goes through the same noise filter
+    (dedup against any overlap with main-pass findings).
+    """
+    env = _get_template_env()
+    template = env.get_template("security_review.jinja2")
+
+    file_contexts = [build_file_context_string(f) for f in files]
+    file_paths = [f.path for f in files]
+
+    system_content = template.render(
+        pr_title=pr_title,
+        file_paths=file_paths,
+    )
+
+    return [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": "\n\n".join(file_contexts)},
     ]
 
 

--- a/src/mira/llm/prompts/templates/review.jinja2
+++ b/src/mira/llm/prompts/templates/review.jinja2
@@ -37,7 +37,9 @@ You are Mira, an expert AI code reviewer. Your job is to review pull request dif
 Do NOT create comments for the following — they add noise without value:
 - Adding or improving docstrings, JSDoc, or function-level comments
 - Adding type hints or type annotations to existing working code
-- Removing unused imports (linters handle this)
+- Removing unused imports or unused local variables (linters handle this)
+- Adding missing import statements (the build / type-checker will catch these)
+- Declaring undefined variables (the build / type-checker will catch these)
 - Using more specific exception types (e.g., ValueError instead of Exception)
 - Adding logging statements
 - Renaming variables for subjective preference (unless the name is actively misleading)

--- a/src/mira/llm/prompts/templates/review.jinja2
+++ b/src/mira/llm/prompts/templates/review.jinja2
@@ -180,6 +180,17 @@ Recent commits that touched the files in this PR. Use this context **before** su
 {% endfor %}
 {% endif %}
 
+{% if footguns %}
+## Common Footguns to Watch For
+
+These are subtle bugs that are easy to miss because they look correct at a
+glance. Use this list as a recognition trigger when reviewing the diff —
+flag matches with the appropriate severity. Don't comment if the pattern
+isn't actually present.
+
+{{ footguns }}
+
+{% endif %}
 ## Diffs to Review
 
 Review the file diffs provided in the user message below.

--- a/src/mira/llm/prompts/templates/security_review.jinja2
+++ b/src/mira/llm/prompts/templates/security_review.jinja2
@@ -20,6 +20,28 @@ Flag findings in any of these categories. Be specific and cite the line.
 - **Missing rate limiting on auth endpoints** — login, password reset, MFA, API keys, signup.
 - **Insecure CORS** — `Access-Control-Allow-Origin: *` with `Allow-Credentials: true`, reflecting the request origin without an allowlist.
 
+## High-signal patterns to grep mentally
+
+These are literal strings and shapes that have been missed before. If you see any of them in the diff, FLAG IT — don't second-guess. Each is an exploitable bug, not a style preference.
+
+- `X-Frame-Options.*ALLOWALL` or `X-Frame-Options:\s*""` — clickjacking protection disabled. **Always blocker** when assigned in a controller or response header.
+- `\.indexOf\(` near `origin`, `referer`, `host`, or `hostname` — substring origin check. `discourseUrl.indexOf(e.origin) === -1` and `e.origin.indexOf("trusted.com") !== -1` are both bypassable. **Warning**.
+- `postMessage\(.+,\s*['"]\*['"]` — wildcard target origin. Use a specific origin string. **Warning**.
+- Missing `event.origin` check inside `addEventListener('message', ...)` or `onmessage` handler. **Warning**.
+- `dangerouslySetInnerHTML`, `v-html`, `\.innerHTML\s*=`, raw `<%= ... %>` of user input in `.html`/`.erb`/`.html.haml`. **Warning to blocker** depending on source.
+- `eval\(`, `new Function\(`, `setTimeout\([\w'"]` (string first arg) — code injection surface. **Warning**.
+- `pickle\.loads`, `yaml\.load\(` (without `SafeLoader`/`safe_load`), `Marshal\.load` — deserialization of untrusted. **Blocker**.
+- `request\.referer`/`request.referrer` used as a security check — referer is spoofable / strippable. **Warning**.
+- `open\(` (Python/Ruby) on a user-controlled URL without scheme allowlist — SSRF. **Blocker**.
+- `Math\.random\(\)`, `random\.random\(\)`, `rand\(\)` for tokens / IDs / nonces — predictable. **Warning**.
+- `MD5`, `SHA1`, `md5\(`, `sha1\(` for password hashing or signing. **Warning**.
+- `==` comparing tokens/HMACs/passwords without `secrets.compare_digest` / `crypto.timingSafeEqual` — timing attack. **Suggestion**.
+- `Access-Control-Allow-Origin:\s*\*` with `Allow-Credentials: true` in the same response. **Blocker**.
+- `redirect\(` / `res\.redirect\(` of a user-supplied URL without scheme + host allowlist — open redirect. **Warning**.
+- `cors\(\{.*origin:\s*true` or origin reflected from request — wildcard CORS. **Warning**.
+
+If a pattern matches but you can prove (from the diff alone) that the input is sanitized, an allowlist is enforced, or the value is not user-controlled, skip it. Otherwise, flag.
+
 ## Rules
 
 - **Only flag what's in the diff** — don't speculate about code you can't see.

--- a/src/mira/llm/prompts/templates/security_review.jinja2
+++ b/src/mira/llm/prompts/templates/security_review.jinja2
@@ -1,0 +1,52 @@
+You are Mira's dedicated security reviewer. Your ONLY job is to find security vulnerabilities in the diff. Ignore style, performance, and general code quality — those are handled by a separate pass.
+
+## What to look for
+
+Flag findings in any of these categories. Be specific and cite the line.
+
+- **Injection** — SQL injection (string concatenation in queries), command injection (shell=True with user input), path traversal (`../` in user-controlled file paths), template injection (raw user content in Jinja2 / EJS / etc), LDAP/XPath injection, NoSQL operator injection (e.g. `{$gt: ''}`).
+- **XSS** — unescaped user content in HTML, `dangerouslyInnerHTML`, `v-html`, manual `innerHTML` writes, unescaped Markdown / Liquid / ERB rendering.
+- **Auth bypass** — missing authentication checks on new endpoints, role/permission checks gated only on truthy fields (`if user.is_admin` when `is_admin` can be `null`), JWT verification skipped, IDOR (using IDs from URL/body without ownership check).
+- **CSRF** — state-changing endpoints without CSRF token verification (POST/PUT/DELETE on session-cookie-authenticated routes that don't check origin or token).
+- **SSRF** — server-side fetch of user-supplied URLs without allowlist (typical with image proxies, OAuth callbacks, webhooks).
+- **Origin / hostname validation bugs** — `indexOf('mydomain.com') !== -1` matches `evil-mydomain.com.attacker`. `startsWith` / `endsWith` without scheme parsing. `referer` substring checks.
+- **Open redirect** — `redirect(url)` where `url` comes from user input without validation.
+- **Insecure deserialization** — `pickle.loads`, `yaml.load` (without `SafeLoader`), `eval`, `Function()`, `JSON.parse` of untrusted then `new Function()`.
+- **Secrets exposure** — hardcoded keys/tokens/passwords (even in tests if checked in), secrets in error messages, secrets logged, secrets in URLs.
+- **postMessage / iframe** — `postMessage(msg, '*')` (origin should be specific), missing `event.origin` check on receiving side, `X-Frame-Options: ALLOWALL` or missing CSP `frame-ancestors`.
+- **Cryptography** — MD5/SHA1 for security purposes, missing `secrets.compare_digest` for token compare (timing attack), weak random (`Math.random()`/`random.random()` for tokens), missing salt, ECB mode.
+- **Race conditions / TOCTOU** — count-then-create patterns (rate limit / quota check), check-then-update without locking, file existence check before write.
+- **Mass assignment** — `User.update(request.body)` allowing `is_admin` etc. to be set, `Object.assign(user, body)` patterns.
+- **Missing rate limiting on auth endpoints** — login, password reset, MFA, API keys, signup.
+- **Insecure CORS** — `Access-Control-Allow-Origin: *` with `Allow-Credentials: true`, reflecting the request origin without an allowlist.
+
+## Rules
+
+- **Only flag what's in the diff** — don't speculate about code you can't see.
+- **One comment per issue.** Cite file + line range. Be specific about why it's a vulnerability and what the attack vector is.
+- **Severity:** `blocker` for exploitable-in-prod issues (authn/authz bypass, RCE, SQLi, XSS in user-facing surface). `warning` for issues that need a specific config or attacker capability. `suggestion` for hardening / defense-in-depth.
+- **Confidence:** be honest. Use 0.8+ only when the diff alone proves the vulnerability. Pattern-matching on a name (e.g. "this looks like an auth function") is 0.6, not 0.9.
+- **No nitpicks.** If the only argument is "could be more defensive," skip it.
+- **Set every comment's `category` to `security`** so they're recognised downstream.
+- For each comment, write an `agent_prompt` describing the exact code change needed to fix it.
+
+## Output
+
+Use the `submit_review` tool. Return an empty `comments` array if you find no security issues — that's the correct outcome on most PRs. Return an empty `key_issues` array unless a finding is severe enough that a human reviewer must examine it before merge.
+
+## Valid File Paths
+
+Only use these file paths in your comments:
+{% for path in file_paths %}
+- `{{ path }}`
+{% endfor %}
+
+{% if pr_title %}
+## Pull Request
+
+**Title**: {{ pr_title }}
+{% endif %}
+
+## Diffs to Review
+
+Review the file diffs provided in the user message below.

--- a/src/mira/llm/provider.py
+++ b/src/mira/llm/provider.py
@@ -458,6 +458,96 @@ class LLMProvider:
                 f"LLM completion failed with {self.config.model}: {primary_err}"
             ) from primary_err
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=30),
+        retry=retry_if_exception_type(Exception),
+        reraise=True,
+    )
+    async def _call_llm_agentic(
+        self,
+        model: str,
+        messages: list,
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> dict:
+        """Make a tool-using LLM call without forcing a specific tool.
+
+        Unlike `_call_llm_with_tools`, this returns the *full* assistant
+        message (with `tool_calls` and `content`) so the caller can
+        dispatch the calls and continue the conversation. This is what
+        the agentic loop needs.
+        """
+        body: dict = {
+            "model": _strip_model_prefix(model),
+            "messages": messages,
+            "tools": tools,
+            "tool_choice": "auto",
+            "temperature": temperature if temperature is not None else self.config.temperature,
+            "max_tokens": self.config.max_tokens,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {_get_api_key()}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/miracodeai/mira",
+            "X-Title": "Mira Code Reviewer",
+        }
+
+        async with httpx.AsyncClient(timeout=120) as client:
+            resp = await client.post(
+                f"{_OPENROUTER_BASE_URL}/chat/completions",
+                headers=headers,
+                json=body,
+            )
+            if resp.status_code != 200:
+                raise LLMError(f"OpenRouter API error {resp.status_code}: {resp.text}")
+            data = resp.json()
+
+        usage = data.get("usage")
+        if usage:
+            self.total_prompt_tokens += usage.get("prompt_tokens", 0)
+            self.total_completion_tokens += usage.get("completion_tokens", 0)
+
+        return data["choices"][0]["message"]
+
+    async def complete_agentic(
+        self,
+        messages: list,
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> dict:
+        """Single hop of an agentic loop. Returns the assistant message dict.
+
+        The caller is responsible for the loop: append the message,
+        dispatch any `tool_calls`, append the tool results as `tool`-role
+        messages, and call again until the terminal tool fires.
+        """
+        try:
+            return await self._call_llm_agentic(
+                self.config.model, messages, tools, temperature=temperature
+            )
+        except Exception as primary_err:
+            if self.config.fallback_model:
+                logger.warning(
+                    "Primary model %s failed (%s), trying fallback %s",
+                    self.config.model,
+                    primary_err,
+                    self.config.fallback_model,
+                )
+                try:
+                    return await self._call_llm_agentic(
+                        self.config.fallback_model, messages, tools, temperature=temperature
+                    )
+                except Exception as fallback_err:
+                    raise LLMError(
+                        f"Both primary ({self.config.model}) and fallback "
+                        f"({self.config.fallback_model}) models failed: {fallback_err}"
+                    ) from fallback_err
+            raise LLMError(
+                f"LLM agentic call failed with {self.config.model}: {primary_err}"
+            ) from primary_err
+
     async def complete_with_tools(
         self,
         messages: list[dict[str, str]],

--- a/src/mira/llm/response_parser.py
+++ b/src/mira/llm/response_parser.py
@@ -57,8 +57,13 @@ def parse_llm_response(raw_text: str) -> LLMReviewResponse:
     """Parse raw LLM text output into a validated LLMReviewResponse."""
     cleaned = strip_code_fences(raw_text)
 
+    # strict=False permits raw control chars (newlines/tabs) inside
+    # strings — some tool-calling models occasionally double-encode the
+    # comments array as a string containing pretty-printed JSON, and
+    # that pretty-printed JSON has literal newlines that strict mode
+    # rejects.
     try:
-        data = json.loads(cleaned)
+        data = json.loads(cleaned, strict=False)
     except json.JSONDecodeError as e:
         raise ResponseParseError(f"LLM response is not valid JSON: {e}") from e
 
@@ -160,11 +165,13 @@ def convert_to_review_comments(
         if c.suggestion and not c.body.strip():
             continue
 
-        # Validate existing_code against diff hunks
-        if c.existing_code and hunk_index:
+        # Validate existing_code against diff hunks (only when present —
+        # an empty/missing citation is permitted but a present-but-wrong
+        # one is dropped as hallucination).
+        if hunk_index and c.existing_code:
             hunk_text = hunk_index.get(c.path, "")
             if c.existing_code.strip() not in hunk_text:
-                continue  # hallucinated existing_code — drop
+                continue
 
         # Clear no-op suggestions (suggestion equals existing_code)
         suggestion = c.suggestion
@@ -237,17 +244,20 @@ _CHANGE_TYPE_MAP: dict[str, FileChangeType] = {
 def _unstring_nested_json(data: dict) -> dict:
     """Recursively parse string values that are valid JSON objects/arrays.
 
-    Some models (via tool calling) double-encode nested objects as JSON strings.
+    Some models (via tool calling) double-encode nested objects as JSON
+    strings — for example returning the ``comments`` array as
+    ``"[{...}, {...}]"`` instead of a real list. We try strict JSON first,
+    then ``strict=False`` to tolerate raw control chars (newlines inside
+    strings).
     """
     result = {}
     for key, value in data.items():
         if isinstance(value, str):
-            try:
-                parsed = json.loads(value)
+            stripped = value.strip()
+            if stripped.startswith(("[", "{")):
+                parsed = _try_load_json(stripped)
                 if isinstance(parsed, (dict, list)):
                     value = parsed
-            except (json.JSONDecodeError, TypeError):
-                pass
         if isinstance(value, dict):
             value = _unstring_nested_json(value)
         elif isinstance(value, list):
@@ -256,6 +266,18 @@ def _unstring_nested_json(data: dict) -> dict:
             ]
         result[key] = value
     return result
+
+
+def _try_load_json(text: str) -> object | None:
+    """Best-effort parse: strict, then lenient (control chars allowed)."""
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        pass
+    try:
+        return json.loads(text, strict=False)
+    except (json.JSONDecodeError, TypeError):
+        return None
 
 
 def parse_walkthrough_response(raw_text: str) -> LLMWalkthroughResponse:

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -207,6 +207,8 @@ class WalkthroughResult:
         in_progress: bool = False,
         skipped_paths: list[str] | None = None,
         total_paths: list[str] | None = None,
+        index_was_empty: bool = False,
+        dashboard_url: str = "",
     ) -> str:
         """Render as a markdown PR comment."""
         parts = [WALKTHROUGH_MARKER, "## Mira PR Walkthrough", ""]
@@ -322,6 +324,24 @@ class WalkthroughResult:
             if len(skipped_paths) > shown:
                 parts.append(f"- _\u2026and {len(skipped_paths) - shown} more_")
 
+        # --- Index-empty nudge ---
+        # When the repo hasn't been indexed, this review used JIT cross-file
+        # lookup — useful but less complete than a pre-built index (no blast
+        # radius, no cross-repo impact, no doc context). Tell the user so
+        # they can choose to index for a noticeably better next review.
+        if index_was_empty and not in_progress:
+            parts.append("")
+            parts.append("---")
+            parts.append("")
+            link = f"[Mira dashboard]({dashboard_url})" if dashboard_url else "the Mira dashboard"
+            parts.append(
+                f"> 💡 **This review will be more accurate after indexing.** "
+                f"This repo hasn't been indexed yet, so the review is based on "
+                f"the diff plus on-demand file lookups. Visit {link} to index "
+                f"this repo — Mira will then know about callers, dependents, "
+                f"and cross-repo impact."
+            )
+
         parts.append("")
         parts.append("---")
         parts.append(
@@ -374,6 +394,11 @@ class PRInfo:
     number: int
     owner: str
     repo: str
+    # Current head commit SHA. Used by round 2+ reviews to fetch the
+    # incremental diff (last reviewed SHA → current head SHA) instead of
+    # re-reviewing the full base→head diff. Empty when unknown
+    # (the engine then falls back to a full review).
+    head_sha: str = ""
 
 
 @dataclass

--- a/src/mira/providers/github.py
+++ b/src/mira/providers/github.py
@@ -446,7 +446,7 @@ class GitHubProvider(BaseProvider):
     async def resolve_outdated_review_threads(self, pr_info: PRInfo) -> int:
         @_retry_transient
         async def _resolve() -> int:
-            # Phase 1: Paginate through review threads and collect bot-authored
+            # Step 1: Paginate through review threads and collect bot-authored
             # unresolved threads that GitHub has marked as outdated.
             bot_login: str | None = None
             thread_ids: list[str] = []
@@ -493,7 +493,7 @@ class GitHubProvider(BaseProvider):
                 len(thread_ids),
             )
 
-            # Phase 2: Resolve each collected outdated thread
+            # Step 2: Resolve each collected outdated thread
             for thread_id in thread_ids:
                 await self._graphql_request(_RESOLVE_THREAD_MUTATION, {"threadId": thread_id})
 

--- a/src/mira/providers/github.py
+++ b/src/mira/providers/github.py
@@ -183,6 +183,7 @@ class GitHubProvider(BaseProvider):
                 number=pr.number,
                 owner=owner,
                 repo=repo,
+                head_sha=pr.head.sha or "",
             )
 
         try:
@@ -212,6 +213,44 @@ class GitHubProvider(BaseProvider):
             raise
         except Exception as e:
             raise ProviderError(f"Failed to fetch PR diff: {e}") from e
+
+    async def get_compare_diff(
+        self,
+        pr_info: PRInfo,
+        base_sha: str,
+        head_sha: str,
+    ) -> str:
+        """Fetch a unified diff between two commits via GitHub's compare API.
+
+        Used by round 2+ reviews so we only review what's been pushed since
+        the last review (``last_reviewed_sha``..``current_head_sha``) rather
+        than re-flagging every file in the PR.
+
+        Returns an empty string if the two SHAs are identical (nothing new
+        to review).
+        """
+        if base_sha == head_sha or not base_sha or not head_sha:
+            return ""
+        url = (
+            f"{_GITHUB_API_URL}/repos/{pr_info.owner}/{pr_info.repo}"
+            f"/compare/{base_sha}...{head_sha}"
+        )
+        headers = {
+            "Authorization": f"token {self._token}",
+            "Accept": "application/vnd.github.v3.diff",
+        }
+
+        @_retry_transient
+        async def _fetch() -> str:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(url, headers=headers, follow_redirects=True)
+                resp.raise_for_status()
+                return resp.text
+
+        try:
+            return await _fetch()
+        except Exception as e:
+            raise ProviderError(f"Failed to fetch compare diff: {e}") from e
 
     async def post_review(
         self,
@@ -590,6 +629,34 @@ class GitHubProvider(BaseProvider):
             raise
         except Exception as e:
             raise ProviderError(f"Failed to remove label: {e}") from e
+
+    async def get_repo_tree(self, pr_info: PRInfo, ref: str) -> list[str]:
+        """List every blob (file) path in the repo at a given ref.
+
+        Used by JIT cross-file context: we fetch the tree once, then
+        check which import-resolution candidates actually exist before
+        spending API calls fetching their contents. One API call → up to
+        thousands of paths in response.
+        """
+        url = f"{_GITHUB_API_URL}/repos/{pr_info.owner}/{pr_info.repo}/git/trees/{ref}?recursive=1"
+        headers = {
+            "Authorization": f"token {self._token}",
+            "Accept": "application/vnd.github+json",
+        }
+
+        @_retry_transient
+        async def _fetch() -> list[str]:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(url, headers=headers, follow_redirects=True)
+                resp.raise_for_status()
+                data = resp.json()
+            return [item["path"] for item in data.get("tree", []) if item.get("type") == "blob"]
+
+        try:
+            return await _fetch()
+        except Exception as exc:
+            logger.debug("Failed to fetch repo tree: %s", exc)
+            return []
 
     async def get_file_content(self, pr_info: PRInfo, path: str, ref: str) -> str:
         """Fetch file content at a specific ref via the REST API."""

--- a/tests/fixtures/sample_llm_response.json
+++ b/tests/fixtures/sample_llm_response.json
@@ -9,6 +9,7 @@
       "title": "Shell injection via subprocess with shell=True",
       "body": "Using `subprocess.run` with `shell=True` and a user-provided string is vulnerable to shell injection. Use a list of arguments instead.",
       "confidence": 0.95,
+      "existing_code": "    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)",
       "suggestion": "    result = subprocess.run(cmd.split(), capture_output=True, text=True)"
     },
     {
@@ -20,6 +21,7 @@
       "title": "Use of eval() for parsing config",
       "body": "Using `eval()` to parse file contents is a critical security vulnerability. It allows arbitrary code execution. Use `json.load()` or `yaml.safe_load()` instead.",
       "confidence": 0.99,
+      "existing_code": "        return eval(f.read())",
       "suggestion": "        return json.loads(f.read())"
     },
     {
@@ -31,6 +33,7 @@
       "title": "Hardcoded default API key",
       "body": "The default value contains what looks like an API key. Default should be an empty string or None, with proper error handling when the key is missing.",
       "confidence": 0.85,
+      "existing_code": "    return os.environ.get(\"API_KEY\", \"sk-default-key-12345\")",
       "suggestion": "    return os.environ.get(\"API_KEY\", \"\")"
     }
   ],

--- a/tests/test_agentic_tools.py
+++ b/tests/test_agentic_tools.py
@@ -1,0 +1,134 @@
+"""Tests for the agentic tool executor used on unindexed-repo reviews."""
+
+from __future__ import annotations
+
+import pytest
+
+from mira.llm.agentic_tools import (
+    AGENTIC_TOOLS,
+    GREP_REPO_TOOL,
+    READ_FILE_TOOL,
+    AgenticToolExecutor,
+)
+
+
+class _FakeFetcher:
+    def __init__(self, sources: dict[str, str | None]):
+        self._sources = sources
+
+    async def fetch(self, path: str) -> str | None:
+        return self._sources.get(path)
+
+
+def _executor(sources: dict[str, str | None], tree: list[str]) -> AgenticToolExecutor:
+    return AgenticToolExecutor(source_fetcher=_FakeFetcher(sources), repo_tree=tree)
+
+
+class TestSchemas:
+    def test_tool_set_exposes_both_helpers(self):
+        names = [t["function"]["name"] for t in AGENTIC_TOOLS]
+        assert "read_file" in names
+        assert "grep_repo" in names
+
+    def test_read_file_requires_path(self):
+        assert READ_FILE_TOOL["function"]["parameters"]["required"] == ["path"]
+
+    def test_grep_repo_requires_pattern(self):
+        assert GREP_REPO_TOOL["function"]["parameters"]["required"] == ["pattern"]
+
+
+class TestReadFile:
+    @pytest.mark.asyncio
+    async def test_returns_numbered_content(self):
+        ex = _executor({"src/a.py": "alpha\nbeta\n"}, ["src/a.py"])
+        out = await ex.execute("read_file", {"path": "src/a.py"})
+        assert "src/a.py" in out
+        assert "    1  alpha" in out
+        assert "    2  beta" in out
+
+    @pytest.mark.asyncio
+    async def test_truncates_huge_files(self):
+        big = "x" * 20_000
+        ex = _executor({"src/big.py": big}, ["src/big.py"])
+        out = await ex.execute("read_file", {"path": "src/big.py"})
+        assert "truncated" in out
+
+    @pytest.mark.asyncio
+    async def test_missing_path_returns_error_string(self):
+        ex = _executor({}, [])
+        out = await ex.execute("read_file", {})
+        assert out.startswith("[error")
+
+    @pytest.mark.asyncio
+    async def test_unknown_path_in_tree_suggests_close_match(self):
+        ex = _executor({}, ["src/auth/middleware.py", "src/util.py"])
+        out = await ex.execute("read_file", {"path": "AUTH/middleware.py"})
+        assert "not found" in out
+        assert "src/auth/middleware.py" in out
+
+    @pytest.mark.asyncio
+    async def test_caches_repeated_reads(self):
+        seen: list[str] = []
+
+        class _Counting:
+            async def fetch(self, path: str) -> str | None:
+                seen.append(path)
+                return "hello"
+
+        ex = AgenticToolExecutor(source_fetcher=_Counting(), repo_tree=["src/a.py"])
+        await ex.execute("read_file", {"path": "src/a.py"})
+        await ex.execute("read_file", {"path": "src/a.py"})
+        assert seen == ["src/a.py"]  # only fetched once
+
+
+class TestGrepRepo:
+    @pytest.mark.asyncio
+    async def test_path_only_returns_matching_paths(self):
+        ex = _executor({}, ["src/auth.py", "src/util.py", "tests/test_auth.py"])
+        out = await ex.execute("grep_repo", {"pattern": "auth", "path_only": True})
+        assert "src/auth.py" in out
+        assert "tests/test_auth.py" in out
+        assert "src/util.py" not in out
+
+    @pytest.mark.asyncio
+    async def test_content_search_returns_line_hits(self):
+        sources = {
+            "src/a.py": "def foo():\n    return BAR\n",
+            "src/b.py": "import os\nBAR = 1\n",
+        }
+        ex = _executor(sources, list(sources))
+        out = await ex.execute("grep_repo", {"pattern": r"\bBAR\b"})
+        assert "src/a.py:2" in out
+        assert "src/b.py:2" in out
+
+    @pytest.mark.asyncio
+    async def test_path_glob_filters_candidates(self):
+        sources = {
+            "src/a.py": "needle\n",
+            "src/a.go": "needle\n",
+        }
+        ex = _executor(sources, list(sources))
+        out = await ex.execute("grep_repo", {"pattern": "needle", "path_glob": "**/*.go"})
+        assert "src/a.go" in out
+        assert "src/a.py" not in out
+
+    @pytest.mark.asyncio
+    async def test_invalid_regex_returns_error_string(self):
+        ex = _executor({"a.py": "x"}, ["a.py"])
+        out = await ex.execute("grep_repo", {"pattern": "[unclosed"})
+        assert out.startswith("[invalid regex")
+
+
+class TestExecutorBudget:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        ex = _executor({}, [])
+        out = await ex.execute("delete_repo", {})
+        assert "unknown tool" in out
+
+    @pytest.mark.asyncio
+    async def test_exhausted_budget_blocks_further_calls(self):
+        ex = _executor({"a.py": "hi"}, ["a.py"])
+        ex.bytes_used = 1_000_000  # simulate exhaustion
+        out = await ex.execute("read_file", {"path": "a.py"})
+        assert "budget exhausted" in out

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -13,9 +13,12 @@ from mira.core.engine import (
     _clamp_confidence_to_findings,
     _drop_orphan_key_issues,
     _extract_sections,
+    _security_relevant_files,
 )
 from mira.llm.provider import LLMProvider
 from mira.models import (
+    FileChangeType,
+    FileDiff,
     KeyIssue,
     PRInfo,
     ReviewComment,
@@ -24,6 +27,60 @@ from mira.models import (
     WalkthroughConfidenceScore,
     WalkthroughResult,
 )
+
+
+def _empty_filediff(path: str) -> FileDiff:
+    return FileDiff(
+        path=path,
+        change_type=FileChangeType.MODIFIED,
+        language="",
+        added_lines=0,
+        deleted_lines=0,
+        hunks=[],
+    )
+
+
+class TestSecurityFileFilter:
+    """The security pass narrows its input so the LLM isn't drowned in non-code files."""
+
+    def test_drops_migrations_specs_styles_lockfiles(self):
+        files = [
+            _empty_filediff("app/controllers/embed_controller.rb"),
+            _empty_filediff("app/assets/javascripts/embed.js"),
+            _empty_filediff("db/migrate/20131217174004_create_topic_embeds.rb"),
+            _empty_filediff("spec/controllers/embed_controller_spec.rb"),
+            _empty_filediff("app/assets/stylesheets/embed.css.scss"),
+            _empty_filediff("Gemfile.lock"),
+            _empty_filediff("CHANGELOG.md"),
+        ]
+        keep = [k.path for k in _security_relevant_files(files)]
+        assert "app/controllers/embed_controller.rb" in keep
+        assert "app/assets/javascripts/embed.js" in keep
+        assert all("/migrate/" not in p for p in keep)
+        assert all("spec/" not in p for p in keep)
+        assert all(not p.endswith(".scss") for p in keep)
+        assert all(not p.endswith(".lock") for p in keep)
+        assert all(not p.endswith(".md") for p in keep)
+
+    def test_drops_test_files_by_suffix(self):
+        files = [
+            _empty_filediff("src/auth.go"),
+            _empty_filediff("src/auth_test.go"),
+            _empty_filediff("src/auth.test.ts"),
+            _empty_filediff("src/login.spec.tsx"),
+        ]
+        keep = [k.path for k in _security_relevant_files(files)]
+        assert keep == ["src/auth.go"]
+
+    def test_keeps_app_code_unchanged(self):
+        files = [
+            _empty_filediff("src/middleware.py"),
+            _empty_filediff("api/views.py"),
+            _empty_filediff("frontend/login.tsx"),
+        ]
+        keep = [k.path for k in _security_relevant_files(files)]
+        assert keep == ["src/middleware.py", "api/views.py", "frontend/login.tsx"]
+
 
 _WALKTHROUGH_LLM_RESPONSE = json.dumps(
     {
@@ -1388,6 +1445,18 @@ class TestSecurityReviewPass:
         from mira.core.engine import ReviewEngine
 
         files = parse_diff(sample_diff_text).files
+        # Pick a verbatim line from the diff so the existing_code citation
+        # validates — the parser drops comments whose citation isn't in the
+        # diff (anti-hallucination check).
+        cited_line = None
+        for h in files[0].hunks:
+            for raw in h.content.splitlines():
+                if raw.startswith("+") and not raw.startswith("+++"):
+                    cited_line = raw[1:]
+                    break
+            if cited_line:
+                break
+        assert cited_line, "fixture must contain at least one added line"
         canned = json.dumps(
             {
                 "comments": [
@@ -1399,6 +1468,7 @@ class TestSecurityReviewPass:
                         "title": "SQL injection",
                         "body": "Concatenating user input into a query.",
                         "confidence": 0.9,
+                        "existing_code": cited_line,
                     }
                 ],
                 "summary": "",
@@ -1424,20 +1494,6 @@ class TestSecurityReviewPass:
         files = parse_diff(sample_diff_text).files
         llm = MagicMock(spec=LLMProvider)
         llm.complete_with_tools = AsyncMock(side_effect=RuntimeError("LLM down"))
-
-        engine = ReviewEngine(config=MiraConfig(), llm=llm, provider=None)
-        out = await engine._security_review_pass(files, "title")
-        assert out == []
-
-    @pytest.mark.asyncio
-    async def test_returns_empty_on_parse_error(self, sample_diff_text):
-        """Bad LLM JSON must not crash."""
-        from mira.core.diff_parser import parse_diff
-        from mira.core.engine import ReviewEngine
-
-        files = parse_diff(sample_diff_text).files
-        llm = MagicMock(spec=LLMProvider)
-        llm.complete_with_tools = AsyncMock(return_value="not json at all")
 
         engine = ReviewEngine(config=MiraConfig(), llm=llm, provider=None)
         out = await engine._security_review_pass(files, "title")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1099,6 +1099,183 @@ class TestRoundDetectionWiring:
         assert captured["review_round"] == 1
 
 
+class TestIncrementalDiff:
+    """Round 2+ should review only commits pushed since the last review."""
+
+    def _make_thread(self, **kw):
+        from mira.models import BotThreadRecord
+
+        defaults = {"thread_id": "t", "path": "a.py", "line": 1, "body": "x", "is_resolved": False}
+        defaults.update(kw)
+        return BotThreadRecord(**defaults)
+
+    def _provider_with_threads_and_compare(self, threads, full_diff="FULL", incremental="INCR"):
+        from mira.models import PRInfo
+
+        mock_provider = MagicMock()
+        mock_provider.get_pr_info = AsyncMock(
+            return_value=PRInfo(
+                title="t",
+                description="",
+                base_branch="main",
+                head_branch="f",
+                url="https://github.com/o/r/pull/1",
+                number=1,
+                owner="o",
+                repo="r",
+                head_sha="HEAD_SHA",
+            )
+        )
+        mock_provider.get_pr_diff = AsyncMock(return_value=full_diff)
+        mock_provider.get_compare_diff = AsyncMock(return_value=incremental)
+        mock_provider.get_unresolved_bot_threads = AsyncMock(return_value=[])
+        mock_provider.get_all_bot_threads = AsyncMock(return_value=threads)
+        mock_provider.find_bot_comment = AsyncMock(return_value=None)
+        mock_provider.post_comment = AsyncMock()
+        mock_provider.update_comment = AsyncMock()
+        mock_provider.resolve_outdated_review_threads = AsyncMock(return_value=0)
+        return mock_provider
+
+    @pytest.mark.asyncio
+    async def test_round_2_uses_incremental_when_sha_stored(self, monkeypatch):
+        """If a last_reviewed_sha exists for this PR, fetch and use the
+        incremental diff (last_sha..head_sha) instead of the full PR diff."""
+        from mira.core.engine import ReviewEngine
+
+        mock_provider = self._provider_with_threads_and_compare(
+            threads=[self._make_thread()],
+        )
+
+        mock_db = MagicMock()
+        mock_db.get_last_reviewed_sha = MagicMock(return_value="OLD_SHA")
+        mock_db.get_repo = MagicMock(return_value=None)
+        mock_db.set_last_reviewed_sha = MagicMock()
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        captured: dict = {}
+
+        async def fake_internal(self, diff_text, **kwargs):
+            captured["diff_text"] = diff_text
+            from mira.models import ReviewResult
+
+            return ReviewResult(comments=[], summary="")
+
+        monkeypatch.setattr(ReviewEngine, "_review_diff_internal", fake_internal)
+
+        engine = ReviewEngine(
+            config=MiraConfig(),
+            llm=AsyncMock(),
+            provider=mock_provider,
+            bot_name="mira",
+        )
+        await engine.review_pr("https://github.com/o/r/pull/1")
+
+        # Compare API was called with the right SHAs and result was used.
+        mock_provider.get_compare_diff.assert_awaited_once()
+        args = mock_provider.get_compare_diff.call_args
+        assert args.args[1] == "OLD_SHA"
+        assert args.args[2] == "HEAD_SHA"
+        assert captured["diff_text"] == "INCR"
+
+    @pytest.mark.asyncio
+    async def test_round_2_falls_back_to_full_diff_when_no_sha(self, monkeypatch):
+        """Missing last_reviewed_sha → no incremental fetch, full diff used.
+        Backward compat for PRs that existed before the feature shipped."""
+        from mira.core.engine import ReviewEngine
+
+        mock_provider = self._provider_with_threads_and_compare(
+            threads=[self._make_thread()],
+        )
+
+        mock_db = MagicMock()
+        mock_db.get_last_reviewed_sha = MagicMock(return_value="")
+        mock_db.get_repo = MagicMock(return_value=None)
+        mock_db.set_last_reviewed_sha = MagicMock()
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        captured: dict = {}
+
+        async def fake_internal(self, diff_text, **kwargs):
+            captured["diff_text"] = diff_text
+            from mira.models import ReviewResult
+
+            return ReviewResult(comments=[], summary="")
+
+        monkeypatch.setattr(ReviewEngine, "_review_diff_internal", fake_internal)
+
+        engine = ReviewEngine(
+            config=MiraConfig(),
+            llm=AsyncMock(),
+            provider=mock_provider,
+            bot_name="mira",
+        )
+        await engine.review_pr("https://github.com/o/r/pull/1")
+
+        mock_provider.get_compare_diff.assert_not_called()
+        assert captured["diff_text"] == "FULL"
+
+    @pytest.mark.asyncio
+    async def test_round_1_does_not_use_compare(self, monkeypatch):
+        """Round 1 must always do a full review — no incremental."""
+        from mira.core.engine import ReviewEngine
+
+        mock_provider = self._provider_with_threads_and_compare(threads=[])
+
+        mock_db = MagicMock()
+        mock_db.get_last_reviewed_sha = MagicMock(return_value="OLD_SHA")
+        mock_db.get_repo = MagicMock(return_value=None)
+        mock_db.set_last_reviewed_sha = MagicMock()
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        async def fake_internal(self, diff_text, **kwargs):
+            from mira.models import ReviewResult
+
+            return ReviewResult(comments=[], summary="")
+
+        monkeypatch.setattr(ReviewEngine, "_review_diff_internal", fake_internal)
+
+        engine = ReviewEngine(
+            config=MiraConfig(),
+            llm=AsyncMock(),
+            provider=mock_provider,
+            bot_name="mira",
+        )
+        await engine.review_pr("https://github.com/o/r/pull/1")
+
+        mock_provider.get_compare_diff.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_records_head_sha_after_review(self, monkeypatch):
+        """After a successful review, the current head SHA is anchored so
+        round 2 has a base for the incremental diff."""
+        from mira.core.engine import ReviewEngine
+
+        mock_provider = self._provider_with_threads_and_compare(threads=[])
+
+        mock_db = MagicMock()
+        mock_db.get_last_reviewed_sha = MagicMock(return_value="")
+        mock_db.get_repo = MagicMock(return_value=None)
+        mock_db.set_last_reviewed_sha = MagicMock()
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        async def fake_internal(self, diff_text, **kwargs):
+            from mira.models import ReviewResult
+
+            return ReviewResult(comments=[], summary="")
+
+        monkeypatch.setattr(ReviewEngine, "_review_diff_internal", fake_internal)
+
+        engine = ReviewEngine(
+            config=MiraConfig(),
+            llm=AsyncMock(),
+            provider=mock_provider,
+            bot_name="mira",
+        )
+        await engine.review_pr("https://github.com/o/r/pull/1")
+
+        mock_db.set_last_reviewed_sha.assert_called_once_with("o", "r", 1, "HEAD_SHA")
+
+
 class TestSelfCritique:
     """Second-pass critique drops confidently-wrong findings before posting."""
 
@@ -1191,6 +1368,80 @@ class TestSelfCritique:
         engine = ReviewEngine(config=MiraConfig(), llm=AsyncMock(), provider=None)
         kept = await engine._self_critique([])
         assert kept == []
+
+
+class TestSecurityReviewPass:
+    """Dedicated security pass returns comments tagged category=security."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_files(self):
+        from mira.core.engine import ReviewEngine
+
+        engine = ReviewEngine(config=MiraConfig(), llm=AsyncMock(), provider=None)
+        out = await engine._security_review_pass([], "title")
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_runs_llm_and_parses_comments(self, sample_diff_text):
+        """Happy path: LLM returns a security finding, we get a ReviewComment."""
+        from mira.core.diff_parser import parse_diff
+        from mira.core.engine import ReviewEngine
+
+        files = parse_diff(sample_diff_text).files
+        canned = json.dumps(
+            {
+                "comments": [
+                    {
+                        "path": files[0].path,
+                        "line": 1,
+                        "severity": "blocker",
+                        "category": "bug",  # LLM forgot — engine should fix to security
+                        "title": "SQL injection",
+                        "body": "Concatenating user input into a query.",
+                        "confidence": 0.9,
+                    }
+                ],
+                "summary": "",
+                "metadata": {"reviewed_files": 1},
+            }
+        )
+        llm = MagicMock(spec=LLMProvider)
+        llm.complete_with_tools = AsyncMock(return_value=canned)
+
+        engine = ReviewEngine(config=MiraConfig(), llm=llm, provider=None)
+        out = await engine._security_review_pass(files, "title")
+        assert len(out) == 1
+        # Engine forces category=security regardless of what the LLM returned.
+        assert out[0].category == "security"
+        assert out[0].title == "SQL injection"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_llm_failure(self, sample_diff_text):
+        """LLM error must not crash — return empty so main review proceeds."""
+        from mira.core.diff_parser import parse_diff
+        from mira.core.engine import ReviewEngine
+
+        files = parse_diff(sample_diff_text).files
+        llm = MagicMock(spec=LLMProvider)
+        llm.complete_with_tools = AsyncMock(side_effect=RuntimeError("LLM down"))
+
+        engine = ReviewEngine(config=MiraConfig(), llm=llm, provider=None)
+        out = await engine._security_review_pass(files, "title")
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_parse_error(self, sample_diff_text):
+        """Bad LLM JSON must not crash."""
+        from mira.core.diff_parser import parse_diff
+        from mira.core.engine import ReviewEngine
+
+        files = parse_diff(sample_diff_text).files
+        llm = MagicMock(spec=LLMProvider)
+        llm.complete_with_tools = AsyncMock(return_value="not json at all")
+
+        engine = ReviewEngine(config=MiraConfig(), llm=llm, provider=None)
+        out = await engine._security_review_pass(files, "title")
+        assert out == []
 
 
 class TestRegenerateSummary:

--- a/tests/test_footguns.py
+++ b/tests/test_footguns.py
@@ -47,17 +47,49 @@ class TestGetFootguns:
         assert "### Python" not in out
         assert "TOCTOU" in out
 
-    def test_multi_language_pr_includes_all_relevant(self):
+    def test_multi_language_pr_includes_all_when_primary_only_false(self):
         out = get_footguns_for_files(
             [
                 _file("api/handler.py"),
                 _file("ui/main.tsx"),
                 _file("backend/server.go"),
-            ]
+            ],
+            primary_only=False,
         )
         assert "### Python" in out
         assert "### Typescript" in out
         assert "### Go" in out
+
+    def test_primary_only_picks_dominant_language(self):
+        # 3 Python files vs 1 TS file → Python wins.
+        out = get_footguns_for_files(
+            [
+                _file("api/a.py"),
+                _file("api/b.py"),
+                _file("api/c.py"),
+                _file("ui/main.tsx"),
+            ]
+        )
+        assert "### Python" in out
+        assert "### Typescript" not in out
+        assert "### Go" not in out
+        # Universal rules still render — they're cross-cutting.
+        assert "### Cross-language" in out
+
+    def test_primary_only_uses_total_changes_not_file_count(self):
+        # 1 Python file with 100 changes outweighs 5 TS files with 1 change each.
+        big_py = FileDiff(
+            path="api/big.py",
+            change_type=FileChangeType.MODIFIED,
+            language="",
+            added_lines=100,
+            deleted_lines=0,
+            hunks=[],
+        )
+        ts_files = [_file(f"ui/{n}.tsx") for n in "abcde"]
+        out = get_footguns_for_files([big_py, *ts_files])
+        assert "### Python" in out
+        assert "### Typescript" not in out
 
     def test_empty_input(self):
         # No files → only universal rules

--- a/tests/test_footguns.py
+++ b/tests/test_footguns.py
@@ -1,0 +1,66 @@
+"""Tests for the framework-footguns prompt section."""
+
+from __future__ import annotations
+
+from mira.llm.prompts.footguns import get_footguns_for_files
+from mira.models import FileChangeType, FileDiff
+
+
+def _file(path: str) -> FileDiff:
+    return FileDiff(
+        path=path,
+        change_type=FileChangeType.MODIFIED,
+        language="",
+        added_lines=1,
+        deleted_lines=0,
+        hunks=[],
+    )
+
+
+class TestGetFootguns:
+    def test_python_file_includes_python_section(self):
+        out = get_footguns_for_files([_file("app/main.py")])
+        assert "### Python" in out
+        # Specific known rule
+        assert "Negative slicing on Django QuerySets" in out
+
+    def test_typescript_file_includes_ts_section(self):
+        out = get_footguns_for_files([_file("src/main.ts")])
+        assert "### Typescript" in out
+        assert "forEach" in out
+
+    def test_go_file_includes_go_section(self):
+        out = get_footguns_for_files([_file("cmd/main.go")])
+        assert "### Go" in out
+        assert "Loop-variable capture" in out
+
+    def test_universal_rules_always_included(self):
+        out = get_footguns_for_files([_file("a.py")])
+        assert "### Cross-language" in out
+        assert "TOCTOU" in out
+
+    def test_unknown_extension_returns_empty(self):
+        # No language match, but universal rules still render
+        out = get_footguns_for_files([_file("README.md")])
+        # README.md isn't in EXT_TO_LANG, so no language sections.
+        # Universal rules are always there.
+        assert "### Python" not in out
+        assert "TOCTOU" in out
+
+    def test_multi_language_pr_includes_all_relevant(self):
+        out = get_footguns_for_files(
+            [
+                _file("api/handler.py"),
+                _file("ui/main.tsx"),
+                _file("backend/server.go"),
+            ]
+        )
+        assert "### Python" in out
+        assert "### Typescript" in out
+        assert "### Go" in out
+
+    def test_empty_input(self):
+        # No files → only universal rules
+        out = get_footguns_for_files([])
+        assert "### Python" not in out
+        assert "TOCTOU" in out

--- a/tests/test_jit_context.py
+++ b/tests/test_jit_context.py
@@ -72,6 +72,142 @@ class TestExtractImportCandidates:
         cands = extract_import_candidates("import x", "rust", "main.rs")
         assert cands == []
 
+    def test_java_resolves_fqn_via_repo_tree(self):
+        src = (
+            "package com.acme.svc;\n"
+            "import com.acme.crypto.KeystoreFactory;\n"
+            "import static com.acme.util.Validators.requireNonNull;\n"
+        )
+        tree = {
+            "src/main/java/com/acme/svc/Main.java",
+            "src/main/java/com/acme/crypto/KeystoreFactory.java",
+            "src/main/java/com/acme/util/Validators.java",
+        }
+        cands = extract_import_candidates(
+            src, "java", "src/main/java/com/acme/svc/Main.java", repo_tree=tree
+        )
+        assert "src/main/java/com/acme/crypto/KeystoreFactory.java" in cands
+        assert "src/main/java/com/acme/util/Validators.java" in cands
+
+    def test_java_drops_wildcard_imports(self):
+        src = "import com.acme.crypto.*;\n"
+        tree = {"src/main/java/com/acme/crypto/Foo.java"}
+        cands = extract_import_candidates(src, "java", "Main.java", repo_tree=tree)
+        assert cands == []
+
+    def test_java_prefers_path_with_matching_package(self):
+        # Two files named Util.java exist in different packages — the one in
+        # the imported package should win.
+        src = "import com.acme.crypto.Util;\n"
+        tree = {
+            "src/main/java/com/acme/web/Util.java",
+            "src/main/java/com/acme/crypto/Util.java",
+        }
+        cands = extract_import_candidates(src, "java", "Main.java", repo_tree=tree)
+        assert cands[0] == "src/main/java/com/acme/crypto/Util.java"
+
+    def test_go_resolves_module_path_tail(self):
+        src = (
+            "package x\n\nimport (\n"
+            '    "github.com/grafana/grafana/pkg/services/auth/anon"\n'
+            '    "fmt"\n'
+            ")\n"
+        )
+        tree = {
+            "pkg/services/auth/anon/store.go",
+            "pkg/services/auth/anon/store_test.go",  # excluded
+            "pkg/services/auth/anon/anon.go",
+            "fmt/fmt.go",  # accidental match — this isn't really stdlib but we skip "fmt" by stdlib hint
+        }
+        cands = extract_import_candidates(src, "go", "pkg/svc/handler.go", repo_tree=tree)
+        assert (
+            "pkg/services/auth/anon/store.go" in cands or "pkg/services/auth/anon/anon.go" in cands
+        )
+        # Test files are excluded
+        assert all("_test.go" not in p for p in cands)
+        # `fmt` skipped as stdlib
+        assert "fmt/fmt.go" not in cands
+
+    def test_go_skips_stdlib_imports(self):
+        src = 'import (\n    "net/http"\n    "encoding/json"\n)\n'
+        tree = {"net/http/foo.go", "encoding/json/bar.go"}
+        cands = extract_import_candidates(src, "go", "main.go", repo_tree=tree)
+        assert cands == []
+
+    def test_returns_empty_when_repo_tree_missing(self):
+        # Java + Go need the tree; without it they should return nothing
+        # rather than guess.
+        src = "import com.acme.svc.Foo;\n"
+        cands = extract_import_candidates(src, "java", "Main.java", repo_tree=None)
+        assert cands == []
+        cands_go = extract_import_candidates('import "x/y/z"\n', "go", "main.go", repo_tree=None)
+        assert cands_go == []
+
+    def test_go_does_not_match_string_constants_or_struct_tags(self):
+        """Quoted strings in the body of a Go file aren't imports."""
+        src = (
+            "package main\n\n"
+            'import (\n    "real/import/path"\n)\n\n'
+            "type User struct {\n"
+            '    Name string `json:"name" db:"users.name"`\n'
+            "}\n\n"
+            'var greeting = "hello world"\n'
+            'func f() error { return fmt.Errorf("not an import") }\n'
+        )
+        tree = {
+            "real/import/path/file.go",
+            "users.name/file.go",  # would falsely match the loose regex
+            "hello world/file.go",
+        }
+        cands = extract_import_candidates(src, "go", "main.go", repo_tree=tree)
+        # Only the real import should resolve.
+        assert cands == ["real/import/path/file.go"]
+
+    def test_go_block_with_alias(self):
+        src = (
+            'import (\n    foo "real/path/foo"\n    . "real/path/dot"\n    _ "real/path/blank"\n)\n'
+        )
+        tree = {
+            "real/path/foo/x.go",
+            "real/path/dot/y.go",
+            "real/path/blank/z.go",
+        }
+        cands = extract_import_candidates(src, "go", "main.go", repo_tree=tree)
+        # Aliased and blank-imports should still resolve.
+        assert any("real/path/foo" in p for p in cands)
+        assert any("real/path/dot" in p for p in cands)
+        assert any("real/path/blank" in p for p in cands)
+
+    def test_enable_java_go_false_skips_resolution(self):
+        java_src = "import com.acme.crypto.Keystore;\n"
+        java_tree = {"src/main/java/com/acme/crypto/Keystore.java"}
+        assert (
+            extract_import_candidates(
+                java_src, "java", "Main.java", repo_tree=java_tree, enable_java_go=False
+            )
+            == []
+        )
+        go_src = 'import "real/path"\n'
+        go_tree = {"real/path/x.go"}
+        assert (
+            extract_import_candidates(
+                go_src, "go", "main.go", repo_tree=go_tree, enable_java_go=False
+            )
+            == []
+        )
+
+    def test_java_capped_at_one_candidate(self):
+        # If a class name appears in many files, we should return exactly one
+        # — better to miss than to flood the prompt with off-topic matches.
+        src = "import com.acme.svc.Util;\n"
+        tree = {
+            "a/b/c/Util.java",
+            "x/y/z/Util.java",
+            "deep/nested/path/Util.java",
+        }
+        cands = extract_import_candidates(src, "java", "Main.java", repo_tree=tree)
+        assert len(cands) == 1
+
 
 class TestBuildJITContext:
     @pytest.mark.asyncio

--- a/tests/test_jit_context.py
+++ b/tests/test_jit_context.py
@@ -1,0 +1,177 @@
+"""Tests for just-in-time cross-file context (unindexed-repo fallback)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mira.index.jit_context import (
+    build_jit_cross_file_context,
+    extract_import_candidates,
+)
+from mira.models import FileChangeType, FileDiff
+
+
+def _file(path: str) -> FileDiff:
+    return FileDiff(
+        path=path,
+        change_type=FileChangeType.MODIFIED,
+        language=path.rsplit(".", 1)[-1] if "." in path else "",
+        added_lines=1,
+        deleted_lines=0,
+        hunks=[],
+    )
+
+
+class _FakeFetcher:
+    """Synchronous source map dressed up as an async fetcher."""
+
+    def __init__(self, sources: dict[str, str]):
+        self._sources = sources
+
+    async def fetch(self, path: str) -> str | None:
+        return self._sources.get(path)
+
+
+class TestExtractImportCandidates:
+    def test_python_relative_resolution(self):
+        src = "from foo.bar import baz\nimport util\n"
+        cands = extract_import_candidates(src, "python", "pkg/sub/main.py")
+        # Should include both same-dir and dotted-path resolutions.
+        assert "foo/bar.py" in cands
+        assert "foo/bar/__init__.py" in cands
+        assert "pkg/sub/foo/bar.py" in cands
+        assert "util.py" in cands
+
+    def test_python_skips_blank(self):
+        cands = extract_import_candidates("", "python", "x.py")
+        assert cands == []
+
+    def test_typescript_relative(self):
+        src = "import {x} from './utils'\nimport y from '../shared/y'"
+        cands = extract_import_candidates(src, "typescript", "src/feature/main.ts")
+        # ./utils → src/feature/utils + extension permutations
+        assert "src/feature/utils.ts" in cands
+        assert "src/feature/utils/index.ts" in cands
+        # ../shared/y → src/shared/y...
+        assert "src/shared/y.ts" in cands
+
+    def test_typescript_skips_npm_packages(self):
+        src = "import React from 'react'\nimport {z} from '@scope/pkg'"
+        cands = extract_import_candidates(src, "typescript", "src/main.ts")
+        assert cands == []
+
+    def test_ruby_require_relative(self):
+        src = "require_relative './helpers'\nrequire 'some/lib'"
+        cands = extract_import_candidates(src, "ruby", "app/main.rb")
+        # require_relative './helpers' → app/helpers.rb
+        assert "app/helpers.rb" in cands
+
+    def test_unknown_language_returns_empty(self):
+        cands = extract_import_candidates("import x", "rust", "main.rs")
+        assert cands == []
+
+
+class TestBuildJITContext:
+    @pytest.mark.asyncio
+    async def test_empty_when_no_changed_files(self):
+        out = await build_jit_cross_file_context(
+            changed_files=[],
+            source_fetcher=_FakeFetcher({}),
+            repo_tree=set(),
+        )
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_empty_when_fetcher_is_none(self):
+        out = await build_jit_cross_file_context(
+            changed_files=[_file("x.py")],
+            source_fetcher=None,
+            repo_tree=None,
+        )
+        assert out == ""
+
+    @pytest.mark.asyncio
+    async def test_pulls_in_imported_python_file(self):
+        """Changed file imports `helpers` — JIT should fetch helpers.py and
+        inline its symbols."""
+        sources = {
+            "app/main.py": "from app.helpers import compute\n\ndef run():\n    return compute(1)\n",
+            "app/helpers.py": "def compute(x):\n    return x * 2\n",
+        }
+        out = await build_jit_cross_file_context(
+            changed_files=[_file("app/main.py")],
+            source_fetcher=_FakeFetcher(sources),
+            repo_tree={"app/main.py", "app/helpers.py"},
+        )
+        assert "app/helpers.py" in out
+        assert "compute" in out
+
+    @pytest.mark.asyncio
+    async def test_skips_candidates_not_in_tree(self):
+        """When repo_tree is provided, only paths that exist should be fetched."""
+        sources = {
+            "app/main.py": "from app.helpers import compute\n",
+            # helpers.py exists in sources but NOT in tree → should be skipped
+            "app/helpers.py": "def compute(): pass\n",
+        }
+        out = await build_jit_cross_file_context(
+            changed_files=[_file("app/main.py")],
+            source_fetcher=_FakeFetcher(sources),
+            repo_tree={"app/main.py"},  # helpers.py NOT listed
+        )
+        assert "app/helpers.py" not in out
+
+    @pytest.mark.asyncio
+    async def test_skips_changed_files_themselves(self):
+        """If a changed file imports another changed file, don't duplicate it
+        in JIT — the regular source-tier already shows it."""
+        sources = {
+            "a.py": "from b import x\n",
+            "b.py": "def x(): pass\n",
+        }
+        out = await build_jit_cross_file_context(
+            changed_files=[_file("a.py"), _file("b.py")],
+            source_fetcher=_FakeFetcher(sources),
+            repo_tree={"a.py", "b.py"},
+        )
+        assert "b.py (imported by" not in out
+
+    @pytest.mark.asyncio
+    async def test_respects_char_budget(self):
+        """A tight char_budget caps how much JIT context gets emitted."""
+        sources = {
+            "a.py": "from helpers import x\n",
+            "helpers.py": "def x():\n    " + "y = 1\n    " * 200,
+        }
+        out = await build_jit_cross_file_context(
+            changed_files=[_file("a.py")],
+            source_fetcher=_FakeFetcher(sources),
+            repo_tree={"a.py", "helpers.py"},
+            char_budget=200,
+        )
+        assert len(out) <= 600  # header + small block, well under unbounded
+
+    @pytest.mark.asyncio
+    async def test_continues_when_one_fetch_fails(self):
+        """A failing fetch shouldn't abort the whole pass."""
+
+        async def flaky_fetch(path):
+            if path == "app/main.py":
+                return "from app.helpers import x\nfrom app.utils import y\n"
+            if path == "app/helpers.py":
+                raise RuntimeError("network blip")
+            if path == "app/utils.py":
+                return "def y(): pass\n"
+            return None
+
+        fetcher = AsyncMock()
+        fetcher.fetch.side_effect = flaky_fetch
+        out = await build_jit_cross_file_context(
+            changed_files=[_file("app/main.py")],
+            source_fetcher=fetcher,
+            repo_tree={"app/main.py", "app/helpers.py", "app/utils.py"},
+        )
+        # utils.py made it in despite helpers.py failing
+        assert "app/utils.py" in out

--- a/tests/test_noise_filter.py
+++ b/tests/test_noise_filter.py
@@ -78,10 +78,49 @@ class TestNoiseFilter:
         assert result[1].severity == Severity.WARNING
         assert result[2].severity == Severity.NITPICK
 
-    def test_caps_at_max_comments(self):
-        comments = [_make_comment(line=i, title=f"Issue {i}") for i in range(20)]
-        result = filter_noise(comments, FilterConfig(confidence_threshold=0.0, max_comments=3))
+    def test_caps_at_max_comments_for_low_priority(self):
+        """The max_comments cap applies to suggestions and nitpicks only —
+        every blocker/warning above the floor should be posted regardless."""
+        comments = [
+            _make_comment(line=i, title=f"Nit {i}", severity=Severity.NITPICK) for i in range(20)
+        ]
+        result = filter_noise(
+            comments,
+            FilterConfig(
+                confidence_threshold=0.0,
+                max_comments=3,
+                min_severity="nitpick",
+            ),
+        )
         assert len(result) == 3
+
+    def test_does_not_cap_blockers_or_warnings(self):
+        """A PR with many real bugs should surface all of them, not be silenced
+        by max_comments. The cap is for low-priority noise, not real findings."""
+        comments = (
+            [_make_comment(line=i, title=f"Bug {i}", severity=Severity.BLOCKER) for i in range(8)]
+            + [
+                _make_comment(line=100 + i, title=f"Warn {i}", severity=Severity.WARNING)
+                for i in range(5)
+            ]
+            + [
+                _make_comment(line=200 + i, title=f"Nit {i}", severity=Severity.NITPICK)
+                for i in range(10)
+            ]
+        )
+        result = filter_noise(
+            comments,
+            FilterConfig(
+                confidence_threshold=0.0,
+                max_comments=3,
+                min_severity="nitpick",
+            ),
+        )
+        # 8 blockers + 5 warnings always pass; nitpicks capped at 3 → 16 total.
+        assert len(result) == 16
+        assert sum(1 for c in result if c.severity == Severity.BLOCKER) == 8
+        assert sum(1 for c in result if c.severity == Severity.WARNING) == 5
+        assert sum(1 for c in result if c.severity == Severity.NITPICK) == 3
 
     def test_empty_input(self):
         result = filter_noise([], FilterConfig())

--- a/tests/test_response_parser.py
+++ b/tests/test_response_parser.py
@@ -51,6 +51,25 @@ class TestParseLLMResponse:
         assert result.comments == []
         assert result.summary == ""
 
+    def test_parses_double_encoded_comments_array(self):
+        """Haiku occasionally returns ``comments`` as a stringified JSON
+        array — sometimes pretty-printed with raw newlines that strict
+        JSON rejects. The parser must recover both the outer and inner."""
+        inner = (
+            "[\n  {\n"
+            '    "path": "a.py",\n'
+            '    "line": 10,\n'
+            '    "body": "raw newlines inside the string",\n'
+            '    "existing_code": "x"\n'
+            "  }\n]"
+        )
+        # Outer JSON has the inner as a quoted string with raw newlines —
+        # invalid in strict mode, valid with strict=False.
+        raw = '{"comments": "' + inner.replace('"', '\\"') + '", "summary": ""}'
+        result = parse_llm_response(raw)
+        assert len(result.comments) == 1
+        assert result.comments[0].body == "raw newlines inside the string"
+
 
 class TestConvertToReviewComments:
     def test_converts_comments(self, sample_llm_response_text: str):
@@ -168,7 +187,8 @@ class TestExistingCodeValidation:
         assert len(comments) == 1
 
     def test_keeps_comment_without_existing_code(self):
-        """Comments without existing_code should pass through unchanged."""
+        """An empty/missing citation is permitted — only present-but-wrong
+        citations are dropped as hallucinations."""
         data = json.dumps(
             {
                 "comments": [


### PR DESCRIPTION
<!--
Thanks for contributing to Mira!

Before opening this PR, please ensure:
- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [ ] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

Security fixes should be reported privately first — see SECURITY.md.
-->

## Summary

<!-- 1-3 bullets on what changed and why -->

- This improves the benchmark results of the Code Reviewer
- Major improvements to code reviewing repositories that have not yet been indexed 

## Test plan

<!-- How did you verify this works? -->
Locally via evals

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
