### PR TITLE
fix(github_app): resolve default branch before counting files

### DIFF
--- a/src/mira/github_app/index_handlers.py
+++ b/src/mira/github_app/index_handlers.py
@@ -8,7 +8,13 @@ from typing import Any
 
 from mira.config import load_config
 from mira.github_app.auth import GitHubAppAuth
-from mira.index.indexer import _fetch_repo_tree, _should_index, index_diff, index_repo
+from mira.index.indexer import (
+    _fetch_default_branch,
+    _fetch_repo_tree,
+    _should_index,
+    index_diff,
+    index_repo,
+)
 from mira.index.store import IndexStore
 from mira.llm import create_llm
 
@@ -48,7 +54,10 @@ async def _count_files_for_repos(
             continue
         owner, repo = full_name.split("/", 1)
         try:
-            tree_paths = await _fetch_repo_tree(owner, repo, token)
+            # Resolve the repo's actual default branch — hardcoding "main"
+            # 404s on repos whose default is "master" (or anything else).
+            branch = await _fetch_default_branch(owner, repo, token)
+            tree_paths = await _fetch_repo_tree(owner, repo, token, branch)
             indexable = [p for p in tree_paths if _should_index(p, exclude_patterns)]
             app_db.set_repo_file_count(owner, repo, len(indexable))
             logger.info("Counted %d indexable files in %s", len(indexable), full_name)

--- a/tests/test_count_files_for_repos.py
+++ b/tests/test_count_files_for_repos.py
@@ -1,0 +1,94 @@
+"""Tests for _count_files_for_repos and the webhook paths that call it.
+
+Regression for https://github.com/miracodeai/mira/issues/122 — file-count
+must use the repo's actual default branch, not a hardcoded ``"main"``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mira.github_app.index_handlers import _count_files_for_repos
+
+
+@pytest.mark.asyncio
+class TestCountFilesForReposResolvesDefaultBranch:
+    async def test_uses_resolved_branch_not_main(self):
+        """When the repo's default branch is ``master``, the tree fetch must
+        be issued against ``master`` — otherwise GitHub returns 404 and the
+        file count silently fails.
+        """
+        app_auth = MagicMock()
+        app_auth.get_installation_token = AsyncMock(return_value="fake-token")
+
+        app_db = MagicMock()
+        app_db.set_repo_file_count = MagicMock()
+
+        repos = [{"full_name": "acme/widget", "private": False}]
+
+        with (
+            patch(
+                "mira.github_app.index_handlers._fetch_default_branch",
+                new=AsyncMock(return_value="master"),
+            ) as mock_branch,
+            patch(
+                "mira.github_app.index_handlers._fetch_repo_tree",
+                new=AsyncMock(return_value=["src/foo.py", "README.md"]),
+            ) as mock_tree,
+            patch("mira.github_app.index_handlers._get_app_db", return_value=app_db),
+            patch("mira.github_app.index_handlers.load_config"),
+        ):
+            await _count_files_for_repos(app_auth, installation_id=42, repos=repos)
+
+        mock_branch.assert_awaited_once_with("acme", "widget", "fake-token")
+        # Tree fetch must use the resolved branch, not the default "main".
+        mock_tree.assert_awaited_once()
+        args, kwargs = mock_tree.call_args
+        # Args can be positional or keyword; both shapes should pass "master".
+        branch = kwargs.get("branch") if "branch" in kwargs else args[3]
+        assert branch == "master"
+        app_db.set_repo_file_count.assert_called_once_with("acme", "widget", 1)
+
+    async def test_resolves_branch_per_repo(self):
+        """Each repo should have its own default branch resolved."""
+        app_auth = MagicMock()
+        app_auth.get_installation_token = AsyncMock(return_value="fake-token")
+
+        app_db = MagicMock()
+        app_db.set_repo_file_count = MagicMock()
+
+        repos = [
+            {"full_name": "acme/on-main", "private": False},
+            {"full_name": "acme/on-master", "private": False},
+        ]
+
+        async def fake_branch(owner, repo, token):
+            return "main" if repo == "on-main" else "master"
+
+        async def fake_tree(owner, repo, token, branch="main"):
+            return [f"{repo}/file.py"]
+
+        with (
+            patch(
+                "mira.github_app.index_handlers._fetch_default_branch",
+                new=AsyncMock(side_effect=fake_branch),
+            ),
+            patch(
+                "mira.github_app.index_handlers._fetch_repo_tree",
+                new=AsyncMock(side_effect=fake_tree),
+            ) as mock_tree,
+            patch("mira.github_app.index_handlers._get_app_db", return_value=app_db),
+            patch("mira.github_app.index_handlers.load_config"),
+        ):
+            await _count_files_for_repos(app_auth, installation_id=42, repos=repos)
+
+        # Branches passed to the tree call, in order, should match the per-repo
+        # default branch each repo actually reports.
+        assert mock_tree.await_count == 2
+        branches_used = [
+            (call.kwargs.get("branch") if "branch" in call.kwargs else call.args[3])
+            for call in mock_tree.await_args_list
+        ]
+        assert branches_used == ["main", "master"]


### PR DESCRIPTION
## Summary

`_count_files_for_repos()` called `_fetch_repo_tree()` without resolving the repo's default branch, so it always queried `git/trees/main`. Repos whose default branch is not `main` (e.g. `master`) would 404 and log `Failed to count files for <owner>/<repo>` on install and at every server startup.

## Change

Mirror the same pattern `index_repo()` already uses: resolve the branch via `_fetch_default_branch`, then pass it to `_fetch_repo_tree`.

```python
branch = await _fetch_default_branch(owner, repo, token)
tree_paths = await _fetch_repo_tree(owner, repo, token, branch)
```

Also adds `_fetch_default_branch` to the imports.

## Tests

`tests/test_count_files_for_repos.py` — two regression tests:
1. Single repo with `master` default branch — asserts the tree fetch is called with `branch="master"`, not `"main"`.
2. Multi-repo — asserts the per-repo default branch is resolved individually (one repo on `main`, one on `master`).

## Verification

- Full suite: 912 passed, 1 skipped, 31 deselected
- `ruff check`: clean
- `mypy` on changed file: no new errors

Fixes #122