### PR TITLE
Add AWS Bedrock as a direct LLM provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev --extra serve
+        run: uv sync --extra dev --extra serve --extra bedrock
 
       # Run the same pre-commit hooks contributors run locally. Single source
       # of truth — if a hook is added/removed/version-bumped in

--- a/.mira.yaml.example
+++ b/.mira.yaml.example
@@ -2,12 +2,22 @@
 # Copy this to .mira.yaml in your repository root
 
 llm:
+  # Provider: "openai" (default, any OpenAI-compatible endpoint) or "bedrock" (AWS)
+  # provider: "openai"
+
   # Model identifier (any LiteLLM-supported model)
   model: "openai/gpt-4o"
   # Fallback model if primary fails
   fallback_model: "openai/gpt-4o-mini"
   temperature: 0.2
   max_tokens: 4096
+
+  # ── AWS Bedrock configuration (uncomment to use) ──
+  # provider: "bedrock"
+  # model: "us.anthropic.claude-sonnet-4-6-v1:0"
+  # fallback_model: "us.anthropic.claude-haiku-4-5-v1:0"
+  # region: "us-east-1"
+  # aws_profile: "my-profile"  # optional, uses default AWS credential chain if omitted
 
 filter:
   # Minimum confidence threshold (0.0 - 1.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 WORKDIR /app
 COPY . /app
-RUN pip install --no-cache-dir "/app[serve]"
+RUN pip install --no-cache-dir "/app[serve,bedrock]"
 
 # Pull the built UI in from stage 1. webhooks.create_app() picks this up
 # automatically and serves it at / with SPA fallback.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,36 @@ Set `OPENROUTER_API_KEY` once; one key works across every provider. See [`src/mi
 
 > **Coming soon:** direct adapters for **Anthropic**, **OpenAI**, **Google Vertex**, **Ollama**, and **vLLM**, for teams that already hold provider keys, run open-weights models in-house, or have data-residency rules that prevent traffic from flowing through OpenRouter.
 
+### AWS Bedrock
+
+For teams with data-residency requirements or existing AWS Bedrock access, Mira can call Bedrock's Converse API directly — no OpenRouter, no intermediary:
+
+```yaml
+# mira.yaml
+llm:
+  provider: "bedrock"
+  model: "us.anthropic.claude-sonnet-4-6-v1:0"
+  fallback_model: "us.anthropic.claude-haiku-4-5-v1:0"
+  region: "us-east-1"
+  # aws_profile: "my-profile"  # optional
+```
+
+Auth uses the standard AWS credential chain (env vars, instance profile, ECS task role, SSO). No API keys to manage.
+
+Available Bedrock models:
+
+| Model | `llm.model` | Use case |
+|-------|-------------|----------|
+| Claude Sonnet 4.6 | `us.anthropic.claude-sonnet-4-6-v1:0` | Review |
+| Claude Haiku 4.5 | `us.anthropic.claude-haiku-4-5-v1:0` | Indexing |
+| Claude Opus 4.6 | `us.anthropic.claude-opus-4-6-v1:0` | Review (premium) |
+
+Test locally without GitHub:
+
+```bash
+git diff HEAD~1 | mira review --stdin --dry-run --config mira.yaml
+```
+
 **3. Install the app** on your repos. Every PR gets auto-reviewed.
 
 **Chat with Mira:** Comment `@miracodeai <question>` on any PR to ask about the code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ serve = [
     # either backend out of the box.
     "psycopg[binary]>=3.1",
 ]
+bedrock = [
+    "boto3>=1.35",
+]
 
 [project.scripts]
 mira = "mira.cli:main"

--- a/src/mira/cli.py
+++ b/src/mira/cli.py
@@ -13,7 +13,7 @@ from mira import __version__
 from mira.config import load_config
 from mira.core.engine import ReviewEngine
 from mira.exceptions import MiraError
-from mira.llm.provider import LLMProvider
+from mira.llm import create_llm
 from mira.models import ReviewResult, Severity
 
 
@@ -176,7 +176,10 @@ def review(
     except MiraError as e:
         raise click.ClickException(str(e)) from e
 
-    llm = LLMProvider(config.llm)
+    from mira.dashboard.models_config import llm_config_for
+
+    llm = create_llm(llm_config_for("review", config.llm))
+    indexing_llm = create_llm(llm_config_for("indexing", config.llm))
 
     github_provider = None
     if pr_url:
@@ -194,7 +197,9 @@ def review(
                 f"Unknown provider type {config.provider.type!r}. Available providers: {available}"
             ) from err
 
-    engine = ReviewEngine(config=config, llm=llm, provider=github_provider, dry_run=dry_run)
+    engine = ReviewEngine(
+        config=config, llm=llm, provider=github_provider, dry_run=dry_run, indexing_llm=indexing_llm
+    )
 
     try:
         if use_stdin:

--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -29,12 +29,19 @@ class LLMConfig(BaseModel):
     temperature: float = 0.2
     max_tokens: int = 4096
     max_context_tokens: int = 120_000
+    # Provider selection. "openai" uses any OpenAI-compatible endpoint (default).
+    # "bedrock" uses AWS Bedrock Converse API directly (requires boto3).
+    provider: str = "openai"
     # Endpoint configuration. Defaults to OpenRouter but any OpenAI-compatible
     # chat-completions endpoint works — vLLM, Ollama, LiteLLM proxy, LocalAI,
     # llama.cpp server, Together, Fireworks, Groq, etc. Set api_key_env to ""
     # for local endpoints that don't require auth.
     base_url: str = "https://openrouter.ai/api/v1"
     api_key_env: str = "OPENROUTER_API_KEY"
+    # AWS Bedrock settings. Auth uses the standard AWS credential chain
+    # (env vars, instance profile, ECS task role, SSO).
+    region: str = "us-east-1"
+    aws_profile: str | None = None
 
 
 class FilterConfig(BaseModel):

--- a/src/mira/core/chunker.py
+++ b/src/mira/core/chunker.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from mira.models import FileDiff, ReviewChunk
 
 if TYPE_CHECKING:
-    from mira.llm.provider import LLMProvider
+    from mira.llm.base import LLMProviderProtocol
 
 
 def _estimate_tokens(text: str) -> int:
@@ -27,7 +27,7 @@ def _file_token_estimate(file_diff: FileDiff) -> int:
 def chunk_files(
     files: list[FileDiff],
     max_tokens: int,
-    provider: LLMProvider | None = None,
+    provider: LLMProviderProtocol | None = None,
 ) -> list[ReviewChunk]:
     """Split files into chunks that fit within token limits.
 

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import contextlib
 import logging
 from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mira.llm.base import LLMProviderProtocol
 
 from mira.analysis.noise_filter import filter_noise
 from mira.analysis.severity import classify_severity
@@ -22,7 +26,6 @@ from mira.llm.prompts.review import (
     build_walkthrough_prompt,
 )
 from mira.llm.prompts.verify_fixes import build_verify_fixes_prompt, parse_verify_fixes_response
-from mira.llm.provider import LLMProvider
 from mira.llm.response_parser import (
     convert_to_review_comments,
     convert_to_walkthrough_result,
@@ -317,13 +320,15 @@ class ReviewEngine:
     def __init__(
         self,
         config: MiraConfig,
-        llm: LLMProvider,
+        llm: LLMProviderProtocol,
         provider: BaseProvider | None = None,
         bot_name: str = "miracodeai",
         dry_run: bool = False,
+        indexing_llm: LLMProviderProtocol | None = None,
     ) -> None:
         self.config = config
         self.llm = llm
+        self.indexing_llm = indexing_llm or llm
         self.provider = provider
         self.bot_name = bot_name
         self.dry_run = dry_run
@@ -1293,52 +1298,19 @@ class ReviewEngine:
             # migrations / specs CAN still introduce auth/permission bugs.
             narrowed = files
 
-        from mira.config import load_config
-        from mira.dashboard.models_config import llm_config_for
         from mira.llm.prompts.review import build_security_review_prompt
-        from mira.llm.provider import SUBMIT_REVIEW_TOOL, LLMProvider
-
-        # Build a security LLM on the indexing tier. If the config is
-        # missing the indexing model (or load_config raises in some
-        # exotic test setup), fall back to the main LLM rather than
-        # skip the pass entirely.
-        try:
-            base_config = load_config()
-            security_llm = LLMProvider(llm_config_for("indexing", base_config.llm))
-        except Exception:
-            security_llm = self.llm
+        from mira.llm.provider import SUBMIT_REVIEW_TOOL
 
         messages = build_security_review_prompt(files=narrowed, pr_title=pr_title)
         try:
-            raw = await security_llm.complete_with_tools(
+            raw = await self.indexing_llm.complete_with_tools(
                 messages=messages,
                 tools=[SUBMIT_REVIEW_TOOL],
                 temperature=0.0,
             )
         except Exception as exc:
-            # The indexing-tier model can fail at call time even when
-            # construction succeeded (missing API key, model not routable
-            # by the provider, etc.). Retry on the main LLM rather than
-            # silently dropping the whole security pass — paying review-
-            # tier cost on this PR is the right tradeoff vs losing the
-            # findings.
-            if security_llm is not self.llm:
-                logger.debug(
-                    "Security pass on indexing tier failed (%s); retrying on review LLM",
-                    exc,
-                )
-                try:
-                    raw = await self.llm.complete_with_tools(
-                        messages=messages,
-                        tools=[SUBMIT_REVIEW_TOOL],
-                        temperature=0.0,
-                    )
-                except Exception as exc2:
-                    logger.warning("Security review pass failed: %s", exc2)
-                    return []
-            else:
-                logger.warning("Security review pass failed: %s", exc)
-                return []
+            logger.warning("Security review pass failed: %s", exc)
+            return []
 
         try:
             parsed = parse_llm_response(raw)
@@ -1372,9 +1344,7 @@ class ReviewEngine:
         """
         import json as _json
 
-        from mira.config import load_config
-        from mira.dashboard.models_config import llm_config_for
-        from mira.llm.provider import SUBMIT_CRITIQUE_TOOL, LLMProvider
+        from mira.llm.provider import SUBMIT_CRITIQUE_TOOL
 
         if not comments:
             return comments
@@ -1411,17 +1381,8 @@ class ReviewEngine:
             "## Draft comments\n\n" + "\n".join(draft_lines)
         )
 
-        # Use the configured indexing model — critique is a verification
-        # task, not generation. Falls back to the review model if no
-        # indexing model is configured.
         try:
-            base_config = load_config()
-            critic_llm = LLMProvider(llm_config_for("indexing", base_config.llm))
-        except Exception:
-            critic_llm = self.llm
-
-        try:
-            raw = await critic_llm.complete_with_tools(
+            raw = await self.indexing_llm.complete_with_tools(
                 messages=[{"role": "user", "content": critic_prompt}],
                 tools=[SUBMIT_CRITIQUE_TOOL],
                 temperature=0.0,
@@ -1470,10 +1431,6 @@ class ReviewEngine:
         if not comments and not key_issues:
             return "No issues found."
 
-        from mira.config import load_config
-        from mira.dashboard.models_config import llm_config_for
-        from mira.llm.provider import LLMProvider
-
         # Compact representation of what got filed.
         filed_lines = []
         for c in comments:
@@ -1498,13 +1455,7 @@ class ReviewEngine:
         )
 
         try:
-            base_config = load_config()
-            summary_llm = LLMProvider(llm_config_for("indexing", base_config.llm))
-        except Exception:
-            summary_llm = self.llm
-
-        try:
-            text = await summary_llm.complete(
+            text = await self.indexing_llm.complete(
                 messages=[{"role": "user", "content": prompt}],
                 json_mode=False,
                 temperature=0.0,

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -737,10 +737,10 @@ async def _run_initial_indexing(default_mode: str) -> None:
     from mira.config import load_config
     from mira.dashboard.models_config import llm_config_for
     from mira.index.indexer import index_repo
-    from mira.llm.provider import LLMProvider
+    from mira.llm import create_llm
 
     config = load_config()
-    llm = LLMProvider(llm_config_for("indexing", config.llm))
+    llm = create_llm(llm_config_for("indexing", config.llm))
 
     for repo_record in to_index:
         full_name = f"{repo_record.owner}/{repo_record.repo}"
@@ -1876,7 +1876,7 @@ async def trigger_index(owner: str, repo: str, full: bool = False) -> dict:
 
     from mira.config import load_config
     from mira.index.indexer import IndexingCancelled, index_repo
-    from mira.llm.provider import LLMProvider
+    from mira.llm import create_llm
 
     async def _do_index() -> None:
         count = 0
@@ -1889,7 +1889,7 @@ async def trigger_index(owner: str, repo: str, full: bool = False) -> dict:
             # Use the configured indexing model — without this swap we'd
             # silently fall back to the review model, which is slower and
             # more expensive per token.
-            llm = LLMProvider(llm_config_for("indexing", config.llm))
+            llm = create_llm(llm_config_for("indexing", config.llm))
             store = IndexStore.open(owner, repo)
             if full:
                 # Wipe existing index

--- a/src/mira/github_app/handlers.py
+++ b/src/mira/github_app/handlers.py
@@ -16,8 +16,9 @@ from mira.core.engine import ReviewEngine
 from mira.dashboard.models_config import llm_config_for
 from mira.github_app.auth import GitHubAppAuth
 from mira.index.store import IndexStore
+from mira.llm import create_llm
 from mira.llm.prompts.conversation import build_conversation_prompt
-from mira.llm.provider import SUBMIT_THREAD_REPLY_TOOL, LLMProvider
+from mira.llm.provider import SUBMIT_THREAD_REPLY_TOOL
 from mira.models import PRInfo
 from mira.providers import create_provider
 
@@ -89,9 +90,16 @@ async def handle_pull_request(
         config = load_config()
         from mira.dashboard.models_config import llm_config_for
 
-        llm = LLMProvider(llm_config_for("review", config.llm))
+        llm = create_llm(llm_config_for("review", config.llm))
+        indexing_llm = create_llm(llm_config_for("indexing", config.llm))
         provider = create_provider("github", token)
-        engine = ReviewEngine(config=config, llm=llm, provider=provider, bot_name=bot_name)
+        engine = ReviewEngine(
+            config=config,
+            llm=llm,
+            provider=provider,
+            bot_name=bot_name,
+            indexing_llm=indexing_llm,
+        )
 
         # Check if repo is indexed
         from mira.dashboard.api import _app_db
@@ -155,7 +163,8 @@ async def handle_comment(
         config = load_config()
         from mira.dashboard.models_config import llm_config_for
 
-        llm = LLMProvider(llm_config_for("review", config.llm))
+        llm = create_llm(llm_config_for("review", config.llm))
+        indexing_llm = create_llm(llm_config_for("indexing", config.llm))
         provider = create_provider("github", token)
 
         normalized = question.lower().strip()
@@ -182,7 +191,13 @@ async def handle_comment(
                     "PR has already been covered. 🎉",
                 )
                 return
-            engine = ReviewEngine(config=config, llm=llm, provider=provider, bot_name=bot_name)
+            engine = ReviewEngine(
+                config=config,
+                llm=llm,
+                provider=provider,
+                bot_name=bot_name,
+                indexing_llm=indexing_llm,
+            )
             engine._review_only_paths = set(progress.skipped_paths)  # type: ignore[attr-defined]
             logger.info(
                 "review-rest triggered for PR %s by @%s — %d remaining file(s)",
@@ -193,7 +208,13 @@ async def handle_comment(
             await engine.review_pr(pr_url)
             logger.info("review-rest complete for PR %s", pr_url)
         elif is_review:
-            engine = ReviewEngine(config=config, llm=llm, provider=provider, bot_name=bot_name)
+            engine = ReviewEngine(
+                config=config,
+                llm=llm,
+                provider=provider,
+                bot_name=bot_name,
+                indexing_llm=indexing_llm,
+            )
             logger.info("Re-review triggered for PR %s by @%s", pr_url, comment_user)
             await engine.review_pr(pr_url)
             logger.info("Re-review complete for PR %s", pr_url)
@@ -280,7 +301,7 @@ async def _handle_thread_freeform_reply(
         # Build prompt and call the cheap indexing model — this isn't a
         # review, just a short conversational classification.
         config = load_config()
-        llm = LLMProvider(llm_config_for("indexing", config.llm))
+        llm = create_llm(llm_config_for("indexing", config.llm))
         template = _THREAD_REPLY_TEMPLATE
         prompt = template.render(
             user_reply=user_reply or "(empty)",
@@ -617,7 +638,7 @@ async def handle_pr_merged(
                     config = load_config()
                     from mira.dashboard.models_config import llm_config_for
 
-                    indexing_llm = LLMProvider(llm_config_for("indexing", config.llm))
+                    indexing_llm = create_llm(llm_config_for("indexing", config.llm))
                     llm_rules = await synthesize_from_human_reviews(store, indexing_llm)
                 except Exception as exc:
                     logger.warning("LLM rule synthesis failed for %s: %s", pr_url, exc)

--- a/src/mira/github_app/index_handlers.py
+++ b/src/mira/github_app/index_handlers.py
@@ -10,7 +10,7 @@ from mira.config import load_config
 from mira.github_app.auth import GitHubAppAuth
 from mira.index.indexer import _fetch_repo_tree, _should_index, index_diff, index_repo
 from mira.index.store import IndexStore
-from mira.llm.provider import LLMProvider
+from mira.llm import create_llm
 
 logger = logging.getLogger(__name__)
 
@@ -243,7 +243,7 @@ async def handle_push_index(
         # Use the configured indexing model (not the default review model)
         from mira.dashboard.models_config import llm_config_for
 
-        llm = LLMProvider(llm_config_for("indexing", config.llm))
+        llm = create_llm(llm_config_for("indexing", config.llm))
         store = IndexStore.open(owner, repo_name)
 
         # If too many files changed (large rebase/squash), do a full re-index

--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -20,7 +20,7 @@ from jinja2 import Environment, FileSystemLoader
 from mira.config import MiraConfig, load_config
 from mira.index.manifests import is_manifest, parse_manifest
 from mira.index.store import DirectorySummary, ExternalRef, FileSummary, IndexStore, SymbolInfo
-from mira.llm.provider import LLMProvider
+from mira.llm import create_llm
 
 logger = logging.getLogger(__name__)
 
@@ -434,7 +434,7 @@ def _build_file_summary(path: str, content: str, file_data: dict[str, Any]) -> F
 
 async def _summarize_batch(
     files: list[tuple[str, str]],  # (path, content)
-    llm: LLMProvider,
+    llm: Any,
     semaphore: asyncio.Semaphore,
 ) -> list[tuple[str, str, dict[str, Any]]]:
     """Summarize a batch of files using the LLM. Returns (path, content, data) triples."""
@@ -489,7 +489,7 @@ async def index_repo(
     token: str,
     config: MiraConfig | None = None,
     store: IndexStore | None = None,
-    llm: LLMProvider | None = None,
+    llm: Any = None,
     full: bool = False,
     branch: str | None = None,
     cancel_check: Callable[[], bool] | None = None,
@@ -509,7 +509,7 @@ async def index_repo(
     if llm is None:
         from mira.dashboard.models_config import llm_config_for
 
-        llm = LLMProvider(llm_config_for("indexing", config.llm))
+        llm = create_llm(llm_config_for("indexing", config.llm))
     if store is None:
         store = IndexStore.open(owner, repo)
 
@@ -799,9 +799,7 @@ async def _index_manifests(
         )
 
 
-async def _summarize_directories(
-    store: IndexStore, llm: LLMProvider, semaphore: asyncio.Semaphore
-) -> None:
+async def _summarize_directories(store: IndexStore, llm: Any, semaphore: asyncio.Semaphore) -> None:
     """Generate directory summaries from file summaries.
 
     Batched into chunks of ~15 directories per LLM call. Each directory was
@@ -904,7 +902,7 @@ async def index_diff(
     token: str,
     config: MiraConfig | None = None,
     store: IndexStore | None = None,
-    llm: LLMProvider | None = None,
+    llm: Any = None,
     changed_paths: list[str] | None = None,
     removed_paths: list[str] | None = None,
     branch: str = "main",
@@ -915,7 +913,7 @@ async def index_diff(
     if llm is None:
         from mira.dashboard.models_config import llm_config_for
 
-        llm = LLMProvider(llm_config_for("indexing", config.llm))
+        llm = create_llm(llm_config_for("indexing", config.llm))
     if store is None:
         store = IndexStore.open(owner, repo)
 
@@ -985,7 +983,7 @@ async def index_diff(
 
 async def _summarize_directories_selective(
     store: IndexStore,
-    llm: LLMProvider,
+    llm: Any,
     semaphore: asyncio.Semaphore,
     target_dirs: set[str],
 ) -> None:

--- a/src/mira/llm/__init__.py
+++ b/src/mira/llm/__init__.py
@@ -1,0 +1,22 @@
+"""LLM provider package — factory entry point."""
+
+from __future__ import annotations
+
+from mira.config import LLMConfig
+from mira.llm.base import LLMProviderProtocol
+
+
+def create_llm(config: LLMConfig) -> LLMProviderProtocol:
+    """Create the appropriate LLM provider based on config.provider.
+
+    Returns an instance satisfying LLMProviderProtocol.
+    """
+    if config.provider == "bedrock":
+        from mira.llm.bedrock import BedrockProvider
+
+        return BedrockProvider(config)
+
+    # Default: OpenAI-compatible endpoint (OpenRouter, vLLM, Ollama, etc.)
+    from mira.llm.provider import LLMProvider
+
+    return LLMProvider(config)

--- a/src/mira/llm/base.py
+++ b/src/mira/llm/base.py
@@ -1,0 +1,55 @@
+"""Provider protocol — the interface that all LLM backends must satisfy."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LLMProviderProtocol(Protocol):
+    """Structural interface for LLM providers.
+
+    Both the OpenAI-compatible provider and direct-API providers
+    (Bedrock, Anthropic, Vertex, etc.) satisfy this protocol.
+
+    Capability annotations:
+        supports_json_mode: Provider natively supports response_format=json_object.
+        supports_tool_calling: Provider supports function/tool calling.
+    """
+
+    supports_json_mode: bool
+    supports_tool_calling: bool
+
+    total_prompt_tokens: int
+    total_completion_tokens: int
+
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        json_mode: bool = True,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str: ...
+
+    async def complete_with_tools(
+        self,
+        messages: list[dict[str, str]],
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> str: ...
+
+    async def complete_agentic(
+        self,
+        messages: list,
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> dict: ...
+
+    async def review(self, messages: list[dict[str, str]]) -> str: ...
+
+    async def walkthrough(self, messages: list[dict[str, str]]) -> str: ...
+
+    def count_tokens(self, text: str) -> int: ...
+
+    @property
+    def usage(self) -> dict[str, int]: ...

--- a/src/mira/llm/bedrock.py
+++ b/src/mira/llm/bedrock.py
@@ -1,0 +1,419 @@
+"""AWS Bedrock provider using the Converse API."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import ClassVar
+
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+from mira.config import LLMConfig
+from mira.exceptions import LLMError
+from mira.llm.provider import SUBMIT_REVIEW_TOOL, SUBMIT_WALKTHROUGH_TOOL
+
+logger = logging.getLogger(__name__)
+
+# Generic tool used to force structured JSON output from models that lack
+# native json_mode. The model "calls" this tool with arbitrary JSON as input.
+_JSON_RESPONSE_TOOL = {
+    "toolSpec": {
+        "name": "submit_json_response",
+        "description": "Return your response as structured JSON.",
+        "inputSchema": {"json": {"type": "object", "additionalProperties": True}},
+    }
+}
+
+
+class _BedrockThrottlingError(Exception):
+    """Wrapper for Bedrock throttling/availability errors to target retries."""
+
+
+def _openai_tool_to_bedrock(tool: dict) -> dict:
+    """Convert OpenAI function-calling tool schema to Bedrock toolSpec format."""
+    func = tool["function"]
+    return {
+        "toolSpec": {
+            "name": func["name"],
+            "description": func.get("description", ""),
+            "inputSchema": {"json": func["parameters"]},
+        }
+    }
+
+
+def _messages_to_bedrock(messages: list[dict]) -> tuple[list[dict] | None, list[dict]]:
+    """Convert OpenAI-style messages to Bedrock Converse format.
+
+    Returns (system_prompts, conversation_messages).
+    """
+    system: list[dict] = []
+    conversation: list[dict] = []
+
+    for msg in messages:
+        role = msg["role"]
+        content = msg.get("content", "")
+
+        if role == "system":
+            system.append({"text": content})
+        elif role == "user":
+            conversation.append({"role": "user", "content": [{"text": content}]})
+        elif role == "assistant":
+            # Reconstruct assistant messages — may have tool_calls from agentic loop
+            blocks: list[dict] = []
+            if content:
+                blocks.append({"text": content})
+            for tc in msg.get("tool_calls", []):
+                blocks.append(
+                    {
+                        "toolUse": {
+                            "toolUseId": tc["id"],
+                            "name": tc["function"]["name"],
+                            "input": json.loads(tc["function"]["arguments"]),
+                        }
+                    }
+                )
+            if blocks:
+                conversation.append({"role": "assistant", "content": blocks})
+        elif role == "tool":
+            # Tool results go back as user messages in Bedrock
+            tool_use_id = msg.get("tool_call_id", "call_0")
+            try:
+                result_content = json.loads(content)
+            except (json.JSONDecodeError, TypeError):
+                result_content = {"result": content}
+            conversation.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "toolResult": {
+                                "toolUseId": tool_use_id,
+                                "content": [{"json": result_content}],
+                            }
+                        }
+                    ],
+                }
+            )
+
+    return system or None, conversation
+
+
+class BedrockProvider:
+    """AWS Bedrock LLM provider using the Converse API.
+
+    Auth uses the standard AWS credential chain (env vars, instance profile,
+    ECS task role, SSO). Optionally accepts an explicit profile name.
+    """
+
+    supports_json_mode: ClassVar[bool] = False
+    supports_tool_calling: ClassVar[bool] = True
+
+    def __init__(self, config: LLMConfig) -> None:
+        try:
+            import boto3
+        except ImportError as e:
+            raise LLMError(
+                "boto3 is required for the Bedrock provider. "
+                "Install with: pip install mira-reviewer[bedrock]"
+            ) from e
+
+        self.config = config
+        session = boto3.Session(
+            profile_name=config.aws_profile,
+            region_name=config.region,
+        )
+        self._client = session.client("bedrock-runtime")
+        self.total_prompt_tokens = 0
+        self.total_completion_tokens = 0
+        logger.info(
+            "Bedrock provider initialized: region=%s, model=%s",
+            config.region,
+            config.model,
+        )
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential_jitter(initial=2, max=30, jitter=2),
+        retry=retry_if_exception_type(_BedrockThrottlingError),
+        reraise=True,
+    )
+    async def _call_converse(
+        self,
+        model: str,
+        messages: list[dict],
+        *,
+        tool_config: dict | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> dict:
+        """Call Bedrock Converse API via thread executor."""
+        import asyncio
+
+        system, conversation = _messages_to_bedrock(messages)
+
+        kwargs: dict = {
+            "modelId": model,
+            "messages": conversation,
+            "inferenceConfig": {
+                "temperature": temperature if temperature is not None else self.config.temperature,
+                "maxTokens": max_tokens if max_tokens is not None else self.config.max_tokens,
+            },
+        }
+        if system:
+            kwargs["system"] = system
+        if tool_config:
+            kwargs["toolConfig"] = tool_config
+
+        logger.debug("Bedrock request: model=%s, messages=%d", model, len(conversation))
+
+        loop = asyncio.get_running_loop()
+        try:
+            response = await loop.run_in_executor(None, lambda: self._client.converse(**kwargs))
+        except Exception as e:
+            self._handle_api_error(e, model)
+            raise  # unreachable, but satisfies type checkers
+
+        # Track usage
+        usage = response.get("usage", {})
+        input_tokens = usage.get("inputTokens", 0)
+        output_tokens = usage.get("outputTokens", 0)
+        self.total_prompt_tokens += input_tokens
+        self.total_completion_tokens += output_tokens
+        logger.info(
+            "Bedrock response: model=%s, input_tokens=%d, output_tokens=%d, stop=%s",
+            model,
+            input_tokens,
+            output_tokens,
+            response.get("stopReason"),
+        )
+
+        return response
+
+    def _handle_api_error(self, error: Exception, model: str) -> None:
+        """Classify Bedrock errors and raise appropriate exceptions."""
+        error_name = type(error).__name__
+        error_msg = str(error)
+
+        # Throttling — retryable
+        if error_name in ("ThrottlingException", "ServiceUnavailableException"):
+            logger.warning("Bedrock throttled: model=%s, error=%s", model, error_msg)
+            raise _BedrockThrottlingError(error_msg) from error
+
+        if "ThrottlingException" in error_msg or "Too many requests" in error_msg:
+            logger.warning("Bedrock throttled: model=%s, error=%s", model, error_msg)
+            raise _BedrockThrottlingError(error_msg) from error
+
+        # Access denied — not retryable, clear message
+        if "AccessDeniedException" in error_msg:
+            raise LLMError(
+                f"Bedrock access denied for model {model}. "
+                "Ensure your IAM role/user has bedrock:InvokeModel permission "
+                "and the model is enabled in your account."
+            ) from error
+
+        # Model not found
+        if "ResourceNotFoundException" in error_msg:
+            raise LLMError(
+                f"Bedrock model not found: {model}. "
+                "Check the model ID and ensure it's available in your region."
+            ) from error
+
+        # Validation error (bad request shape)
+        if "ValidationException" in error_msg:
+            raise LLMError(f"Bedrock validation error for {model}: {error_msg}") from error
+
+        # Catch-all
+        raise LLMError(f"Bedrock API error for {model}: {error_msg}") from error
+
+    def _extract_text(self, response: dict) -> str:
+        """Extract text content from a Bedrock Converse response."""
+        output = response.get("output", {})
+        message = output.get("message", {})
+        for block in message.get("content", []):
+            if "text" in block:
+                return block["text"]
+        return ""
+
+    def _extract_tool_use(self, response: dict) -> str | None:
+        """Extract tool use input JSON from a Bedrock Converse response."""
+        output = response.get("output", {})
+        message = output.get("message", {})
+        for block in message.get("content", []):
+            if "toolUse" in block:
+                return json.dumps(block["toolUse"]["input"])
+        return None
+
+    async def _call_with_fallback(
+        self,
+        messages: list[dict],
+        *,
+        tool_config: dict | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> dict:
+        """Call primary model with fallback on failure."""
+        try:
+            return await self._call_converse(
+                self.config.model,
+                messages,
+                tool_config=tool_config,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except Exception as primary_err:
+            if self.config.fallback_model:
+                logger.warning(
+                    "Primary model %s failed (%s), trying fallback %s",
+                    self.config.model,
+                    primary_err,
+                    self.config.fallback_model,
+                )
+                try:
+                    return await self._call_converse(
+                        self.config.fallback_model,
+                        messages,
+                        tool_config=tool_config,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                    )
+                except Exception as fallback_err:
+                    raise LLMError(
+                        f"Both primary ({self.config.model}) and fallback "
+                        f"({self.config.fallback_model}) models failed: {fallback_err}"
+                    ) from fallback_err
+            raise LLMError(
+                f"Bedrock call failed with {self.config.model}: {primary_err}"
+            ) from primary_err
+
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        json_mode: bool = True,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        """Complete a prompt. Uses tool calling to enforce JSON when json_mode=True."""
+        if json_mode:
+            # Force structured JSON output via tool use
+            tool_config = {
+                "tools": [_JSON_RESPONSE_TOOL],
+                "toolChoice": {"tool": {"name": "submit_json_response"}},
+            }
+            response = await self._call_with_fallback(
+                messages,
+                tool_config=tool_config,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            result = self._extract_tool_use(response)
+            if result:
+                return result
+            # Fallback to text if model didn't use the tool
+            return self._extract_text(response)
+
+        response = await self._call_with_fallback(
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        return self._extract_text(response)
+
+    async def complete_with_tools(
+        self,
+        messages: list[dict[str, str]],
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> str:
+        """Complete using tool calling for structured output."""
+        bedrock_tools = [_openai_tool_to_bedrock(t) for t in tools]
+        tool_config = {
+            "tools": bedrock_tools,
+            "toolChoice": {"tool": {"name": tools[0]["function"]["name"]}},
+        }
+
+        response = await self._call_with_fallback(
+            messages,
+            tool_config=tool_config,
+            temperature=temperature,
+        )
+
+        tool_json = self._extract_tool_use(response)
+        if tool_json:
+            return tool_json
+
+        # Fallback: some models may return text instead of tool call
+        text = self._extract_text(response)
+        if text:
+            logger.warning("Bedrock model returned text instead of tool call, using as fallback")
+            return text
+
+        raise LLMError("Bedrock model returned neither tool call nor content")
+
+    async def complete_agentic(
+        self,
+        messages: list,
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> dict:
+        """Single hop of an agentic loop. Returns OpenAI-shaped assistant message."""
+        bedrock_tools = [_openai_tool_to_bedrock(t) for t in tools]
+        tool_config = {"tools": bedrock_tools}
+
+        response = await self._call_with_fallback(
+            messages,
+            tool_config=tool_config,
+            temperature=temperature,
+        )
+
+        # Convert Bedrock response to OpenAI-compatible message format
+        output = response.get("output", {})
+        message = output.get("message", {})
+        content_blocks = message.get("content", [])
+
+        openai_msg: dict = {"role": "assistant", "content": None, "tool_calls": []}
+
+        for block in content_blocks:
+            if "text" in block:
+                openai_msg["content"] = block["text"]
+            elif "toolUse" in block:
+                tool_use = block["toolUse"]
+                openai_msg["tool_calls"].append(
+                    {
+                        "id": tool_use["toolUseId"],
+                        "type": "function",
+                        "function": {
+                            "name": tool_use["name"],
+                            "arguments": json.dumps(tool_use["input"]),
+                        },
+                    }
+                )
+
+        if not openai_msg["tool_calls"]:
+            del openai_msg["tool_calls"]
+
+        return openai_msg
+
+    async def review(self, messages: list[dict[str, str]]) -> str:
+        """Submit a review using tool calling."""
+        return await self.complete_with_tools(messages, tools=[SUBMIT_REVIEW_TOOL])
+
+    async def walkthrough(self, messages: list[dict[str, str]]) -> str:
+        """Submit a walkthrough using tool calling."""
+        return await self.complete_with_tools(messages, tools=[SUBMIT_WALKTHROUGH_TOOL])
+
+    def count_tokens(self, text: str) -> int:
+        """Estimate token count. Uses ~4 chars per token heuristic."""
+        return len(text) // 4
+
+    @property
+    def usage(self) -> dict[str, int]:
+        return {
+            "prompt_tokens": self.total_prompt_tokens,
+            "completion_tokens": self.total_completion_tokens,
+            "total_tokens": self.total_prompt_tokens + self.total_completion_tokens,
+        }

--- a/src/mira/llm/models.json
+++ b/src/mira/llm/models.json
@@ -88,5 +88,39 @@
     "supports_json_mode": true,
     "purposes": ["review"],
     "recommended_for": []
+  },
+
+  "us.anthropic.claude-sonnet-4-6-v1:0": {
+    "label": "Claude Sonnet 4.6 (Bedrock)",
+    "provider": "bedrock",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_1m": 3.00,
+    "output_cost_per_1m": 15.00,
+    "supports_json_mode": false,
+    "purposes": ["review"],
+    "recommended_for": ["review"]
+  },
+  "us.anthropic.claude-haiku-4-5-v1:0": {
+    "label": "Claude Haiku 4.5 (Bedrock)",
+    "provider": "bedrock",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 64000,
+    "input_cost_per_1m": 1.00,
+    "output_cost_per_1m": 5.00,
+    "supports_json_mode": false,
+    "purposes": ["indexing", "review"],
+    "recommended_for": ["indexing"]
+  },
+  "us.anthropic.claude-opus-4-6-v1:0": {
+    "label": "Claude Opus 4.6 (Bedrock)",
+    "provider": "bedrock",
+    "max_input_tokens": 200000,
+    "max_output_tokens": 32000,
+    "input_cost_per_1m": 15.00,
+    "output_cost_per_1m": 75.00,
+    "supports_json_mode": false,
+    "purposes": ["review"],
+    "recommended_for": []
   }
 }

--- a/src/mira/llm/provider.py
+++ b/src/mira/llm/provider.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import ClassVar
 
 import httpx
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
@@ -312,6 +313,9 @@ def _strip_model_prefix(model: str, base_url: str) -> str:
 
 class LLMProvider:
     """Direct OpenRouter API client for LLM completions."""
+
+    supports_json_mode: ClassVar[bool] = True
+    supports_tool_calling: ClassVar[bool] = True
 
     def __init__(self, config: LLMConfig) -> None:
         self.config = config

--- a/tests/evals/test_eval_bedrock.py
+++ b/tests/evals/test_eval_bedrock.py
@@ -1,0 +1,124 @@
+"""Bedrock integration eval — runs against real AWS Bedrock.
+
+Requires AWS credentials with bedrock:InvokeModel permission.
+Skipped when credentials are not available.
+
+Run with: pytest tests/evals/test_eval_bedrock.py -m eval -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from mira.config import LLMConfig
+from mira.core.engine import ReviewEngine
+from mira.llm import create_llm
+
+pytestmark = [
+    pytest.mark.eval,
+    pytest.mark.skipif(
+        not os.environ.get("AWS_ACCESS_KEY_ID")
+        and not os.environ.get("AWS_PROFILE")
+        and not os.environ.get("AWS_ROLE_ARN"),
+        reason="No AWS credentials available (need AWS_ACCESS_KEY_ID, AWS_PROFILE, or AWS_ROLE_ARN)",
+    ),
+]
+
+_BEDROCK_MODEL = os.environ.get("MIRA_BEDROCK_MODEL", "us.anthropic.claude-haiku-4-5-v1:0")
+_BEDROCK_REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+
+def _make_provider():
+    config = LLMConfig(
+        provider="bedrock",
+        model=_BEDROCK_MODEL,
+        region=_BEDROCK_REGION,
+        aws_profile=os.environ.get("AWS_PROFILE"),
+    )
+    return create_llm(config)
+
+
+def _make_diff(filename: str, content: str) -> str:
+    """Create a minimal unified diff for testing."""
+    lines = content.strip().splitlines()
+    added = "\n".join(f"+{line}" for line in lines)
+    header = (
+        f"diff --git a/{filename} b/{filename}\n"
+        f"--- a/{filename}\n"
+        f"+++ b/{filename}\n"
+        f"@@ -1,0 +1,{len(lines)} @@\n"
+    )
+    return header + added + "\n"
+
+
+class TestBedrockReviewIntegration:
+    """End-to-end: send a diff through the review engine with Bedrock."""
+
+    @pytest.mark.asyncio
+    async def test_reviews_sql_injection(self) -> None:
+        """Bedrock should catch an obvious SQL injection."""
+        from mira.config import load_config
+
+        code = """\
+def get_user(user_id):
+    query = f"SELECT * FROM users WHERE id = {user_id}"
+    return db.execute(query)
+"""
+        diff = _make_diff("app/db.py", code)
+
+        config = load_config()
+        config.review.walkthrough = False
+        config.review.self_critique = False
+        config.review.security_pass = False
+
+        llm = _make_provider()
+        engine = ReviewEngine(config=config, llm=llm, dry_run=True)
+        result = await engine.review_diff(diff)
+
+        # Should produce at least one comment mentioning SQL or injection
+        assert result.comments, "Expected at least one review comment"
+        all_text = " ".join(c.title + " " + c.body for c in result.comments).lower()
+        assert "sql" in all_text or "injection" in all_text
+
+    @pytest.mark.asyncio
+    async def test_basic_completion(self) -> None:
+        """Verify basic Bedrock completion works."""
+        provider = _make_provider()
+        result = await provider.complete(
+            [
+                {"role": "system", "content": "Return valid JSON only."},
+                {"role": "user", "content": 'Return {"status": "ok"}'},
+            ],
+            json_mode=True,
+        )
+
+        parsed = json.loads(result)
+        assert "status" in parsed
+
+    @pytest.mark.asyncio
+    async def test_tool_calling(self) -> None:
+        """Verify Bedrock tool calling works with a simple tool."""
+        provider = _make_provider()
+        result = await provider.complete_with_tools(
+            [{"role": "user", "content": "Say hello in a greeting tool call"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "greet",
+                        "description": "Generate a greeting",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"message": {"type": "string"}},
+                            "required": ["message"],
+                        },
+                    },
+                }
+            ],
+        )
+
+        parsed = json.loads(result)
+        assert "message" in parsed

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -1,0 +1,501 @@
+"""Tests for the Bedrock LLM provider."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mira.config import LLMConfig
+from mira.exceptions import LLMError
+
+boto3 = pytest.importorskip("boto3", reason="boto3 not installed (install with: pip install mira-reviewer[bedrock])")
+
+
+def _bedrock_config(**kwargs) -> LLMConfig:
+    return LLMConfig(
+        provider="bedrock",
+        model="us.anthropic.claude-sonnet-4-6-v1:0",
+        region="us-east-1",
+        **kwargs,
+    )
+
+
+def _mock_converse_response(text: str = "response", usage: dict | None = None) -> dict:
+    """Mock Bedrock Converse API response with text content."""
+    return {
+        "output": {"message": {"role": "assistant", "content": [{"text": text}]}},
+        "usage": usage or {"inputTokens": 100, "outputTokens": 50},
+        "stopReason": "end_turn",
+    }
+
+
+def _mock_tool_use_response(
+    name: str = "submit_review", input_data: dict | None = None, usage: dict | None = None
+) -> dict:
+    """Mock Bedrock Converse API response with a tool use block."""
+    return {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "call_abc123",
+                            "name": name,
+                            "input": input_data or {"comments": [], "summary": "LGTM"},
+                        }
+                    }
+                ],
+            }
+        },
+        "usage": usage or {"inputTokens": 200, "outputTokens": 100},
+        "stopReason": "tool_use",
+    }
+
+
+class TestBedrockProviderInit:
+    @patch("boto3.Session")
+    def test_creates_client_with_region(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        BedrockProvider(_bedrock_config())
+
+        mock_session_cls.assert_called_once_with(profile_name=None, region_name="us-east-1")
+        mock_session.client.assert_called_once_with("bedrock-runtime")
+
+    @patch("boto3.Session")
+    def test_creates_client_with_profile(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        BedrockProvider(_bedrock_config(aws_profile="my-profile"))
+
+        mock_session_cls.assert_called_once_with(profile_name="my-profile", region_name="us-east-1")
+
+    @patch("boto3.Session")
+    def test_initial_token_counts(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_session_cls.return_value = MagicMock()
+        provider = BedrockProvider(_bedrock_config())
+        assert provider.total_prompt_tokens == 0
+        assert provider.total_completion_tokens == 0
+
+    def test_missing_boto3_raises(self):
+        with (
+            patch.dict("sys.modules", {"boto3": None}),
+            pytest.raises(LLMError, match="boto3 is required"),
+        ):
+            import importlib
+
+            from mira.llm import bedrock
+
+            importlib.reload(bedrock)
+            bedrock.BedrockProvider(_bedrock_config())
+
+
+class TestBedrockComplete:
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_successful_completion_json_mode(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        # json_mode uses tool calling, so response is a tool use
+        mock_client.converse.return_value = _mock_tool_use_response(
+            "submit_json_response", {"result": "ok"}
+        )
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        result = await provider.complete([{"role": "user", "content": "hello"}])
+
+        parsed = json.loads(result)
+        assert parsed["result"] == "ok"
+        assert provider.total_prompt_tokens == 200
+        assert provider.total_completion_tokens == 100
+
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_completion_no_json_mode(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = _mock_converse_response("plain text response")
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        result = await provider.complete([{"role": "user", "content": "hello"}], json_mode=False)
+
+        assert result == "plain text response"
+        # Should NOT have toolConfig in the request
+        call_kwargs = mock_client.converse.call_args[1]
+        assert "toolConfig" not in call_kwargs
+
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_json_mode_uses_tool_forcing(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = _mock_tool_use_response("submit_json_response", {})
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        await provider.complete([{"role": "user", "content": "hello"}], json_mode=True)
+
+        call_kwargs = mock_client.converse.call_args[1]
+        tool_config = call_kwargs["toolConfig"]
+        assert tool_config["toolChoice"] == {"tool": {"name": "submit_json_response"}}
+
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_fallback_on_primary_failure(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        # Primary fails with non-throttle error (exhausts retries), fallback succeeds
+        mock_client.converse.side_effect = [
+            Exception("model overloaded"),
+            _mock_converse_response("fallback response"),
+        ]
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        config = _bedrock_config(fallback_model="us.anthropic.claude-haiku-4-5-v1:0")
+        provider = BedrockProvider(config)
+        result = await provider.complete([{"role": "user", "content": "hello"}], json_mode=False)
+
+        assert result == "fallback response"
+
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_no_fallback_raises(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        mock_client.converse.side_effect = Exception("broken")
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        with pytest.raises(LLMError, match="Bedrock call failed"):
+            await provider.complete([{"role": "user", "content": "hello"}], json_mode=False)
+
+
+class TestBedrockErrorHandling:
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_access_denied_error(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        err = Exception("AccessDeniedException: User is not authorized")
+        mock_client.converse.side_effect = err
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        with pytest.raises(LLMError, match="access denied"):
+            await provider.complete([{"role": "user", "content": "hello"}], json_mode=False)
+
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_resource_not_found_error(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        err = Exception("ResourceNotFoundException: Model not found")
+        mock_client.converse.side_effect = err
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        with pytest.raises(LLMError, match="not found"):
+            await provider.complete([{"role": "user", "content": "hello"}], json_mode=False)
+
+
+class TestBedrockCompleteWithTools:
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_review_tool_calling(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        review_data = {"comments": [], "summary": "Clean code", "key_issues": []}
+        mock_client = MagicMock()
+        mock_client.converse.return_value = _mock_tool_use_response("submit_review", review_data)
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        result = await provider.review([{"role": "user", "content": "review this"}])
+
+        parsed = json.loads(result)
+        assert parsed["summary"] == "Clean code"
+
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_tool_config_format(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = _mock_tool_use_response()
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        await provider.review([{"role": "user", "content": "review"}])
+
+        call_kwargs = mock_client.converse.call_args[1]
+        tool_config = call_kwargs["toolConfig"]
+        assert "tools" in tool_config
+        tool_spec = tool_config["tools"][0]["toolSpec"]
+        assert tool_spec["name"] == "submit_review"
+        assert "inputSchema" in tool_spec
+        assert tool_config["toolChoice"] == {"tool": {"name": "submit_review"}}
+
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_text_fallback_when_no_tool_call(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        # Model returns text instead of tool call
+        mock_client = MagicMock()
+        mock_client.converse.return_value = _mock_converse_response('{"comments": []}')
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        result = await provider.complete_with_tools(
+            [{"role": "user", "content": "review"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "test",
+                        "description": "",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        )
+
+        assert result == '{"comments": []}'
+
+
+class TestBedrockAgentic:
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_returns_openai_shaped_message(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"text": "Let me check that."},
+                        {
+                            "toolUse": {
+                                "toolUseId": "call_xyz",
+                                "name": "read_file",
+                                "input": {"path": "src/main.py"},
+                            }
+                        },
+                    ],
+                }
+            },
+            "usage": {"inputTokens": 50, "outputTokens": 30},
+            "stopReason": "tool_use",
+        }
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        msg = await provider.complete_agentic(
+            [{"role": "user", "content": "check the file"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "description": "Read a file",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"path": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        )
+
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Let me check that."
+        assert len(msg["tool_calls"]) == 1
+        assert msg["tool_calls"][0]["function"]["name"] == "read_file"
+        assert json.loads(msg["tool_calls"][0]["function"]["arguments"]) == {"path": "src/main.py"}
+
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_no_tool_calls_omits_key(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = _mock_converse_response("Done, no tools needed.")
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        msg = await provider.complete_agentic(
+            [{"role": "user", "content": "summarize"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "noop",
+                        "description": "",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        )
+
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "Done, no tools needed."
+        assert "tool_calls" not in msg
+
+
+class TestCreateProvider:
+    @patch("boto3.Session")
+    def test_factory_returns_bedrock(self, mock_session_cls):
+        from mira.llm import create_llm
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_session_cls.return_value = MagicMock()
+        provider = create_llm(_bedrock_config())
+        assert isinstance(provider, BedrockProvider)
+
+    def test_factory_returns_openai_by_default(self):
+        from mira.llm import create_llm
+        from mira.llm.provider import LLMProvider
+
+        config = LLMConfig()
+        provider = create_llm(config)
+        assert isinstance(provider, LLMProvider)
+
+
+class TestMessageConversion:
+    def test_system_messages_extracted(self):
+        from mira.llm.bedrock import _messages_to_bedrock
+
+        messages = [
+            {"role": "system", "content": "You are a reviewer."},
+            {"role": "user", "content": "Review this code."},
+        ]
+        system, conversation = _messages_to_bedrock(messages)
+
+        assert system == [{"text": "You are a reviewer."}]
+        assert len(conversation) == 1
+        assert conversation[0]["role"] == "user"
+
+    def test_tool_results_converted(self):
+        from mira.llm.bedrock import _messages_to_bedrock
+
+        messages = [
+            {"role": "user", "content": "check file"},
+            {"role": "assistant", "content": "reading..."},
+            {"role": "tool", "content": '{"data": "file contents"}', "tool_call_id": "call_1"},
+        ]
+        system, conversation = _messages_to_bedrock(messages)
+
+        assert system is None
+        assert len(conversation) == 3
+        tool_result = conversation[2]["content"][0]["toolResult"]
+        assert tool_result["toolUseId"] == "call_1"
+        assert tool_result["content"] == [{"json": {"data": "file contents"}}]
+
+    def test_tool_schema_conversion(self):
+        from mira.llm.bedrock import _openai_tool_to_bedrock
+
+        openai_tool = {
+            "type": "function",
+            "function": {
+                "name": "test_tool",
+                "description": "A test tool",
+                "parameters": {"type": "object", "properties": {"x": {"type": "string"}}},
+            },
+        }
+        bedrock_tool = _openai_tool_to_bedrock(openai_tool)
+
+        assert bedrock_tool["toolSpec"]["name"] == "test_tool"
+        assert bedrock_tool["toolSpec"]["description"] == "A test tool"
+        assert (
+            bedrock_tool["toolSpec"]["inputSchema"]["json"] == openai_tool["function"]["parameters"]
+        )
+
+
+class TestCapabilityAnnotations:
+    @patch("boto3.Session")
+    def test_bedrock_capabilities(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_session_cls.return_value = MagicMock()
+        provider = BedrockProvider(_bedrock_config())
+        assert provider.supports_json_mode is False
+        assert provider.supports_tool_calling is True
+
+    def test_openai_capabilities(self):
+        from mira.llm.provider import LLMProvider
+
+        provider = LLMProvider(LLMConfig())
+        assert provider.supports_json_mode is True
+        assert provider.supports_tool_calling is True
+
+
+class TestUsage:
+    @pytest.mark.asyncio
+    @patch("boto3.Session")
+    async def test_token_tracking(self, mock_session_cls):
+        from mira.llm.bedrock import BedrockProvider
+
+        mock_client = MagicMock()
+        mock_client.converse.side_effect = [
+            _mock_converse_response("r1", {"inputTokens": 100, "outputTokens": 50}),
+            _mock_converse_response("r2", {"inputTokens": 200, "outputTokens": 80}),
+        ]
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_cls.return_value = mock_session
+
+        provider = BedrockProvider(_bedrock_config())
+        await provider.complete([{"role": "user", "content": "a"}], json_mode=False)
+        await provider.complete([{"role": "user", "content": "b"}], json_mode=False)
+
+        assert provider.usage == {
+            "prompt_tokens": 300,
+            "completion_tokens": 130,
+            "total_tokens": 430,
+        }

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -10,7 +10,9 @@ import pytest
 from mira.config import LLMConfig
 from mira.exceptions import LLMError
 
-boto3 = pytest.importorskip("boto3", reason="boto3 not installed (install with: pip install mira-reviewer[bedrock])")
+boto3 = pytest.importorskip(
+    "boto3", reason="boto3 not installed (install with: pip install mira-reviewer[bedrock])"
+)
 
 
 def _bedrock_config(**kwargs) -> LLMConfig:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1373,19 +1373,12 @@ class TestSelfCritique:
             }
         )
 
-        # Patch LLMProvider so the critic LLM returns our canned response.
-        # The engine instantiates the critic via load_config(); easier to
-        # patch complete_with_tools globally.
-        from mira.llm import provider as provider_mod
+        mock_llm = AsyncMock()
+        mock_llm.complete_with_tools.return_value = verdict_response
 
-        async def fake_complete_with_tools(self, messages, tools, temperature=None):
-            return verdict_response
-
-        monkeypatch.setattr(
-            provider_mod.LLMProvider, "complete_with_tools", fake_complete_with_tools
+        engine = ReviewEngine(
+            config=MiraConfig(), llm=AsyncMock(), provider=None, indexing_llm=mock_llm
         )
-
-        engine = ReviewEngine(config=MiraConfig(), llm=AsyncMock(), provider=None)
         kept = await engine._self_critique(comments)
 
         assert len(kept) == 1
@@ -1528,16 +1521,15 @@ class TestRegenerateSummary:
 
     @pytest.mark.asyncio
     async def test_uses_cheap_llm_output(self, monkeypatch):
-        """Successful regen returns the cheap LLM's prose, stripped."""
+        """Successful regen returns the LLM's prose, stripped."""
         from mira.core.engine import ReviewEngine
-        from mira.llm import provider as provider_mod
 
-        async def fake_complete(self, messages, json_mode=True, temperature=None, max_tokens=None):
-            return "  Fresh summary based on filed issues only.  "
+        mock_llm = AsyncMock()
+        mock_llm.complete.return_value = "  Fresh summary based on filed issues only.  "
 
-        monkeypatch.setattr(provider_mod.LLMProvider, "complete", fake_complete)
-
-        engine = ReviewEngine(config=MiraConfig(), llm=AsyncMock(), provider=None)
+        engine = ReviewEngine(
+            config=MiraConfig(), llm=AsyncMock(), provider=None, indexing_llm=mock_llm
+        )
         out = await engine._regenerate_summary(
             [self._comment()], [], "title", "desc", fallback="old summary"
         )
@@ -1547,14 +1539,13 @@ class TestRegenerateSummary:
     async def test_falls_back_on_llm_failure(self, monkeypatch):
         """LLM error must not crash the review — use the original summary."""
         from mira.core.engine import ReviewEngine
-        from mira.llm import provider as provider_mod
 
-        async def fake_complete(self, messages, json_mode=True, temperature=None, max_tokens=None):
-            raise RuntimeError("LLM down")
+        mock_llm = AsyncMock()
+        mock_llm.complete.side_effect = RuntimeError("LLM down")
 
-        monkeypatch.setattr(provider_mod.LLMProvider, "complete", fake_complete)
-
-        engine = ReviewEngine(config=MiraConfig(), llm=AsyncMock(), provider=None)
+        engine = ReviewEngine(
+            config=MiraConfig(), llm=AsyncMock(), provider=None, indexing_llm=mock_llm
+        )
         out = await engine._regenerate_summary(
             [self._comment()], [], "t", "d", fallback="original prose"
         )
@@ -1564,14 +1555,13 @@ class TestRegenerateSummary:
     async def test_falls_back_when_llm_returns_empty(self, monkeypatch):
         """Empty LLM output → use fallback so summary is never blank."""
         from mira.core.engine import ReviewEngine
-        from mira.llm import provider as provider_mod
 
-        async def fake_complete(self, messages, json_mode=True, temperature=None, max_tokens=None):
-            return "   "
+        mock_llm = AsyncMock()
+        mock_llm.complete.return_value = "   "
 
-        monkeypatch.setattr(provider_mod.LLMProvider, "complete", fake_complete)
-
-        engine = ReviewEngine(config=MiraConfig(), llm=AsyncMock(), provider=None)
+        engine = ReviewEngine(
+            config=MiraConfig(), llm=AsyncMock(), provider=None, indexing_llm=mock_llm
+        )
         out = await engine._regenerate_summary([self._comment()], [], "t", "d", fallback="fallback")
         assert out == "fallback"
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -69,7 +69,7 @@ def mock_pr_info() -> PRInfo:
 
 @patch("mira.github_app.handlers.ReviewEngine")
 @patch("mira.github_app.handlers.create_provider")
-@patch("mira.github_app.handlers.LLMProvider")
+@patch("mira.github_app.handlers.create_llm")
 @patch("mira.github_app.handlers.load_config")
 async def test_handle_pr_event(
     mock_config: MagicMock,
@@ -93,7 +93,7 @@ async def test_handle_pr_event(
 
 @patch("mira.github_app.handlers.ReviewEngine")
 @patch("mira.github_app.handlers.create_provider")
-@patch("mira.github_app.handlers.LLMProvider")
+@patch("mira.github_app.handlers.create_llm")
 @patch("mira.github_app.handlers.load_config")
 async def test_handle_comment_review_keyword(
     mock_config: MagicMock,
@@ -115,7 +115,7 @@ async def test_handle_comment_review_keyword(
 
 
 @patch("mira.github_app.handlers.create_provider")
-@patch("mira.github_app.handlers.LLMProvider")
+@patch("mira.github_app.handlers.create_llm")
 @patch("mira.github_app.handlers.load_config")
 @pytest.mark.parametrize("verb", ["help", "?", "commands", "HELP", "Help"])
 async def test_handle_comment_help_posts_command_list(
@@ -151,7 +151,7 @@ async def test_handle_comment_help_posts_command_list(
 
 
 @patch("mira.github_app.handlers.create_provider")
-@patch("mira.github_app.handlers.LLMProvider")
+@patch("mira.github_app.handlers.create_llm")
 @patch("mira.github_app.handlers.load_config")
 async def test_handle_comment_question(
     mock_config: MagicMock,
@@ -183,7 +183,7 @@ async def test_handle_comment_question(
 
 
 @patch("mira.github_app.handlers.create_provider")
-@patch("mira.github_app.handlers.LLMProvider")
+@patch("mira.github_app.handlers.create_llm")
 @patch("mira.github_app.handlers.load_config")
 async def test_handle_comment_formats_reply_with_attribution(
     mock_config: MagicMock,

--- a/tests/test_merge_learning.py
+++ b/tests/test_merge_learning.py
@@ -505,7 +505,7 @@ async def test_handle_pr_merged_end_to_end(tmp_path, monkeypatch):
             }
         )
     )
-    monkeypatch.setattr(handlers, "LLMProvider", lambda *a, **kw: fake_llm)
+    monkeypatch.setattr(handlers, "create_llm", lambda *a, **kw: fake_llm)
 
     payload = {
         "action": "closed",

--- a/ui/mira/package-lock.json
+++ b/ui/mira/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "mira",
+  "name": "mira-dashboard",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mira",
+      "name": "mira-dashboard",
       "version": "0.1.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",


### PR DESCRIPTION
Adds a BedrockProvider that calls the Converse API directly, letting teams with data-residency requirements or existing Bedrock access run Mira without routing code through OpenRouter.

Key changes:
- LLMProviderProtocol with capability annotations (supports_json_mode, supports_tool_calling) for provider-agnostic dispatch
- BedrockProvider using Converse API with tool calling, throttle-aware retry (exponential backoff + jitter), and detailed error messages
- create_llm() factory replaces direct LLMProvider instantiation at all call sites — provider choice is driven by config
- Engine accepts an indexing_llm parameter so secondary tasks (critique, security scan, summary) use the configured indexing model through the same provider, rather than creating a separate provider internally
- boto3 as an optional dependency (pip install mira-reviewer[bedrock]), included in the Docker image by default
- JSON mode enforced via tool calling on providers that lack native response_format support

Config:
  llm: provider: "bedrock" model: "us.anthropic.claude-sonnet-4-6-v1:0" indexing_model: "us.anthropic.claude-haiku-4-5-v1:0" region: "us-east-1" aws_profile: "my-profile"  # optional

Closes #69

<!--
Thanks for contributing to Mira!

Before opening this PR, please ensure:
- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [ ] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

Security fixes should be reported privately first — see SECURITY.md.
-->

## Summary

- Adds AWS Bedrock as a direct LLM provider via the Converse API, for teams with data-residency requirements or existing Bedrock access
- Introduces LLMProviderProtocol with capability annotations (supports_json_mode, supports_tool_calling) to support future provider adapters
- create_llm() factory replaces direct LLMProvider instantiation — provider choice driven by config
- Engine now accepts an explicit indexing_llm so secondary tasks (critique, security scan, summary) respect the configured provider rather than creating a separate instance internally
- boto3 as optional dependency (pip install mira-reviewer[bedrock]), included in Docker image

## Test plan

- 24 unit tests covering init, completion, JSON mode (via tool use), fallback, error handling, retry on throttle, agentic loop, message conversion, factory, and capabilities
- Integration eval test gated behind @pytest.mark.eval + AWS creds
- Full test suite passes (684 tests, 0 regressions)
- Manually tested end-to-end: CLI --stdin review and full GitHub App webhook flow with real Bedrock calls

## Notes for reviewers

- JSON mode on Bedrock uses forced tool calling (Bedrock lacks native response_format support) — reliable across all Bedrock-hosted models
- Engine change: secondary tasks previously created their own LLM via load_config() internally, losing the configured provider. Now the engine takes an indexing_llm parameter at construction. This is a behavior change — callers that don't pass it get the same LLM for both (safe default).
- models.json entries use cross-region inference profile IDs (us.anthropic.*); single-region IDs also work — we pass through as-is
