### PR TITLE
Add max file size setting for indexing

### DIFF
--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -161,6 +161,14 @@ class ReviewConfig(BaseModel):
     blast_radius: bool = True
 
 
+class IndexConfig(BaseModel):
+    # Skip indexing any file larger than this (bytes). Generated SDKs, vendored
+    # bundles and large test fixtures burn indexing tokens for little value.
+    # Defaults to the previous hard-coded tarball cap (1 MB) so it's a no-op
+    # until lowered; 0 disables the limit. In bytes, matching review.max_file_size.
+    max_file_size: int = Field(default=1024 * 1024, ge=0)
+
+
 class ProviderConfig(BaseModel):
     type: str = "github"
 
@@ -174,6 +182,7 @@ class MiraConfig(BaseModel):
     llm: LLMConfig = Field(default_factory=LLMConfig)
     filter: FilterConfig = Field(default_factory=FilterConfig)
     review: ReviewConfig = Field(default_factory=ReviewConfig)
+    index: IndexConfig = Field(default_factory=IndexConfig)
     provider: ProviderConfig = Field(default_factory=ProviderConfig)
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
 

--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -288,6 +288,7 @@ async def _fetch_repo_tarball(
     repo: str,
     token: str,
     ref: str = "main",
+    max_file_size: int = 1_048_576,
 ) -> dict[str, str] | None:
     """Download the entire repo as a tarball and return ``{path: content}``.
 
@@ -297,7 +298,8 @@ async def _fetch_repo_tarball(
     our previous concurrency cap.
 
     Returns ``None`` on failure (caller should fall back to per-file fetch).
-    Files larger than 1 MB or undecodable as UTF-8 are skipped silently.
+    Files larger than ``max_file_size`` bytes or undecodable as UTF-8 are
+    skipped silently.
     """
     url = f"https://api.github.com/repos/{owner}/{repo}/tarball/{ref}"
     headers = {
@@ -327,7 +329,7 @@ async def _fetch_repo_tarball(
             for member in tf:
                 if not member.isfile():
                     continue
-                if member.size > 1_048_576:  # 1 MB
+                if max_file_size and member.size > max_file_size:
                     continue
                 # Tarballs are wrapped in a top-level dir like "owner-repo-{sha}/".
                 # Strip that prefix so paths match the GitHub tree paths.
@@ -594,8 +596,11 @@ async def index_repo(
     # first — one request gets every file, ~10x faster than per-file fetches
     # for typical repos. Fall back to the per-file API if the tarball fails
     # (e.g. for a >100 MB repo where GitHub may reject the request).
+    max_file_size = config.index.max_file_size
     fetch_sem = asyncio.Semaphore(_FILE_FETCH_SEMAPHORE)
-    tarball: dict[str, str] | None = await _fetch_repo_tarball(owner, repo, token, ref=branch)
+    tarball: dict[str, str] | None = await _fetch_repo_tarball(
+        owner, repo, token, ref=branch, max_file_size=max_file_size
+    )
 
     if tarball is not None:
         contents: list[str | None] = [tarball.get(p) for p in indexable]
@@ -610,8 +615,13 @@ async def index_repo(
     # Filter out failed fetches and compute hashes for staleness check
     file_pairs: list[tuple[str, str]] = []
     trivial_pairs: list[tuple[str, str]] = []
+    skipped_large = 0
     for path, content in zip(indexable, contents, strict=False):
         if content is None:
+            continue
+        # Catches the per-file fetch path, which the tarball cap doesn't cover.
+        if max_file_size and len(content.encode("utf-8")) > max_file_size:
+            skipped_large += 1
             continue
         if not full:
             existing = store.get_summary(path)
@@ -626,10 +636,11 @@ async def index_repo(
             file_pairs.append((path, content))
 
     logger.info(
-        "Indexing %d files (%d trivial / skipped %d unchanged)",
+        "Indexing %d files (%d trivial / skipped %d unchanged / %d over size limit)",
         len(file_pairs) + len(trivial_pairs),
         len(trivial_pairs),
-        len(indexable) - len(file_pairs) - len(trivial_pairs),
+        len(indexable) - len(file_pairs) - len(trivial_pairs) - skipped_large,
+        skipped_large,
     )
 
     # Clean up deleted files
@@ -1009,10 +1020,14 @@ async def index_diff(
     ]
     contents = await asyncio.gather(*tasks)
 
+    max_file_size = config.index.max_file_size
     file_pairs: list[tuple[str, str]] = []
     for path, content in zip(to_index, contents, strict=False):
-        if content is not None:
-            file_pairs.append((path, content))
+        if content is None:
+            continue
+        if max_file_size and len(content.encode("utf-8")) > max_file_size:
+            continue
+        file_pairs.append((path, content))
 
     # Summarize changed files
     llm_sem = asyncio.Semaphore(_LLM_SEMAPHORE)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,7 @@ class TestLoadConfig:
         assert config.review.focus_only_on_problems is False
         assert config.review.walkthrough is True
         assert config.review.walkthrough_sequence_diagram is True
+        assert config.index.max_file_size == 1_048_576
 
     def test_focus_only_on_problems_override(self, sample_config_path: Path):
         config = load_config(

--- a/tests/test_index_indexer.py
+++ b/tests/test_index_indexer.py
@@ -243,6 +243,36 @@ class TestIndexRepo:
         assert summary.summary == "Main entry point."
         store.close()
 
+    async def test_skips_files_over_size_limit(self, tmp_path):
+        """Files above index.max_file_size are dropped before summarization."""
+        store = IndexStore(str(tmp_path / "test.db"))
+        mock_llm = AsyncMock()
+        mock_llm.complete = AsyncMock()
+
+        config = MiraConfig()
+        config.index.max_file_size = 1_000
+        big_content = "print('x')\n" * 500  # ~5 KB, over the 1 KB limit
+
+        with (
+            patch("mira.index.indexer._fetch_repo_tree", return_value=["src/main.py"]),
+            patch(
+                "mira.index.indexer._fetch_repo_tarball", return_value={"src/main.py": big_content}
+            ),
+        ):
+            count = await index_repo(
+                owner="test",
+                repo="repo",
+                token="fake-token",
+                config=config,
+                store=store,
+                llm=mock_llm,
+                full=True,
+            )
+
+        assert count == 0
+        mock_llm.complete.assert_not_called()
+        store.close()
+
 
 @pytest.mark.asyncio
 class TestIndexDiff:

--- a/tests/test_indexing_cancel.py
+++ b/tests/test_indexing_cancel.py
@@ -79,7 +79,7 @@ async def test_index_repo_raises_on_cancel(tmp_path, monkeypatch):
     async def fake_fetch(owner, repo, path, token, ref, semaphore):
         return f"# contents of {path}\n{_content_pad}"
 
-    async def fake_tarball(owner, repo, token, ref="main"):
+    async def fake_tarball(owner, repo, token, ref="main", max_file_size=1_048_576):
         return {p: f"# contents of {p}\n{_content_pad}" for p in ["a.py", "b.py", "c.py", "d.py"]}
 
     async def fake_summarize_batch(batch, llm, sem):


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`
 
## Summary

- Adds a new setting for max file size within indexing step https://github.com/miracodeai/mira/issues/98

## Test plan

Full test cases & CI 

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
