### PR TITLE
Fix for duplicate existing conversation threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Run Mira as a GitHub App that auto-reviews every PR and responds to comments.
 
 **1. Create a GitHub App** at [github.com/settings/apps/new](https://github.com/settings/apps/new):
 - Webhook URL: `https://your-server.com/github/webhook`
-- Permissions: Pull Requests (read+write), Contents (read), Issues (read+write)
+- Permissions: Pull Requests (read+write), Contents (read+write), Issues (read+write)
 - Events: Pull requests, Issue comments
 - Generate a private key (.pem)
 

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -16,7 +16,7 @@ from mira.core.chunker import chunk_files
 from mira.core.context import expand_context
 from mira.core.diff_parser import parse_diff
 from mira.core.file_filter import filter_files
-from mira.core.noise_filter import filter_noise
+from mira.core.noise_filter import drop_already_posted, filter_noise
 from mira.core.passes import (
     agentic_review_loop,
     regenerate_summary,
@@ -958,6 +958,17 @@ class ReviewEngine:
             self.config.filter,
             review_round=review_round,
         )
+
+        # Dedupe against still-open threads before self-critique, so we don't
+        # spend critique calls on comments we'd discard anyway.
+        if existing_comments:
+            before = len(final_comments)
+            final_comments = drop_already_posted(final_comments, existing_comments)
+            if before != len(final_comments):
+                logger.info(
+                    "Dropped %d comment(s) duplicating existing open threads",
+                    before - len(final_comments),
+                )
 
         # Self-critique catches confident-but-wrong claims that the noise
         # filter can't, since confidence scores are LLM-generated too. Pass

--- a/src/mira/core/noise_filter.py
+++ b/src/mira/core/noise_filter.py
@@ -122,3 +122,33 @@ def filter_noise(
     urgent = [c for c in result if c.severity >= Severity.WARNING]
     low_priority = [c for c in result if c.severity < Severity.WARNING]
     return urgent + low_priority[: config.max_comments]
+
+
+def drop_already_posted(
+    comments: list[ReviewComment],
+    existing_threads: list,
+) -> list[ReviewComment]:
+    """Drop comments that overlap an open bot thread from an earlier round.
+
+    filter_noise dedupes within one review; this dedupes across rounds, so a
+    re-review on the next push doesn't re-post a finding that still has an open
+    thread. Threads with a non-positive line (outdated) can't be located, so
+    they never suppress.
+    """
+    if not existing_threads:
+        return comments
+
+    open_lines: dict[str, list[int]] = {}
+    for t in existing_threads:
+        if t.line > 0:
+            open_lines.setdefault(t.path, []).append(t.line)
+    if not open_lines:
+        return comments
+
+    kept: list[ReviewComment] = []
+    for c in comments:
+        end = c.end_line or c.line
+        if any(c.line <= ln <= end for ln in open_lines.get(c.path, [])):
+            continue
+        kept.append(c)
+    return kept

--- a/src/mira/providers/github.py
+++ b/src/mira/providers/github.py
@@ -701,11 +701,12 @@ class GitHubProvider(BaseProvider):
             try:
                 await self._graphql_request(_RESOLVE_THREAD_MUTATION, {"threadId": tid})
                 resolved += 1
-            except Exception:
+            except Exception as exc:
                 logger.warning(
-                    "Failed to resolve thread %s on PR %s",
+                    "Failed to resolve thread %s on PR %s: %s",
                     tid,
                     pr_info.url,
+                    exc,
                 )
         if resolved < len(thread_ids):
             logger.warning(

--- a/tests/test_dedup_existing_threads.py
+++ b/tests/test_dedup_existing_threads.py
@@ -1,0 +1,73 @@
+"""Tests for drop_already_posted — cross-round dedup against open bot threads.
+
+filter_noise dedupes within one review; drop_already_posted stops a re-review
+from re-posting a finding that already has an open thread (the bug seen on
+PR #68, where utils.py:10 got the same comment on three separate pushes).
+"""
+
+from __future__ import annotations
+
+from mira.core.noise_filter import drop_already_posted
+from mira.models import ReviewComment, Severity, UnresolvedThread
+
+
+def _comment(
+    path: str, line: int, end_line: int | None = None, title: str = "issue"
+) -> ReviewComment:
+    return ReviewComment(
+        path=path,
+        line=line,
+        end_line=end_line,
+        severity=Severity.WARNING,
+        category="bug",
+        title=title,
+        body="b",
+        confidence=0.9,
+    )
+
+
+def _thread(path: str, line: int) -> UnresolvedThread:
+    return UnresolvedThread(thread_id=f"T:{path}:{line}", path=path, line=line, body="prev")
+
+
+def test_drops_comment_on_open_thread_line():
+    comments = [_comment("src/a.py", 10)]
+    existing = [_thread("src/a.py", 10)]
+    assert drop_already_posted(comments, existing) == []
+
+
+def test_keeps_comment_with_no_open_thread():
+    comments = [_comment("src/a.py", 10)]
+    existing = [_thread("src/a.py", 99)]
+    assert len(drop_already_posted(comments, existing)) == 1
+
+
+def test_path_must_match():
+    comments = [_comment("src/a.py", 10)]
+    existing = [_thread("src/b.py", 10)]
+    assert len(drop_already_posted(comments, existing)) == 1
+
+
+def test_open_thread_line_within_multiline_comment_range():
+    # New comment spans 8-12; an open thread sits at line 10 inside it.
+    comments = [_comment("src/a.py", 8, end_line=12)]
+    existing = [_thread("src/a.py", 10)]
+    assert drop_already_posted(comments, existing) == []
+
+
+def test_outdated_thread_unknown_line_does_not_suppress():
+    comments = [_comment("src/a.py", 10)]
+    existing = [_thread("src/a.py", 0)]  # unknown / outdated location
+    assert len(drop_already_posted(comments, existing)) == 1
+
+
+def test_no_existing_threads_is_passthrough():
+    comments = [_comment("src/a.py", 10), _comment("src/b.py", 20)]
+    assert drop_already_posted(comments, []) == comments
+
+
+def test_mixed_some_dropped_some_kept():
+    comments = [_comment("src/a.py", 10), _comment("src/a.py", 50), _comment("src/c.py", 5)]
+    existing = [_thread("src/a.py", 10), _thread("src/c.py", 5)]
+    kept = drop_already_posted(comments, existing)
+    assert [(c.path, c.line) for c in kept] == [("src/a.py", 50)]


### PR DESCRIPTION
<!--
Thanks for contributing to Mira!

Before opening this PR, please ensure:
- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [ ] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

Security fixes should be reported privately first — see SECURITY.md.
-->

## Summary

<!-- 1-3 bullets on what changed and why -->
- Fix for duplicate threads being raised on PRs

## Test plan

<!-- How did you verify this works? -->
Ran tests, CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
