### PR TITLE
fix: skip PR review if one is already in progress

### DIFF
--- a/src/mira/core/review_status.py
+++ b/src/mira/core/review_status.py
@@ -1,0 +1,106 @@
+"""In-memory review status tracker for active/in-flight reviews."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class ReviewStatus:
+    repo: str  # "owner/repo"
+    pr_number: int
+    pr_title: str
+    pr_url: str
+    status: str  # "reviewing", "completed", "failed"
+    started_at: float = 0.0
+    finished_at: float = 0.0
+    error: str = ""
+
+
+class ReviewTracker:
+    """Thread-safe tracker for active review jobs.
+
+    Completed/failed jobs older than _TTL_SECONDS are evicted from memory
+    since they are already persisted in the per-repo review events DB.
+    """
+
+    _TTL_SECONDS = 3600  # 1 hour
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._jobs: dict[str, ReviewStatus] = {}
+
+    def _key(self, repo: str, pr_number: int) -> str:
+        return f"{repo}#{pr_number}"
+
+    def start(self, repo: str, pr_number: int, pr_title: str, pr_url: str) -> None:
+        with self._lock:
+            key = self._key(repo, pr_number)
+            self._jobs[key] = ReviewStatus(
+                repo=repo,
+                pr_number=pr_number,
+                pr_title=pr_title,
+                pr_url=pr_url,
+                status="reviewing",
+                started_at=time.time(),
+            )
+
+    def try_start(self, repo: str, pr_number: int, pr_title: str, pr_url: str) -> bool:
+        """Atomically check and register. Returns False if already reviewing."""
+        with self._lock:
+            self._evict_old()
+            key = self._key(repo, pr_number)
+            existing = self._jobs.get(key)
+            if existing and existing.status == "reviewing":
+                return False
+            self._jobs[key] = ReviewStatus(
+                repo=repo,
+                pr_number=pr_number,
+                pr_title=pr_title,
+                pr_url=pr_url,
+                status="reviewing",
+                started_at=time.time(),
+            )
+            return True
+
+    def complete(self, repo: str, pr_number: int) -> None:
+        with self._lock:
+            key = self._key(repo, pr_number)
+            job = self._jobs.get(key)
+            if job:
+                job.status = "completed"
+                job.finished_at = time.time()
+
+    def fail(self, repo: str, pr_number: int, error: str = "") -> None:
+        with self._lock:
+            key = self._key(repo, pr_number)
+            job = self._jobs.get(key)
+            if job:
+                job.status = "failed"
+                job.error = error
+                job.finished_at = time.time()
+
+    def get_active(self) -> list[ReviewStatus]:
+        with self._lock:
+            self._evict_old()
+            return [j for j in self._jobs.values() if j.status == "reviewing"]
+
+    def get_all(self) -> list[ReviewStatus]:
+        with self._lock:
+            self._evict_old()
+            return list(self._jobs.values())
+
+    def _evict_old(self) -> None:
+        now = time.time()
+        self._jobs = {
+            k: j
+            for k, j in self._jobs.items()
+            if j.status == "reviewing"
+            or j.finished_at == 0
+            or (now - j.finished_at) <= self._TTL_SECONDS
+        }
+
+
+tracker = ReviewTracker()

--- a/src/mira/platforms/forgejo/webhook.py
+++ b/src/mira/platforms/forgejo/webhook.py
@@ -148,7 +148,15 @@ async def handle_forgejo_pr(payload: dict[str, Any], auth: PlatformAuth, bot_nam
         token = await auth.get_token()
         provider = create_provider("forgejo", token)
         await run_pr_review(
-            provider, owner, repo_name, number, pr_url, is_private, bot_name, platform="forgejo"
+            provider,
+            owner,
+            repo_name,
+            number,
+            pr_url,
+            is_private,
+            bot_name,
+            platform="forgejo",
+            pr_title=pr.get("title", "") or "",
         )
     except Exception:
         logger.exception(

--- a/src/mira/platforms/github/webhook.py
+++ b/src/mira/platforms/github/webhook.py
@@ -594,7 +594,16 @@ async def handle_pull_request(
         # the review itself fails. Idempotent on every synchronize re-fire.
         _record_pr_contribution(payload, "pr_opened")
 
-        await run_pr_review(provider, owner, repo, number, pr_url, is_private, bot_name)
+        await run_pr_review(
+            provider,
+            owner,
+            repo,
+            number,
+            pr_url,
+            is_private,
+            bot_name,
+            pr_title=pr.get("title", ""),
+        )
     except Exception as exc:
         logger.exception("Error handling pull_request event")
         if pr_url:
@@ -628,7 +637,15 @@ async def handle_comment(
 
         provider = create_provider("github", token)
         await run_pr_command(
-            provider, owner, repo, number, pr_url, question, comment_user, bot_name
+            provider,
+            owner,
+            repo,
+            number,
+            pr_url,
+            question,
+            comment_user,
+            bot_name,
+            pr_title=payload["issue"].get("title", ""),
         )
     except Exception:
         logger.exception("Error handling comment event")

--- a/src/mira/platforms/gitlab/webhook.py
+++ b/src/mira/platforms/gitlab/webhook.py
@@ -117,7 +117,15 @@ async def handle_merge_request(payload: dict[str, Any], auth: PlatformAuth, bot_
         token = await auth.get_token()
         provider = create_provider("gitlab", token)
         await run_pr_review(
-            provider, owner, repo, iid, mr_url, is_private, bot_name, platform="gitlab"
+            provider,
+            owner,
+            repo,
+            iid,
+            mr_url,
+            is_private,
+            bot_name,
+            platform="gitlab",
+            pr_title=attrs.get("title", "") or "",
         )
     except Exception:
         logger.exception("Error handling GitLab merge_request event for %s/%s!%s", owner, repo, iid)

--- a/src/mira/platforms/handlers.py
+++ b/src/mira/platforms/handlers.py
@@ -13,6 +13,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from mira.config import load_config
 from mira.core.engine import ReviewEngine
+from mira.core.review_status import tracker as review_tracker
 from mira.dashboard.models_config import llm_config_for
 from mira.index.store import IndexStore
 from mira.llm import create_llm
@@ -82,6 +83,7 @@ async def run_pr_review(
     is_private: bool,
     bot_name: str,
     platform: str = "github",
+    pr_title: str = "",
 ) -> None:
     """Platform-neutral review core: review a PR/MR and post the result.
 
@@ -90,6 +92,13 @@ async def run_pr_review(
     every platform.
     """
     repo_full = f"{owner}/{repo}"
+
+    # Atomically claim the slot — avoids stacking redundant runs when
+    # two concurrent webhooks arrive. Returns False if already reviewing.
+    if not review_tracker.try_start(repo_full, number, pr_title, pr_url):
+        logger.info("Review already in progress for %s, skipping", pr_url)
+        return
+
     config = load_config()
     from mira.dashboard.models_config import llm_config_for
 
@@ -113,7 +122,12 @@ async def run_pr_review(
     is_indexed = bool(repo_record and repo_record.status == "ready")
 
     logger.info("Reviewing %s (indexed=%s)", pr_url, is_indexed)
-    result = await engine.review_pr(pr_url)
+    try:
+        result = await engine.review_pr(pr_url)
+        review_tracker.complete(repo_full, number)
+    except Exception as exc:
+        review_tracker.fail(repo_full, number, str(exc))
+        raise
 
     # The walkthrough comment already carries the "more accurate after indexing"
     # nudge for unindexed repos, so we don't post a separate note here — that
@@ -152,12 +166,14 @@ async def run_pr_command(
     actor: str,
     bot_name: str,
     platform: str = "github",
+    pr_title: str = "",
 ) -> None:
     """Platform-neutral handler for an @-mention command on a PR/MR.
 
     Dispatches help / review / review-rest / free-form Q&A through the provider
     and engine. Shared by the GitHub and GitLab comment handlers.
     """
+    repo_full = f"{owner}/{repo}"
     config = load_config()
     from mira.dashboard.models_config import llm_config_for
 
@@ -195,10 +211,18 @@ async def run_pr_command(
             indexing_llm=indexing_llm,
         )
         engine._review_only_paths = set(progress.skipped_paths)  # type: ignore[attr-defined]
+        if not review_tracker.try_start(repo_full, number, pr_title, pr_url):
+            logger.info("Review already in progress for %s, skipping", pr_url)
+            return
         logger.info(
             "review-rest on %s by @%s — %d file(s)", pr_url, actor, len(progress.skipped_paths)
         )
-        await engine.review_pr(pr_url)
+        try:
+            await engine.review_pr(pr_url)
+            review_tracker.complete(repo_full, number)
+        except Exception as exc:
+            review_tracker.fail(repo_full, number, str(exc))
+            raise
     elif is_review:
         engine = ReviewEngine(
             config=config,
@@ -207,8 +231,16 @@ async def run_pr_command(
             bot_name=bot_name,
             indexing_llm=indexing_llm,
         )
+        if not review_tracker.try_start(repo_full, number, pr_title, pr_url):
+            logger.info("Review already in progress for %s, skipping", pr_url)
+            return
         logger.info("Re-review triggered for %s by @%s", pr_url, actor)
-        await engine.review_pr(pr_url)
+        try:
+            await engine.review_pr(pr_url)
+            review_tracker.complete(repo_full, number)
+        except Exception as exc:
+            review_tracker.fail(repo_full, number, str(exc))
+            raise
     else:
         pr_info = await provider.get_pr_info(pr_url)
         diff_text = await provider.get_pr_diff(pr_info)


### PR DESCRIPTION
When a user pushes multiple commits in rapid succession, each push fires a
`synchronize` webhook event, stacking redundant review runs. This adds a check
at the top of `handle_pull_request` — if a review for the same PR is already
running, skip the new event. The next push will always trigger a fresh run.

Also wires `review_tracker.start/complete/fail` into the review handlers so the
dashboard accurately reflects in-progress status.

## Test Plan

- [x] `pytest tests/` — 962 passed
- [x] `ruff check` — clean