### PR TITLE
Fix index parsing

### DIFF
--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -366,41 +366,89 @@ def _strip_code_fences(raw: str) -> str:
     return text.strip()
 
 
+_VALID_JSON_ESCAPES = set('"\\/bfnrtu')
+
+
+def _escape_lone_backslashes(text: str) -> str:
+    """Escape backslashes that aren't part of a valid JSON escape sequence.
+
+    Models like DeepSeek mention PHP namespaces (``\\App\\Models``) or Windows
+    paths in summaries and emit the backslashes unescaped, so json.loads bails
+    with "Invalid \\escape". We walk string literals and double any backslash
+    that doesn't start a real escape, consuming valid escapes as pairs so an
+    escaped quote is never mistaken for a string boundary.
+    """
+    out: list[str] = []
+    in_string = False
+    i, n = 0, len(text)
+    while i < n:
+        ch = text[i]
+        if not in_string:
+            if ch == '"':
+                in_string = True
+            out.append(ch)
+            i += 1
+        elif ch == "\\":
+            nxt = text[i + 1] if i + 1 < n else ""
+            if nxt in _VALID_JSON_ESCAPES:
+                out.append(ch + nxt)
+                i += 2
+            else:
+                out.append("\\\\")
+                i += 1
+        else:
+            if ch == '"':
+                in_string = False
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
 def _parse_summarize_response(raw: str) -> list[dict[str, Any]]:
     """Parse the LLM response from the summarization prompt."""
     text = strip_think_blocks(_strip_code_fences(raw))
-    try:
-        data = json.loads(text)
-        if isinstance(data, dict) and "files" in data:
-            result: list[dict[str, Any]] = data["files"]
-            return result
-        if isinstance(data, list):
-            return list(data)
-        logger.warning(
-            "Summarization response has unexpected structure (keys: %s): %s",
-            list(data.keys()) if isinstance(data, dict) else type(data).__name__,
-            text[:200],
-        )
+    # strict=False tolerates raw newlines in strings; a repair pass for lone
+    # backslashes salvages otherwise-valid responses from models that don't
+    # escape paths/namespaces, so one bad string doesn't drop the whole batch.
+    data: Any = None
+    for candidate in (text, _escape_lone_backslashes(text)):
+        try:
+            data = json.loads(candidate, strict=False)
+            break
+        except (json.JSONDecodeError, TypeError):
+            continue
+    else:
+        logger.warning("Failed to parse summarization response: %s", raw[:300])
         return []
-    except (json.JSONDecodeError, TypeError) as exc:
-        logger.warning(
-            "Failed to parse summarization response (%s): %s",
-            exc,
-            raw[:300],
-        )
-        return []
+
+    if isinstance(data, dict) and "files" in data:
+        result: list[dict[str, Any]] = data["files"]
+        return result
+    if isinstance(data, list):
+        return list(data)
+    logger.warning(
+        "Summarization response has unexpected structure (keys: %s): %s",
+        list(data.keys()) if isinstance(data, dict) else type(data).__name__,
+        text[:200],
+    )
+    return []
 
 
 def _build_file_summary(path: str, content: str, file_data: dict[str, Any]) -> FileSummary:
     """Convert LLM output for a single file into a FileSummary."""
     symbols = []
     for sym in file_data.get("symbols", []):
+        name = sym.get("name") or ""
+        if not name:
+            continue
+        # `or ""` not `get(key, "")` — models emit explicit nulls that the
+        # default wouldn't catch, and these columns are NOT NULL.
         symbols.append(
             SymbolInfo(
-                name=sym.get("name", ""),
-                kind=sym.get("kind", "function"),
-                signature=sym.get("signature", ""),
-                description=sym.get("description", ""),
+                name=name,
+                kind=sym.get("kind") or "function",
+                signature=sym.get("signature") or "",
+                description=sym.get("description") or "",
             )
         )
 

--- a/tests/test_index_indexer.py
+++ b/tests/test_index_indexer.py
@@ -93,6 +93,18 @@ class TestParseSummarizeResponse:
         result = _parse_summarize_response(raw)
         assert len(result) == 1
 
+    def test_unescaped_backslash_in_string(self):
+        # DeepSeek-style: PHP namespace backslashes left unescaped (issue #96).
+        raw = '{"files": [{"path": "a.php", "summary": "Model in \\App\\Models namespace"}]}'
+        result = _parse_summarize_response(raw)
+        assert len(result) == 1
+        assert result[0]["summary"] == "Model in \\App\\Models namespace"
+
+    def test_valid_escapes_preserved(self):
+        raw = json.dumps({"files": [{"path": "a.py", "summary": 'tab\there "quote"'}]})
+        result = _parse_summarize_response(raw)
+        assert result[0]["summary"] == 'tab\there "quote"'
+
 
 class TestStripCodeFences:
     def test_json_fence(self):
@@ -141,6 +153,20 @@ class TestBuildFileSummary:
         assert fs.path == "empty.py"
         assert fs.symbols == []
         assert fs.imports == []
+
+    def test_null_symbol_fields_coerced(self):
+        # Models emit explicit nulls; columns are NOT NULL (issue #96).
+        data = {"symbols": [{"name": "foo", "kind": None, "signature": None, "description": None}]}
+        fs = _build_file_summary("a.py", "content", data)
+        assert len(fs.symbols) == 1
+        assert fs.symbols[0].kind == "function"
+        assert fs.symbols[0].signature == ""
+        assert fs.symbols[0].description == ""
+
+    def test_nameless_symbol_skipped(self):
+        data = {"symbols": [{"name": None, "signature": "x"}, {"name": "ok"}]}
+        fs = _build_file_summary("a.py", "content", data)
+        assert [s.name for s in fs.symbols] == ["ok"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary
- Fixes indexing parsing errors https://github.com/miracodeai/mira/issues/96

## Test plan

Fully tested via test cases & CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
