### PR TITLE
Fix exclude files option on indexing

### DIFF
--- a/src/mira/github_app/index_handlers.py
+++ b/src/mira/github_app/index_handlers.py
@@ -41,6 +41,7 @@ async def _count_files_for_repos(
         return
 
     app_db = _get_app_db()
+    exclude_patterns = load_config().filter.exclude_patterns
     for repo_info in repos:
         full_name = repo_info.get("full_name", "")
         if "/" not in full_name:
@@ -48,7 +49,7 @@ async def _count_files_for_repos(
         owner, repo = full_name.split("/", 1)
         try:
             tree_paths = await _fetch_repo_tree(owner, repo, token)
-            indexable = [p for p in tree_paths if _should_index(p)]
+            indexable = [p for p in tree_paths if _should_index(p, exclude_patterns)]
             app_db.set_repo_file_count(owner, repo, len(indexable))
             logger.info("Counted %d indexable files in %s", len(indexable), full_name)
         except Exception as exc:

--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -152,14 +152,21 @@ def _build_batches(file_pairs: list[tuple[str, str]]) -> list[list[tuple[str, st
     return batches
 
 
-def _should_index(path: str) -> bool:
-    """Check if a file path should be indexed."""
+def _should_index(path: str, exclude_patterns: list[str] | None = None) -> bool:
+    """Check if a file path should be indexed.
+
+    ``exclude_patterns`` are the user's ``filter.exclude_patterns`` globs; they
+    layer on top of the built-in skip list so indexing honours the same
+    exclusions as review (e.g. committed vendor dirs that bloat indexing cost).
+    """
     filename = os.path.basename(path)
-    # Check skip patterns
     for pattern in _SKIP_PATTERNS:
         if fnmatch(path, pattern) or fnmatch(filename, pattern):
             return False
-    # Check extension
+    if exclude_patterns:
+        for pattern in exclude_patterns:
+            if fnmatch(path, pattern) or fnmatch(filename, pattern):
+                return False
     _, ext = os.path.splitext(filename)
     return ext.lower() in _INDEXABLE_EXTENSIONS
 
@@ -574,7 +581,7 @@ async def index_repo(
 
     # Fetch repo tree
     tree_paths = await _fetch_repo_tree(owner, repo, token, branch)
-    indexable = [p for p in tree_paths if _should_index(p)]
+    indexable = [p for p in tree_paths if _should_index(p, config.filter.exclude_patterns)]
     logger.info(
         "Found %d indexable files in %s/%s (out of %d total)",
         len(indexable),
@@ -990,7 +997,7 @@ async def index_diff(
         return 0
 
     # Filter to indexable files
-    to_index = [p for p in changed_paths if _should_index(p)]
+    to_index = [p for p in changed_paths if _should_index(p, config.filter.exclude_patterns)]
     if not to_index:
         return 0
 

--- a/tests/test_index_indexer.py
+++ b/tests/test_index_indexer.py
@@ -51,6 +51,15 @@ class TestShouldIndex:
     def test_unknown_extension(self):
         assert _should_index("README.md") is False
 
+    def test_user_exclude_pattern(self):
+        assert _should_index("app/generated/api.py", ["*/generated/*"]) is False
+
+    def test_user_exclude_glob_by_extension(self):
+        assert _should_index("src/schema.proto", ["*.proto"]) is False
+
+    def test_user_exclude_does_not_affect_others(self):
+        assert _should_index("src/main.py", ["*.proto"]) is True
+
 
 class TestContentHash:
     def test_deterministic(self):


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`


## Summary

- Fixes the custom exclude_files option not working on indexing step https://github.com/miracodeai/mira/issues/97

## Test plan

Fully tested & CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
