### PR TITLE
feat: add review_on_synchronize config to opt out of per-commit reviews

### DIFF
--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -226,6 +226,13 @@ class ReviewConfig(BaseModel):
     # resolves them (user-initiated reject/resolve replies still work).
     auto_resolve_conversations: bool = True
 
+    # Auto-review on every push (`synchronize` event). When False, Mira only
+    # reviews when the PR is opened or reopened. Subsequent commits are
+    # ignored unless you comment `@bot_name review` to trigger a manual pass.
+    # Disabling this saves tokens and reduces noise when you batch commits
+    # locally before pushing — only the final diff gets reviewed.
+    review_on_synchronize: bool = True
+
 
 class IndexConfig(BaseModel):
     # Skip indexing any file larger than this (bytes). Generated SDKs, vendored

--- a/src/mira/platforms/forgejo/webhook.py
+++ b/src/mira/platforms/forgejo/webhook.py
@@ -114,6 +114,15 @@ async def handle_forgejo_pr(payload: dict[str, Any], auth: PlatformAuth, bot_nam
     if action not in ("opened", "synchronized", "reopened"):
         return
 
+    # Same opt-out as GitHub's `synchronize`: new commits on an already open PR
+    # only get reviewed on an explicit `@bot review` comment.
+    if action == "synchronized" and not load_config().review.review_on_synchronize:
+        logger.info(
+            "Forgejo PR %s push skipped — review.review_on_synchronize is off",
+            payload.get("repository", {}).get("full_name", "?"),
+        )
+        return
+
     pr = payload.get("pull_request", {})
     repo = payload.get("repository", {})
     full_name = repo.get("full_name", "")

--- a/src/mira/platforms/github/webhook.py
+++ b/src/mira/platforms/github/webhook.py
@@ -477,6 +477,16 @@ async def dispatch_github_event(
             logger.debug("Ignoring pull_request event from self (%s)", sender)
             return "ignored"
 
+        # Opt out of per-push reviews: only open/reopen auto-review, later
+        # commits wait for an explicit `@bot review` comment.
+        if action == "synchronize" and not cfg.review.review_on_synchronize:
+            logger.info(
+                "PR %s#%s push skipped — review.review_on_synchronize is off",
+                payload.get("repository", {}).get("full_name", "?"),
+                payload.get("pull_request", {}).get("number", 0),
+            )
+            return "ignored"
+
         if author_is_filtered(sender, cfg.filter.allowed_authors, cfg.filter.blocked_authors):
             owner = payload.get("repository", {}).get("owner", {}).get("login", "?")
             repo = payload.get("repository", {}).get("name", "?")

--- a/src/mira/platforms/gitlab/webhook.py
+++ b/src/mira/platforms/gitlab/webhook.py
@@ -302,6 +302,14 @@ async def dispatch_gitlab_event(
             if author_is_filtered(actor, cfg.filter.allowed_authors, cfg.filter.blocked_authors):
                 logger.debug("MR skipped — author %s filtered by author filter", actor)
                 return "ignored"
+            # Same opt-out as GitHub's `synchronize`: new commits on an already
+            # open MR only get reviewed on an explicit `@bot review` comment.
+            if action == "update" and not cfg.review.review_on_synchronize:
+                logger.info(
+                    "MR !%s push skipped — review.review_on_synchronize is off",
+                    attrs.get("iid", 0),
+                )
+                return "ignored"
             background_tasks.add_task(handle_merge_request, payload, auth, bot_name)
             return "processing"
         if action == "merge":

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -11,7 +11,7 @@ import psycopg
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from mira.config import FilterConfig, MiraConfig
+from mira.config import FilterConfig, MiraConfig, ReviewConfig
 from mira.platforms.github.auth import GitHubAppAuth
 from mira.platforms.server import create_app
 
@@ -448,6 +448,45 @@ async def test_pr_opened_blocked_author_filtered(
     result = await _post(client, "pull_request", payload)
     assert result["status"] == "ignored"
     mock_handler.assert_not_awaited()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_pull_request", new_callable=AsyncMock)
+async def test_pr_synchronize_skipped_when_review_on_synchronize_off(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    mock_load_config.return_value = MiraConfig(review=ReviewConfig(review_on_synchronize=False))
+    payload = _make_pr_payload(action="synchronize")
+    payload["sender"] = {"login": "alice"}
+    result = await _post(client, "pull_request", payload)
+    assert result["status"] == "ignored"
+    mock_handler.assert_not_awaited()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_pull_request", new_callable=AsyncMock)
+async def test_pr_opened_still_reviewed_when_review_on_synchronize_off(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    mock_load_config.return_value = MiraConfig(review=ReviewConfig(review_on_synchronize=False))
+    payload = _make_pr_payload(action="opened")
+    payload["sender"] = {"login": "alice"}
+    result = await _post(client, "pull_request", payload)
+    assert result["status"] == "processing"
+    mock_handler.assert_awaited_once()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_pull_request", new_callable=AsyncMock)
+async def test_pr_synchronize_reviewed_by_default(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    mock_load_config.return_value = MiraConfig()
+    payload = _make_pr_payload(action="synchronize")
+    payload["sender"] = {"login": "alice"}
+    result = await _post(client, "pull_request", payload)
+    assert result["status"] == "processing"
+    mock_handler.assert_awaited_once()
 
 
 @patch("mira.platforms.github.webhook.load_config")

--- a/ui/mira/src/pages/settings.tsx
+++ b/ui/mira/src/pages/settings.tsx
@@ -468,6 +468,12 @@ export function SettingsPage() {
                   "Auto-resolve conversations",
                   "Automatically resolve bot review threads the LLM verifies as fixed on each review. Turn off to leave comments open until a human resolves them."
                 )}
+                {boolField(
+                  "review",
+                  "review_on_synchronize",
+                  "Review on every push",
+                  "When enabled, Mira reviews every new commit pushed to a PR. Disable to only review on PR open or manual @bot_name review."
+                )}
                 {numField(
                   "review",
                   "max_concurrent_chunks",


### PR DESCRIPTION
When working iteratively on a PR, every `git push` triggers a full review cycle — even if you're mid-work and plan to push more commits. This burns tokens, clutters the PR timeline with redundant reviews, and forces the team to wait for a review pass on every WIP push.

Adds `review.review_on_synchronize` (default `true`) to `ReviewConfig`. When set to `false`:

- Mira only auto-reviews on **PR open** and **reopen**
- Subsequent pushes (`synchronize` webhook) are silently skipped
- A manual `@bot_name review` comment still triggers a full review on demand

This gives teams a choice: get continuous feedback on every push, or stage your commits and request review only when ready.

### Changes

- `src/mira/config.py` — New `review_on_synchronize: bool` field with docstring
- `src/mira/github_app/webhooks.py` — Early return on `synchronize` action when disabled
- `ui/mira/src/pages/settings.tsx` — Toggle in Settings → Review behaviour overrides