### PR TITLE
Add php composer dependency detection

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,7 +23,7 @@ Mira is a self-hostable, fully open-source AI code reviewer. Everything below is
 - Blast-radius SVG rendering and interactive ReactFlow graph
 - Relationship overrides and custom edges
 - External reference tracking
-- Manifest-based package extraction (`package.json`, `requirements.txt`, `pyproject.toml`, `go.mod`, `Dockerfile`) with version constraints — zero LLM cost
+- Manifest-based package extraction (`package.json`, `requirements.txt`, `pyproject.toml`, `go.mod`, `composer.json`, `Dockerfile`) with version constraints — zero LLM cost
 
 ## Security
 

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -1257,7 +1257,7 @@ def get_external_refs(owner: str, repo: str) -> list[ExternalRefModel]:
 
 class PackageModel(BaseModel):
     name: str
-    kind: str  # "npm" | "pip" | "docker" | "go" | "rust"
+    kind: str  # "npm" | "pip" | "docker" | "go" | "rust" | "composer"
     version: str
     file_path: str
     is_dev: bool = False

--- a/src/mira/index/manifests.py
+++ b/src/mira/index/manifests.py
@@ -291,6 +291,77 @@ def parse_dockerfile(content: str, file_path: str) -> list[ParsedPackage]:
     return out
 
 
+# ── composer.json / composer.lock (PHP) ──
+
+
+def parse_composer_json(content: str, file_path: str) -> list[ParsedPackage]:
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        logger.debug("Skipping %s (invalid JSON): %s", file_path, exc)
+        return []
+
+    out: list[ParsedPackage] = []
+    for key, is_dev in (
+        ("require", False),
+        ("require-dev", True),
+    ):
+        block = data.get(key) or {}
+        if not isinstance(block, dict):
+            continue
+        for name, version in block.items():
+            if not isinstance(name, str) or not isinstance(version, str):
+                continue
+            # Skip platform requirements: php, ext-*, lib-*, etc.
+            lower = name.lower()
+            if lower == "php" or lower.startswith("ext-") or lower.startswith("lib-"):
+                continue
+            out.append(
+                ParsedPackage(
+                    name=name,
+                    kind="composer",
+                    version=version.strip(),
+                    file_path=file_path,
+                    is_dev=is_dev,
+                )
+            )
+    return out
+
+
+def parse_composer_lock(content: str, file_path: str) -> list[ParsedPackage]:
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        logger.debug("Skipping %s (invalid JSON): %s", file_path, exc)
+        return []
+
+    out: list[ParsedPackage] = []
+    for key, is_dev in (
+        ("packages", False),
+        ("packages-dev", True),
+    ):
+        entries = data.get(key) or []
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            version = entry.get("version")
+            if not isinstance(name, str) or not isinstance(version, str) or not name:
+                continue
+            out.append(
+                ParsedPackage(
+                    name=name,
+                    kind="composer",
+                    version=version,
+                    file_path=file_path,
+                    is_dev=is_dev,
+                )
+            )
+    return out
+
+
 # ── Lockfile parsers ──
 #
 # Lockfiles record the *resolved* version of every transitive dependency,
@@ -399,18 +470,20 @@ _PARSERS: list[tuple[re.Pattern[str], object]] = [
     # lockfile entry's resolved version is what we want for vuln matching.
     (re.compile(r"(^|/)uv\.lock$"), parse_uv_lock),
     (re.compile(r"(^|/)poetry\.lock$"), parse_poetry_lock),
+    (re.compile(r"(^|/)composer\.lock$"), parse_composer_lock),
     (re.compile(r"(^|/)package-lock\.json$"), parse_package_lock_json),
     (re.compile(r"(^|/)package\.json$"), parse_package_json),
     (re.compile(r"(^|/)requirements[^/]*\.txt$"), parse_requirements_txt),
     (re.compile(r"(^|/)pyproject\.toml$"), parse_pyproject_toml),
     (re.compile(r"(^|/)go\.mod$"), parse_go_mod),
+    (re.compile(r"(^|/)composer\.json$"), parse_composer_json),
     (re.compile(r"(^|/)(Dockerfile|[^/]+\.Dockerfile)$"), parse_dockerfile),
 ]
 
 
 def _is_lockfile_path(path: str) -> bool:
     """Heuristic — does this path look like a lockfile (resolved versions)?"""
-    return bool(re.search(r"(^|/)(uv|poetry)\.lock$|(^|/)package-lock\.json$", path))
+    return bool(re.search(r"(^|/)(uv|poetry|composer)\.lock$|(^|/)package-lock\.json$", path))
 
 
 def is_manifest(path: str) -> bool:

--- a/src/mira/index/manifests.py
+++ b/src/mira/index/manifests.py
@@ -312,9 +312,10 @@ def parse_composer_json(content: str, file_path: str) -> list[ParsedPackage]:
         for name, version in block.items():
             if not isinstance(name, str) or not isinstance(version, str):
                 continue
-            # Skip platform requirements: php, ext-*, lib-*, etc.
-            lower = name.lower()
-            if lower == "php" or lower.startswith("ext-") or lower.startswith("lib-"):
+            # Skip platform/virtual requirements: php, ext-*, lib-*, hhvm,
+            # composer-plugin-api, etc. Real Packagist packages are always
+            # namespaced as vendor/package (contain "/").
+            if "/" not in name:
                 continue
             out.append(
                 ParsedPackage(

--- a/src/mira/index/pg_store.py
+++ b/src/mira/index/pg_store.py
@@ -290,7 +290,7 @@ def list_packages_org_wide(url: str) -> list[dict]:
         cur.execute(
             "SELECT DISTINCT owner, repo, kind, name, version, file_path "
             "FROM package_manifests "
-            "WHERE kind IN ('npm', 'pip', 'go', 'rust') AND version <> ''"
+            "WHERE kind IN ('npm', 'pip', 'go', 'rust', 'composer') AND version <> ''"
         )
         rows = cur.fetchall()
     return [

--- a/src/mira/index/store.py
+++ b/src/mira/index/store.py
@@ -249,7 +249,7 @@ class LearnedRuleRow:
 class PackageManifestRow:
     id: int
     name: str
-    kind: str  # "npm" | "pip" | "docker" | "go" | "rust"
+    kind: str  # "npm" | "pip" | "docker" | "go" | "rust" | "composer"
     version: str
     file_path: str
     is_dev: bool = False
@@ -1154,7 +1154,7 @@ def list_packages_org_wide_sqlite() -> list[dict]:
             try:
                 rows = conn.execute(
                     "SELECT DISTINCT kind, name, version, file_path FROM package_manifests "
-                    "WHERE kind IN ('npm', 'pip', 'go', 'rust') AND version != ''"
+                    "WHERE kind IN ('npm', 'pip', 'go', 'rust', 'composer') AND version != ''"
                 ).fetchall()
             finally:
                 conn.close()

--- a/src/mira/security/osv.py
+++ b/src/mira/security/osv.py
@@ -29,6 +29,7 @@ _ECOSYSTEM_MAP: dict[str, str] = {
     "pip": "PyPI",
     "go": "Go",
     "rust": "crates.io",
+    "composer": "Packagist",
 }
 
 # Stripping common version constraint operators. OSV.dev wants a concrete

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -9,6 +9,8 @@ import pytest
 from mira.index.manifests import (
     _is_lockfile_path,
     is_manifest,
+    parse_composer_json,
+    parse_composer_lock,
     parse_dockerfile,
     parse_go_mod,
     parse_manifest,
@@ -170,6 +172,83 @@ class TestDockerfile:
         assert pkgs[0].version == ""
 
 
+class TestComposerJson:
+    def test_require_and_require_dev(self):
+        content = json.dumps(
+            {
+                "name": "acme/app",
+                "require": {
+                    "laravel/framework": "^10.0",
+                    "guzzlehttp/guzzle": "7.8.*",
+                },
+                "require-dev": {
+                    "phpunit/phpunit": "^10.0",
+                },
+            }
+        )
+        pkgs = parse_composer_json(content, "composer.json")
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["laravel/framework"].version == "^10.0"
+        assert by_name["laravel/framework"].is_dev is False
+        assert by_name["guzzlehttp/guzzle"].version == "7.8.*"
+        assert by_name["phpunit/phpunit"].is_dev is True
+        assert all(p.kind == "composer" for p in pkgs)
+
+    def test_skips_platform_packages(self):
+        content = json.dumps(
+            {
+                "require": {
+                    "php": ">=8.1",
+                    "ext-json": "*",
+                    "lib-openssl": ">=1.0",
+                    "symfony/console": "^6.0",
+                }
+            }
+        )
+        pkgs = parse_composer_json(content, "composer.json")
+        assert [p.name for p in pkgs] == ["symfony/console"]
+
+    def test_invalid_json_returns_empty(self):
+        assert parse_composer_json("{not-json", "composer.json") == []
+
+
+class TestComposerLock:
+    def test_packages_and_packages_dev(self):
+        content = json.dumps(
+            {
+                "packages": [
+                    {"name": "laravel/framework", "version": "10.48.0"},
+                    {"name": "guzzlehttp/guzzle", "version": "7.8.1"},
+                ],
+                "packages-dev": [
+                    {"name": "phpunit/phpunit", "version": "10.5.0"},
+                ],
+            }
+        )
+        pkgs = parse_composer_lock(content, "composer.lock")
+        by_name = {p.name: p for p in pkgs}
+        assert by_name["laravel/framework"].version == "10.48.0"
+        assert by_name["laravel/framework"].is_dev is False
+        assert by_name["phpunit/phpunit"].is_dev is True
+        assert all(p.kind == "composer" for p in pkgs)
+
+    def test_invalid_json_returns_empty(self):
+        assert parse_composer_lock("not json", "composer.lock") == []
+
+    def test_skips_entries_missing_name_or_version(self):
+        content = json.dumps(
+            {
+                "packages": [
+                    {"name": "valid/pkg", "version": "1.0.0"},
+                    {"name": "missing-version"},
+                    {"version": "1.0.0"},
+                ]
+            }
+        )
+        pkgs = parse_composer_lock(content, "composer.lock")
+        assert [p.name for p in pkgs] == ["valid/pkg"]
+
+
 class TestDispatcher:
     @pytest.mark.parametrize(
         "path,expected",
@@ -185,6 +264,8 @@ class TestDispatcher:
             ("uv.lock", True),
             ("poetry.lock", True),
             ("package-lock.json", True),
+            ("composer.json", True),
+            ("backend/composer.lock", True),
             ("README.md", False),
             ("src/main.py", False),
         ],
@@ -287,11 +368,14 @@ class TestLockfileHeuristic:
         [
             ("uv.lock", True),
             ("poetry.lock", True),
+            ("composer.lock", True),
+            ("backend/composer.lock", True),
             ("package-lock.json", True),
             ("frontend/package-lock.json", True),
             ("pyproject.toml", False),
             ("package.json", False),
             ("requirements.txt", False),
+            ("composer.json", False),
         ],
     )
     def test_is_lockfile_path(self, path, expected):

--- a/tests/test_manifests.py
+++ b/tests/test_manifests.py
@@ -199,8 +199,12 @@ class TestComposerJson:
             {
                 "require": {
                     "php": ">=8.1",
+                    "php-64bit": ">=8.1",
                     "ext-json": "*",
                     "lib-openssl": ">=1.0",
+                    "composer-plugin-api": "^2.0",
+                    "composer-runtime-api": "^2.0",
+                    "hhvm": "^4.0",
                     "symfony/console": "^6.0",
                 }
             }

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -44,6 +44,7 @@ class TestEcosystemMapping:
             ("pip", "PyPI"),
             ("go", "Go"),
             ("rust", "crates.io"),
+            ("composer", "Packagist"),
             ("docker", None),
             ("unknown", None),
         ],

--- a/ui/mira/src/components/dashboard/dependencies-table.tsx
+++ b/ui/mira/src/components/dashboard/dependencies-table.tsx
@@ -27,6 +27,7 @@ const KIND_LABELS: Record<string, string> = {
   docker: "Docker",
   go: "Go",
   rust: "Cargo",
+  composer: "Composer",
 }
 
 function kindBadgeVariant(kind: string) {
@@ -38,6 +39,7 @@ function kindBadgeVariant(kind: string) {
     docker: "text-blue-400 border-blue-500/40",
     go: "text-cyan-400 border-cyan-500/40",
     rust: "text-orange-400 border-orange-500/40",
+    composer: "text-purple-400 border-purple-500/40",
   }
   return colors[kind] ?? "text-muted-foreground border-border"
 }
@@ -108,7 +110,7 @@ export function DependenciesTable({
         <p className="text-sm font-medium">No packages detected</p>
         <p className="mt-1 text-sm text-muted-foreground">
           Mira parses package.json, requirements.txt, pyproject.toml, go.mod,
-          and Dockerfile. Re-index this repo to populate.
+          composer.json, and Dockerfile. Re-index this repo to populate.
         </p>
       </div>
     )

--- a/ui/mira/src/pages/repo-detail.tsx
+++ b/ui/mira/src/pages/repo-detail.tsx
@@ -470,7 +470,7 @@ export function RepoDetailPage() {
               <CardTitle>Dependencies</CardTitle>
               <CardDescription>
                 Packages declared in package.json, requirements.txt,
-                pyproject.toml, go.mod, and Dockerfile.
+                pyproject.toml, go.mod, composer.json, and Dockerfile.
               </CardDescription>
             </CardHeader>
             <CardContent>


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [ ] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`) - **This seemed to pick up existing issues which were unrelated to my changes**
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary

- Added parsing for PHP Composer manifests (`composer.json`) and lockfiles (`composer.lock`).
- Enabled vulnerability scanning for Composer packages by mapping them to the OSV.dev `Packagist` ecosystem.
- Updated dashboard UI to include Composer badge with appropriate colour.

## Test plan

Manual verification:

- Seeded a local SQLite index with fake Composer packages and vulnerabilities.
- Confirmed the repo detail Dependencies tab renders Composer packages with the new badge and shows vulnerabilities.
- Verified the API returns Composer packages at `/api/repos/{owner}/{repo}/packages`.

## Notes for reviewers

- `uv run mypy src/mira/ --ignore-missing-imports` - Returned a lot of errors that were unrelated to my changes
- I wasn't able to fully get the app running with a live repo so I seeded a lot of the data locally