### PR TITLE
0.3.1 evals fix

### DIFF
--- a/src/mira/core/noise_filter.py
+++ b/src/mira/core/noise_filter.py
@@ -35,7 +35,9 @@ def _is_duplicate(
 
     Two comments are duplicates if:
     - Same file + overlapping lines + any title similarity (>= 0.25), OR
-    - Same file + exact same line + different titles (line-overlap alone is enough)
+    - Same file + exact same line + same category (one line can host two
+      distinct findings — e.g. a resource leak and an injection on one
+      `open()` call — so different categories are kept apart)
     - Same file + non-overlapping lines but near-identical titles (>= title_threshold)
     """
     title_sim = _jaccard_similarity(a.title, b.title)
@@ -47,11 +49,13 @@ def _is_duplicate(
 
     overlap = _lines_overlap(a, b)
 
-    # Exact same line — almost certainly about the same code
+    # Exact same line + same category — almost certainly the same finding.
+    # Different categories are distinct findings even on the same line;
+    # collapsing them lets a later critique drop take both out.
     end_a = a.end_line or a.line
     end_b = b.end_line or b.line
     same_line = (a.line == b.line) and (end_a == end_b)
-    if same_line:
+    if same_line and a.category == b.category:
         return True
 
     # Overlapping lines — lower title similarity bar

--- a/tests/test_noise_filter.py
+++ b/tests/test_noise_filter.py
@@ -13,13 +13,14 @@ def _make_comment(
     severity: Severity = Severity.WARNING,
     confidence: float = 0.8,
     title: str = "Issue",
+    category: str = "bug",
 ) -> ReviewComment:
     return ReviewComment(
         path=path,
         line=line,
         end_line=None,
         severity=severity,
-        category="bug",
+        category=category,
         title=title,
         body="Description",
         confidence=confidence,
@@ -136,6 +137,29 @@ class TestNoiseFilter:
         assert len(result) == 1
         assert result[0].severity == Severity.WARNING
 
+    def test_same_line_distinct_findings_both_survive(self):
+        # Regression: a speculative security blocker on the same line must not
+        # swallow a real resource-leak warning — if dedup collapses them and
+        # critique later drops the blocker, both findings are lost.
+        comments = [
+            _make_comment(
+                line=2,
+                severity=Severity.WARNING,
+                confidence=0.99,
+                title="File handle not closed on exception",
+                category="resource-leak",
+            ),
+            _make_comment(
+                line=2,
+                severity=Severity.BLOCKER,
+                confidence=0.85,
+                title="Path traversal via unsanitized user-controlled file path",
+                category="security",
+            ),
+        ]
+        result = filter_noise(comments, FilterConfig())
+        assert len(result) == 2
+
     def test_dedup_overlapping_lines_low_title_similarity(self):
         """Two comments on overlapping lines should dedup even with different titles."""
         comments = [
@@ -235,10 +259,19 @@ class TestIsDuplicate:
         b = _make_comment(path="b.py", line=1, title="Same title")
         assert _is_duplicate(a, b) is True
 
-    def test_same_line_always_duplicate(self):
+    def test_same_line_same_category_duplicate(self):
         a = _make_comment(path="a.py", line=5, title="Totally different")
         b = _make_comment(path="a.py", line=5, title="Completely unrelated")
         assert _is_duplicate(a, b) is True
+
+    def test_same_line_different_category_not_duplicate(self):
+        a = _make_comment(
+            path="a.py", line=5, title="File handle not closed", category="resource-leak"
+        )
+        b = _make_comment(
+            path="a.py", line=5, title="Path traversal via user input", category="security"
+        )
+        assert _is_duplicate(a, b) is False
 
     def test_non_overlapping_similar_titles_duplicate(self):
         a = _make_comment(path="a.py", line=5, title="Missing null check here")

--- a/uv.lock
+++ b/uv.lock
@@ -729,7 +729,7 @@ wheels = [
 
 [[package]]
 name = "mira-reviewer"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
<!--
Thanks for contributing to Mira!

Before opening this PR, please ensure:
- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [ ] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

Security fixes should be reported privately first — see SECURITY.md.
-->

## Summary

<!-- 1-3 bullets on what changed and why -->

## Test plan

<!-- How did you verify this works? -->

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
