### PR TITLE
0.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Mira are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] — 2026-06-08
+
+### Added
+
+- **MiniMax M2.7 support with think-block stripping** — `<think>…</think>` reasoning blocks (as emitted by MiniMax and some other models) are stripped before JSON parsing, so models that "think out loud" work for indexing and review. New `minimax/MiniMax-M2.7` registry entry.
+- **Dynamic bot @mention in the dashboard** — the UI now shows the App's real handle (auto-detected from its GitHub slug, default `@miracodeai`) instead of a hardcoded `@mira-bot`. Exposed via `/api/version`.
+
+### Fixed
+
+- **Blast Radius no longer leaks private repos** — a public repo's review never names a dependent repo that isn't known to be public. Repo visibility is tracked in the registry, backfilled automatically on startup/sync, and unknown visibility is treated as private (safe by default).
+- **No more duplicate review comments on re-review** — findings that already have an open bot thread are skipped, so each push stops re-posting the same suggestion.
+- **Indexing is resilient to bad files** — a duplicate symbol name no longer crashes the whole index (`symbols` upsert is conflict-safe on both Postgres and SQLite), and a single failed file/batch is skipped instead of aborting the repo (which also stops runaway token spend after a failure).
+- **Thread-resolution failures are now logged** — the real GraphQL error surfaces instead of being silently swallowed.
+- **Think-block regex** now strips the full `<think>…</think>` block (it previously matched only the opening tag).
+- **Sidebar navigation active state** — the active nav item is driven off `aria-current` (single source of truth), with a cleaner fill + bold treatment and a fixed header divider.
+
+### Changed
+
+- Dependency bumps (vite 8, tailwindcss 4.3, react-dom, eslint 10, lucide-react, @vitejs/plugin-react, @types/node, etc.).
+
 ## [0.2.2] — 2026-06-03
 
 ### Added
@@ -119,6 +139,7 @@ Initial public release.
 - `handle_push_index` now updates `updated_at` after incremental re-indexing
   so the "Indexed X ago" timestamp tracks reality.
 
+[0.2.3]: https://github.com/miracodeai/mira/releases/tag/v0.2.3
 [0.2.2]: https://github.com/miracodeai/mira/releases/tag/v0.2.2
 [0.2.1]: https://github.com/miracodeai/mira/releases/tag/v0.2.1
 [0.2.0]: https://github.com/miracodeai/mira/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mira-reviewer"
-version = "0.2.2"
+version = "0.2.3"
 description = "AI-powered PR reviewer with low-noise filtering"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/mira/__init__.py
+++ b/src/mira/__init__.py
@@ -1,3 +1,3 @@
 """Mira — AI-powered PR reviewer."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -50,7 +50,7 @@ def register_dashboard(app: FastAPI) -> None:
 
 # Standalone app — initialized at module load, but routes are registered at
 # the bottom of this file, *after* all @router decorators have run.
-app = FastAPI(title="Mira Dashboard API", version="0.2.2")
+app = FastAPI(title="Mira Dashboard API", version="0.2.3")
 
 _INDEX_DIR = os.environ.get("MIRA_INDEX_DIR", "/data/indexes")
 


### PR DESCRIPTION
<!--
Thanks for contributing to Mira!

Before opening this PR, please ensure:
- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [ ] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

Security fixes should be reported privately first — see SECURITY.md.
-->

## Summary

0.2.3 release
### Added

- **MiniMax M2.7 support with think-block stripping.** `<think>…</think>` reasoning blocks (MiniMax and similar "thinking" models) are stripped before JSON parsing, so those models work for indexing and review. New `minimax/MiniMax-M2.7` model entry.
- **Dynamic bot @mention in the dashboard.** The UI shows the App's real handle (auto-detected from its GitHub slug, default `@miracodeai`) instead of a hardcoded placeholder.

### Fixed

- **Blast Radius no longer leaks private repos.** A public repo's review never names a dependent repo that isn't known-public. Visibility is tracked in the registry, backfilled automatically, and unknown visibility is treated as private (safe by default).
- **No more duplicate review comments on re-review.** Findings that already have an open bot thread are skipped, so each push stops re-posting the same suggestion.
- **Resilient indexing.** A duplicate symbol name no longer crashes the index (conflict-safe upsert on Postgres + SQLite), and a single failed file is skipped instead of aborting the whole repo — which also stops runaway token spend after a failure.
- **Thread-resolution failures are logged** instead of silently swallowed.
- **Sidebar navigation active state** — cleaner active-item styling, driven off `aria-current`.

### Changed

- Dependency bumps (Vite 8, Tailwind 4.3, eslint 10, lucide-react, react-dom, and others).

## Test plan

<!-- How did you verify this works? -->
CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
