### PR TITLE
Runtime-loadable models.json via MIRA_MODELS_JSON_PATH (closes #83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ Mira talks to OpenRouter under the hood, so any model OpenRouter supports works.
 
 Set `OPENROUTER_API_KEY` once; one key works across every provider. See [`src/mira/llm/models.json`](src/mira/llm/models.json) for the full registry of models Mira recognises (with pricing and per-purpose recommendations).
 
+**Adding your own models.** The dashboard's model dropdowns (and the validation behind them) come from that registry. To make a custom model selectable — e.g. DeepSeek or a local endpoint — point `MIRA_MODELS_JSON_PATH` at your own `models.json` (a volume mount works well). Its entries are **merged over** the bundled ones by model id, so you only list what you want to add or override:
+
+```bash
+MIRA_MODELS_JSON_PATH=/config/models.json
+```
+
+```jsonc
+// /config/models.json — copy an entry from the bundled file as a template
+{
+  "deepseek/deepseek-chat": {
+    "label": "DeepSeek Chat",
+    "provider": "openai",
+    "max_input_tokens": 64000,
+    "max_output_tokens": 8000,
+    "input_cost_per_1m": 0.27,
+    "output_cost_per_1m": 1.10,
+    "supports_json_mode": true,
+    "purposes": ["indexing", "review"]
+  }
+}
+```
+
+The file is read at startup; a missing or invalid file falls back to the bundled registry with a warning.
+
 > **Coming soon:** direct adapters for **Anthropic**, **OpenAI**, **Google Vertex**, **Ollama**, and **vLLM**, for teams that already hold provider keys, run open-weights models in-house, or have data-residency rules that prevent traffic from flowing through OpenRouter.
 
 ### AWS Bedrock

--- a/src/mira/llm/registry.py
+++ b/src/mira/llm/registry.py
@@ -3,22 +3,61 @@
 Backed by ``models.json``. Adding a new model is a one-line registry entry
 plus a release note; no other code needs to change. To deny a model entirely,
 remove its entry — the dashboard validation and dropdown derive from this file.
+
+Operators can extend or override the bundled list at runtime by pointing
+``MIRA_MODELS_JSON_PATH`` at their own ``models.json`` (e.g. a volume mount):
+its entries are overlaid onto the bundled ones by model id, so you can add a
+custom model (``deepseek/...``, a local endpoint, …) or tweak an existing one
+without forking the package. A missing/invalid override file is ignored with a
+warning.
 """
 
 from __future__ import annotations
 
 import json
+import logging
+import os
 from functools import lru_cache
 from pathlib import Path
 
-_REGISTRY_PATH = Path(__file__).parent / "models.json"
+logger = logging.getLogger(__name__)
+
+_BUNDLED_PATH = Path(__file__).parent / "models.json"
+_OVERRIDE_ENV = "MIRA_MODELS_JSON_PATH"
+
+
+def _read(path: Path) -> dict[str, dict]:
+    """Parse a models.json file, dropping the leading ``_*`` doc keys."""
+    raw = json.loads(path.read_text())
+    return {k: v for k, v in raw.items() if not k.startswith("_")}
 
 
 @lru_cache(maxsize=1)
 def _load() -> dict[str, dict]:
-    """Load the registry once per process, dropping the leading ``_*`` docs."""
-    raw = json.loads(_REGISTRY_PATH.read_text())
-    return {k: v for k, v in raw.items() if not k.startswith("_")}
+    """Load the registry once per process.
+
+    Starts from the bundled ``models.json``, then overlays the file at
+    ``MIRA_MODELS_JSON_PATH`` (if set) by model id — user entries add new models
+    or override bundled ones. The env var is read on first use (after process
+    startup), so a container's environment is in effect.
+    """
+    models = _read(_BUNDLED_PATH)
+    override = os.environ.get(_OVERRIDE_ENV)
+    if override:
+        path = Path(override)
+        try:
+            models = {**models, **_read(path)}
+            logger.info("Loaded model overrides from %s (%s)", _OVERRIDE_ENV, path)
+        except FileNotFoundError:
+            logger.warning("%s=%s not found; using bundled models only", _OVERRIDE_ENV, path)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning(
+                "Failed to read %s=%s (%s); using bundled models only",
+                _OVERRIDE_ENV,
+                path,
+                exc,
+            )
+    return models
 
 
 def all_models() -> dict[str, dict]:
@@ -73,10 +112,12 @@ def max_output_tokens(model_id: str, default: int = 4096) -> int:
 def pricing(model_id: str) -> tuple[float, float]:
     """Return ``(input_cost_per_1m, output_cost_per_1m)`` USD for the model.
 
-    Falls back to Sonnet pricing for unknown models so cost estimates aren't
-    silently zero.
+    Falls back to Sonnet pricing for unknown models — and for any cost field a
+    (possibly user-supplied) entry omits — so cost estimates aren't silently
+    zero and a partial custom entry can't crash registry load.
     """
-    info = get(model_id)
-    if info is None:
-        return (3.00, 15.00)
-    return (float(info["input_cost_per_1m"]), float(info["output_cost_per_1m"]))
+    info = get(model_id) or {}
+    return (
+        float(info.get("input_cost_per_1m", 3.00)),
+        float(info.get("output_cost_per_1m", 15.00)),
+    )

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -58,6 +58,9 @@ def test_override_adds_and_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyP
     f = tmp_path / "models.json"
     f.write_text(json.dumps(custom))
     monkeypatch.setenv("MIRA_MODELS_JSON_PATH", str(f))
+    # Required (not redundant with the fixture): all_models() was already called
+    # above to read `bundled`, which populated the lru_cache before the env var
+    # was set. Clear it so the call below re-reads with the override in place.
     registry._load.cache_clear()
 
     models = registry.all_models()
@@ -83,7 +86,6 @@ def test_custom_entry_without_cost_fields_does_not_crash(
         json.dumps({"local/llama": {"label": "Local", "purposes": ["review"]}})
     )
     monkeypatch.setenv("MIRA_MODELS_JSON_PATH", str(f))
-    registry._load.cache_clear()
 
     assert registry.is_supported("local/llama", purpose="review")
     # Falls back to default pricing rather than raising KeyError.
@@ -92,7 +94,6 @@ def test_custom_entry_without_cost_fields_does_not_crash(
 
 def test_missing_override_falls_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MIRA_MODELS_JSON_PATH", str(tmp_path / "nope.json"))
-    registry._load.cache_clear()
     # No crash; bundled models still load.
     assert registry.all_models()
 
@@ -101,5 +102,4 @@ def test_invalid_override_falls_back(tmp_path: Path, monkeypatch: pytest.MonkeyP
     bad = tmp_path / "models.json"
     bad.write_text("{ not valid json ")
     monkeypatch.setenv("MIRA_MODELS_JSON_PATH", str(bad))
-    registry._load.cache_clear()
     assert registry.all_models()

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,105 @@
+"""Tests for the model registry, incl. the runtime MIRA_MODELS_JSON_PATH override."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mira.llm import registry
+
+_CUSTOM = {
+    "deepseek/deepseek-chat": {
+        "label": "DeepSeek Chat",
+        "provider": "openai",
+        "max_input_tokens": 64000,
+        "max_output_tokens": 8000,
+        "input_cost_per_1m": 0.27,
+        "output_cost_per_1m": 1.10,
+        "supports_json_mode": True,
+        "purposes": ["indexing", "review"],
+        "recommended_for": [],
+    },
+    "_comment": "doc key — must be dropped",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_registry_cache():
+    # The registry caches per-process; clear around each test so env changes
+    # take effect and don't leak.
+    registry._load.cache_clear()
+    yield
+    registry._load.cache_clear()
+
+
+def test_bundled_models_load() -> None:
+    models = registry.all_models()
+    assert models  # non-empty
+    assert all(not k.startswith("_") for k in models)  # doc keys dropped
+
+
+def test_override_adds_and_overrides(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bundled = set(registry.all_models())
+    existing = next(iter(bundled))  # an arbitrary bundled model to override
+
+    custom = dict(_CUSTOM)
+    custom[existing] = {
+        "label": "OVERRIDDEN",
+        "provider": "x",
+        "max_input_tokens": 1,
+        "max_output_tokens": 1,
+        "input_cost_per_1m": 0,
+        "output_cost_per_1m": 0,
+        "supports_json_mode": False,
+        "purposes": ["review"],
+    }
+    f = tmp_path / "models.json"
+    f.write_text(json.dumps(custom))
+    monkeypatch.setenv("MIRA_MODELS_JSON_PATH", str(f))
+    registry._load.cache_clear()
+
+    models = registry.all_models()
+    # New model is added, supported, and shows up in the dropdown.
+    assert "deepseek/deepseek-chat" in models
+    assert registry.is_supported("deepseek/deepseek-chat", purpose="review")
+    assert any(
+        m["value"] == "deepseek/deepseek-chat" for m in registry.models_for_purpose("review")
+    )
+    # Bundled defaults are preserved (merge, not replace).
+    assert bundled <= set(models)
+    # The overlay replaced the existing entry, and doc keys are dropped.
+    assert models[existing]["label"] == "OVERRIDDEN"
+    assert "_comment" not in models
+
+
+def test_custom_entry_without_cost_fields_does_not_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A minimal custom entry (no cost fields) must not break pricing/registry load.
+    f = tmp_path / "models.json"
+    f.write_text(
+        json.dumps({"local/llama": {"label": "Local", "purposes": ["review"]}})
+    )
+    monkeypatch.setenv("MIRA_MODELS_JSON_PATH", str(f))
+    registry._load.cache_clear()
+
+    assert registry.is_supported("local/llama", purpose="review")
+    # Falls back to default pricing rather than raising KeyError.
+    assert registry.pricing("local/llama") == (3.00, 15.00)
+
+
+def test_missing_override_falls_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIRA_MODELS_JSON_PATH", str(tmp_path / "nope.json"))
+    registry._load.cache_clear()
+    # No crash; bundled models still load.
+    assert registry.all_models()
+
+
+def test_invalid_override_falls_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bad = tmp_path / "models.json"
+    bad.write_text("{ not valid json ")
+    monkeypatch.setenv("MIRA_MODELS_JSON_PATH", str(bad))
+    registry._load.cache_clear()
+    assert registry.all_models()

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -82,9 +82,7 @@ def test_custom_entry_without_cost_fields_does_not_crash(
 ) -> None:
     # A minimal custom entry (no cost fields) must not break pricing/registry load.
     f = tmp_path / "models.json"
-    f.write_text(
-        json.dumps({"local/llama": {"label": "Local", "purposes": ["review"]}})
-    )
+    f.write_text(json.dumps({"local/llama": {"label": "Local", "purposes": ["review"]}}))
     monkeypatch.setenv("MIRA_MODELS_JSON_PATH", str(f))
 
     assert registry.is_supported("local/llama", purpose="review")


### PR DESCRIPTION
Closes #83.

## Problem
The model registry (`src/mira/llm/registry.py`) loaded `models.json` from `Path(__file__).parent` — baked into the wheel. To use a custom/cheaper model (DeepSeek, a local endpoint), the only workaround was overwriting the installed file (volume mount) and reinstalling on each start, because the baked copy wins. Custom models also couldn't get past the dashboard dropdowns, since both the dropdown options *and* the `is_supported` validation derive from that registry.

## Fix
`registry._load()` now starts from the bundled `models.json` and, if `MIRA_MODELS_JSON_PATH` is set, **overlays** the user's file on top, merged by model id. Because everything downstream (dropdowns via `models_for_purpose`, `is_supported`, `pricing`, cost estimates) reads this one load, a custom model added to that file:
- shows up in the indexing/review dropdowns, and
- passes the PUT `/api/settings/models` validation

…with **no changes to any consumer**.

- **Merge, not replace** — you only list what you want to add or override; the curated defaults stay.
- **Resilient** — a missing or invalid override file logs a warning and falls back to the bundled registry (no crash).
- **`pricing()` hardened** — tolerates custom entries that omit cost fields (falls back), so a partial entry can't crash the import-time `MODEL_PRICING` build.
- Read once at startup (matches the volume-mount workflow; no hot-reload needed).

## Notes
- No frontend changes — the dropdowns already source from the registry, so they "just work."
- Env var only (mirrors `MIRA_INDEX_DIR` / `DATABASE_URL`), per the issue's "configurable path."

## Test plan
- New `tests/test_model_registry.py`: merge+override, graceful fallback for missing/invalid files, and partial entries (no cost fields). Full suite green (763 passed); ruff clean. README documents the env var with an example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)