### PR TITLE
Fixed indexing conflicts

### DIFF
--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -618,11 +618,20 @@ async def index_repo(
                     indexed_count,
                 )
                 raise IndexingCancelled(indexed_count)
-            results = await fut
+            try:
+                results = await fut
+            except Exception as exc:
+                # Skip a failed batch and keep going — one bad batch shouldn't
+                # abort the repo (and aborting leaves the other tasks burning tokens).
+                logger.warning("Skipping a summarization batch for %s/%s: %s", owner, repo, exc)
+                continue
             for path, content, data in results:
-                summary = _build_file_summary(path, content, data)
-                store.upsert_summary(summary)
-                indexed_count += 1
+                try:
+                    summary = _build_file_summary(path, content, data)
+                    store.upsert_summary(summary)
+                    indexed_count += 1
+                except Exception as exc:
+                    logger.warning("Skipping file %s in %s/%s: %s", path, owner, repo, exc)
     except IndexingCancelled:
         raise
 

--- a/src/mira/index/pg_store.py
+++ b/src/mira/index/pg_store.py
@@ -451,9 +451,14 @@ class PgIndexStore(_StoreSharedMixin):
                 (self._owner, self._repo, summary.path),
             )
             for sym in summary.symbols:
+                # Two symbols can share a name in one file (overloads, or LLM
+                # dupes) and collide on the PK — keep the last, don't crash.
                 cur.execute(
                     "INSERT INTO symbols (owner, repo, file_path, name, kind, signature, description) "
-                    "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s) "
+                    "ON CONFLICT (owner, repo, file_path, name) DO UPDATE SET "
+                    "kind=EXCLUDED.kind, signature=EXCLUDED.signature, "
+                    "description=EXCLUDED.description",
                     (
                         self._owner,
                         self._repo,

--- a/src/mira/index/store.py
+++ b/src/mira/index/store.py
@@ -379,8 +379,10 @@ class IndexStore(_StoreSharedMixin):
         )
         self._conn.execute("DELETE FROM symbols WHERE file_path = ?", (summary.path,))
         for sym in summary.symbols:
+            # Two symbols can share a name in one file (overloads, or LLM dupes)
+            # and collide on the PK — keep the last, don't raise.
             self._conn.execute(
-                "INSERT INTO symbols (file_path, name, kind, signature, description) "
+                "INSERT OR REPLACE INTO symbols (file_path, name, kind, signature, description) "
                 "VALUES (?, ?, ?, ?, ?)",
                 (summary.path, sym.name, sym.kind, sym.signature, sym.description),
             )

--- a/tests/test_upsert_duplicate_symbols.py
+++ b/tests/test_upsert_duplicate_symbols.py
@@ -1,0 +1,69 @@
+"""Regression for issue #78: a file whose symbol list has two symbols with the
+same name must not crash indexing (overloads / repeated defs / LLM dupes).
+
+The symbols PK is (file_path, name), so upsert must be conflict-safe
+(last-write-wins) rather than raising on the duplicate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mira.index.store import FileSummary, IndexStore, SymbolInfo
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> IndexStore:
+    return IndexStore(str(tmp_path / "index.db"))
+
+
+def _summary(symbols: list[SymbolInfo]) -> FileSummary:
+    return FileSummary(
+        path="src/overloads.py",
+        language="python",
+        summary="file with duplicate symbol names",
+        symbols=symbols,
+        imports=[],
+        symbol_refs=[],
+        external_refs=[],
+    )
+
+
+def test_duplicate_symbol_names_do_not_crash(store: IndexStore):
+    summary = _summary(
+        [
+            SymbolInfo(name="handle", kind="function", signature="handle(a)", description="first"),
+            SymbolInfo(
+                name="handle", kind="function", signature="handle(a, b)", description="second"
+            ),
+        ]
+    )
+    # Must not raise IntegrityError.
+    store.upsert_summary(summary)
+
+
+def test_last_write_wins_for_duplicate_name(store: IndexStore):
+    store.upsert_summary(
+        _summary(
+            [
+                SymbolInfo(
+                    name="handle", kind="function", signature="handle(a)", description="first"
+                ),
+                SymbolInfo(
+                    name="handle", kind="function", signature="handle(a, b)", description="second"
+                ),
+            ]
+        )
+    )
+    syms = [s for s in store.get_summary("src/overloads.py").symbols if s.name == "handle"]
+    assert len(syms) == 1
+    assert syms[0].signature == "handle(a, b)"  # last one kept
+
+
+def test_reindex_same_file_is_idempotent(store: IndexStore):
+    s = _summary([SymbolInfo(name="f", kind="function", signature="f()", description="d")])
+    store.upsert_summary(s)
+    store.upsert_summary(s)  # re-index must not crash or duplicate
+    assert len([x for x in store.get_summary("src/overloads.py").symbols if x.name == "f"]) == 1


### PR DESCRIPTION
<!--
Thanks for contributing to Mira!

Before opening this PR, please ensure:
- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [ ] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

Security fixes should be reported privately first — see SECURITY.md.
-->

## Summary

- Fixes index conflicts https://github.com/miracodeai/mira/issues/78

## Test plan

Tested locally with new tests & CI

<!-- How did you verify this works? -->

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
