### PR TITLE
Databricks AI Gateway compatibility for the OpenAI-compatible provider

### DIFF
--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -33,6 +33,10 @@ class LLMConfig(BaseModel):
     review_reasoning_effort: str | None = None
     reasoning_effort: str | None = None
     temperature: float = 0.2
+    # Some gateways reject the temperature parameter outright (e.g. Databricks-
+    # served Anthropic/reasoning models). Set false to omit it proactively and
+    # skip the wasted 400+retry. The provider also self-heals if left true.
+    send_temperature: bool = True
     max_tokens: int = 4096
     max_context_tokens: int = 120_000
     # Provider selection. "openai" uses any OpenAI-compatible endpoint (default).

--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -115,6 +115,8 @@ _SKIP_PATTERNS = [
 ]
 
 _FILE_FETCH_SEMAPHORE = 10
+
+
 # Concurrent LLM summarization batches per repo. The indexing model
 # typically handles 6-8 comfortably on OpenRouter; bumping from 3 nearly
 # halves file-phase wall time without changing quality. Env-overridable so

--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -120,7 +120,25 @@ _FILE_FETCH_SEMAPHORE = 10
 # halves file-phase wall time without changing quality. Env-overridable so
 # deployments against rate-limited gateways (e.g. Databricks FMAPI
 # output-tokens-per-minute tiers) can throttle indexing to avoid 429 storms.
-_LLM_SEMAPHORE = int(os.environ.get("MIRA_INDEX_LLM_CONCURRENCY") or 8)
+def _resolve_index_concurrency() -> int:
+    """Parse MIRA_INDEX_LLM_CONCURRENCY, guarding against bad values.
+
+    A raw int() would crash at import on a non-numeric value, and an
+    unclamped result lets 0 deadlock the semaphore (no slot ever acquired)
+    or a huge value remove the concurrency cap entirely (429 storms). Clamp
+    to [1, 64]; fall back to the default 8 on anything unparseable.
+    """
+    raw = os.environ.get("MIRA_INDEX_LLM_CONCURRENCY")
+    if not raw:
+        return 8
+    try:
+        return max(1, min(64, int(raw)))
+    except ValueError:
+        logger.warning("Invalid MIRA_INDEX_LLM_CONCURRENCY=%r; using default 8", raw)
+        return 8
+
+
+_LLM_SEMAPHORE = _resolve_index_concurrency()
 # Smaller batches → faster individual calls → better wave parallelism.
 # Empirically a 5-file batch with one large file bloated to 7k output
 # tokens and took 87s, dominating an entire indexing run. With 3-file

--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -117,8 +117,10 @@ _SKIP_PATTERNS = [
 _FILE_FETCH_SEMAPHORE = 10
 # Concurrent LLM summarization batches per repo. The indexing model
 # typically handles 6-8 comfortably on OpenRouter; bumping from 3 nearly
-# halves file-phase wall time without changing quality.
-_LLM_SEMAPHORE = 8
+# halves file-phase wall time without changing quality. Env-overridable so
+# deployments against rate-limited gateways (e.g. Databricks FMAPI
+# output-tokens-per-minute tiers) can throttle indexing to avoid 429 storms.
+_LLM_SEMAPHORE = int(os.environ.get("MIRA_INDEX_LLM_CONCURRENCY") or 8)
 # Smaller batches → faster individual calls → better wave parallelism.
 # Empirically a 5-file batch with one large file bloated to 7k output
 # tokens and took 87s, dominating an entire indexing run. With 3-file

--- a/src/mira/llm/provider.py
+++ b/src/mira/llm/provider.py
@@ -405,6 +405,9 @@ class LLMProvider:
         next unsupported param, so we heal in a short loop.
         """
         resp = await client.post(self._chat_url(), headers=self._build_headers(), json=body)
+        # One heal per rejected param; bounded by the 4 healable params above
+        # (tool_choice, response_format, reasoning, temperature). So this is up
+        # to 1 initial POST + 4 heal-retries = 5 requests in the worst case.
         for _ in range(4):
             if resp.status_code != 400:
                 return resp

--- a/src/mira/llm/provider.py
+++ b/src/mira/llm/provider.py
@@ -413,7 +413,9 @@ class LLMProvider:
                 logger.info("Model %s rejected forced tool_choice; retrying with auto", api_model)
                 self._no_forced_tool_choice.add(api_model)
                 body["tool_choice"] = "auto"
-            elif "response_format" in body and "response format" in text:
+            elif "response_format" in body and (
+                "response_format" in text or "response format" in text
+            ):
                 logger.info(
                     "Model %s rejected response_format=json_object; retrying without it", api_model
                 )
@@ -425,7 +427,11 @@ class LLMProvider:
                 body.pop("reasoning", None)
                 # reasoning had suppressed temperature; restore it unless the
                 # model also rejects temperature.
-                if temperature is not None and api_model not in self._no_temperature:
+                if (
+                    self.config.send_temperature
+                    and temperature is not None
+                    and api_model not in self._no_temperature
+                ):
                     body["temperature"] = temperature
             elif "temperature" in body and "temperature" in text:
                 logger.info("Model %s rejected temperature; retrying without it", api_model)
@@ -458,7 +464,7 @@ class LLMProvider:
             "messages": messages,
             "max_tokens": max_tokens if max_tokens is not None else self.config.max_tokens,
         }
-        if api_model not in self._no_temperature:
+        if self.config.send_temperature and api_model not in self._no_temperature:
             body["temperature"] = temp
         if json_mode and api_model not in self._no_response_format:
             body["response_format"] = {"type": "json_object"}
@@ -512,7 +518,7 @@ class LLMProvider:
             "tool_choice": "auto" if api_model in self._no_forced_tool_choice else forced_choice,
             "max_tokens": self.config.max_tokens,
         }
-        if api_model not in self._no_temperature:
+        if self.config.send_temperature and api_model not in self._no_temperature:
             body["temperature"] = temp
         self._apply_reasoning(body)
 
@@ -620,7 +626,7 @@ class LLMProvider:
             "tool_choice": "auto",
             "max_tokens": self.config.max_tokens,
         }
-        if api_model not in self._no_temperature:
+        if self.config.send_temperature and api_model not in self._no_temperature:
             body["temperature"] = temp
         self._apply_reasoning(body)
 

--- a/src/mira/llm/provider.py
+++ b/src/mira/llm/provider.py
@@ -337,6 +337,14 @@ class LLMProvider:
         # whatever model is selected); remembered so we drop it and review
         # without thinking rather than failing.
         self._no_reasoning: set[str] = set()
+        # Models that 400 on response_format=json_object (e.g. Anthropic models
+        # served via Databricks AI Gateway, which only support json_schema).
+        # Remembered so we drop response_format and rely on the prompt + the
+        # tolerant parser in utils.py instead of failing the call.
+        self._no_response_format: set[str] = set()
+        # Models that 400 on the temperature parameter (Databricks-served
+        # Anthropic/reasoning models reject it). Remembered so we omit it.
+        self._no_temperature: set[str] = set()
 
     def _chat_url(self) -> str:
         return f"{self.config.base_url.rstrip('/')}/chat/completions"
@@ -379,9 +387,58 @@ class LLMProvider:
         body["reasoning"] = {"effort": effort}
         body.pop("temperature", None)
 
+    async def _post_chat(
+        self,
+        client: httpx.AsyncClient,
+        body: dict,
+        api_model: str,
+        temperature: float | None,
+    ) -> httpx.Response:
+        """POST to the chat endpoint, self-healing on 400s for parameters that
+        some endpoints reject.
+
+        OpenRouter accepts all of these, so this is a no-op there. Other
+        endpoints (notably Databricks-served Anthropic models) reject a forced
+        ``tool_choice``, ``response_format=json_object``, OpenRouter-style
+        ``reasoning``, or even ``temperature``. Each rejected param is stripped
+        and remembered per-model so later calls skip it. Each 400 may reveal the
+        next unsupported param, so we heal in a short loop.
+        """
+        resp = await client.post(self._chat_url(), headers=self._build_headers(), json=body)
+        for _ in range(4):
+            if resp.status_code != 400:
+                return resp
+            text = resp.text.lower()
+            if body.get("tool_choice") not in (None, "auto") and "tool_choice" in text:
+                logger.info("Model %s rejected forced tool_choice; retrying with auto", api_model)
+                self._no_forced_tool_choice.add(api_model)
+                body["tool_choice"] = "auto"
+            elif "response_format" in body and "response format" in text:
+                logger.info(
+                    "Model %s rejected response_format=json_object; retrying without it", api_model
+                )
+                self._no_response_format.add(api_model)
+                body.pop("response_format", None)
+            elif "reasoning" in body and "reasoning" in text:
+                logger.info("Model %s rejected reasoning effort; retrying without it", api_model)
+                self._no_reasoning.add(api_model)
+                body.pop("reasoning", None)
+                # reasoning had suppressed temperature; restore it unless the
+                # model also rejects temperature.
+                if temperature is not None and api_model not in self._no_temperature:
+                    body["temperature"] = temperature
+            elif "temperature" in body and "temperature" in text:
+                logger.info("Model %s rejected temperature; retrying without it", api_model)
+                self._no_temperature.add(api_model)
+                body.pop("temperature", None)
+            else:
+                return resp  # 400 we don't know how to heal — let the caller raise
+            resp = await client.post(self._chat_url(), headers=self._build_headers(), json=body)
+        return resp
+
     @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=30),
+        stop=stop_after_attempt(6),
+        wait=wait_exponential(multiplier=1, min=2, max=60),
         retry=retry_if_exception_type(Exception),
         reraise=True,
     )
@@ -394,22 +451,21 @@ class LLMProvider:
         max_tokens: int | None = None,
     ) -> str:
         """Make a single LLM call with retries against the configured endpoint."""
+        api_model = _strip_model_prefix(model, self.config.base_url)
+        temp = temperature if temperature is not None else self.config.temperature
         body: dict = {
-            "model": _strip_model_prefix(model, self.config.base_url),
+            "model": api_model,
             "messages": messages,
-            "temperature": temperature if temperature is not None else self.config.temperature,
             "max_tokens": max_tokens if max_tokens is not None else self.config.max_tokens,
         }
-        if json_mode:
+        if api_model not in self._no_temperature:
+            body["temperature"] = temp
+        if json_mode and api_model not in self._no_response_format:
             body["response_format"] = {"type": "json_object"}
         self._apply_reasoning(body)
 
         async with httpx.AsyncClient(timeout=120) as client:
-            resp = await client.post(
-                self._chat_url(),
-                headers=self._build_headers(),
-                json=body,
-            )
+            resp = await self._post_chat(client, body, api_model, temp)
             if resp.status_code != 200:
                 raise LLMError(f"LLM API error {resp.status_code}: {resp.text}")
             data = resp.json()
@@ -424,8 +480,8 @@ class LLMProvider:
         return content
 
     @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=30),
+        stop=stop_after_attempt(6),
+        wait=wait_exponential(multiplier=1, min=2, max=60),
         retry=retry_if_exception_type(Exception),
         reraise=True,
     )
@@ -442,6 +498,7 @@ class LLMProvider:
         tool arguments as the JSON response.
         """
         api_model = _strip_model_prefix(model, self.config.base_url)
+        temp = temperature if temperature is not None else self.config.temperature
         forced_choice: dict | str = {
             "type": "function",
             "function": {"name": tools[0]["function"]["name"]},
@@ -451,39 +508,16 @@ class LLMProvider:
             "messages": messages,
             "tools": tools,
             # Force the one tool for structured args; models that reject a
-            # forced choice fall back to "auto" (handled on the 400 below).
+            # forced choice fall back to "auto" (handled by _post_chat).
             "tool_choice": "auto" if api_model in self._no_forced_tool_choice else forced_choice,
-            "temperature": temperature if temperature is not None else self.config.temperature,
             "max_tokens": self.config.max_tokens,
         }
+        if api_model not in self._no_temperature:
+            body["temperature"] = temp
         self._apply_reasoning(body)
 
         async with httpx.AsyncClient(timeout=120) as client:
-            resp = await client.post(
-                self._chat_url(),
-                headers=self._build_headers(),
-                json=body,
-            )
-            if (
-                resp.status_code == 400
-                and body["tool_choice"] != "auto"
-                and "tool_choice" in resp.text.lower()
-            ):
-                # Forced choice unsupported — remember it and let the model pick.
-                logger.info("Model %s rejected forced tool_choice; retrying with auto", api_model)
-                self._no_forced_tool_choice.add(api_model)
-                body["tool_choice"] = "auto"
-                resp = await client.post(self._chat_url(), headers=self._build_headers(), json=body)
-            if resp.status_code == 400 and "reasoning" in body and "reasoning" in resp.text.lower():
-                # Reasoning effort unsupported on this model/endpoint — drop it
-                # and review without thinking instead of failing the review.
-                logger.info("Model %s rejected reasoning effort; retrying without it", api_model)
-                self._no_reasoning.add(api_model)
-                body.pop("reasoning", None)
-                body["temperature"] = (
-                    temperature if temperature is not None else self.config.temperature
-                )
-                resp = await client.post(self._chat_url(), headers=self._build_headers(), json=body)
+            resp = await self._post_chat(client, body, api_model, temp)
             if resp.status_code != 200:
                 raise LLMError(f"LLM API error {resp.status_code}: {resp.text}")
             data = resp.json()
@@ -558,8 +592,8 @@ class LLMProvider:
             ) from primary_err
 
     @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=30),
+        stop=stop_after_attempt(6),
+        wait=wait_exponential(multiplier=1, min=2, max=60),
         retry=retry_if_exception_type(Exception),
         reraise=True,
     )
@@ -577,22 +611,21 @@ class LLMProvider:
         dispatch the calls and continue the conversation. This is what
         the agentic loop needs.
         """
+        api_model = _strip_model_prefix(model, self.config.base_url)
+        temp = temperature if temperature is not None else self.config.temperature
         body: dict = {
-            "model": _strip_model_prefix(model, self.config.base_url),
+            "model": api_model,
             "messages": messages,
             "tools": tools,
             "tool_choice": "auto",
-            "temperature": temperature if temperature is not None else self.config.temperature,
             "max_tokens": self.config.max_tokens,
         }
+        if api_model not in self._no_temperature:
+            body["temperature"] = temp
         self._apply_reasoning(body)
 
         async with httpx.AsyncClient(timeout=120) as client:
-            resp = await client.post(
-                self._chat_url(),
-                headers=self._build_headers(),
-                json=body,
-            )
+            resp = await self._post_chat(client, body, api_model, temp)
             if resp.status_code != 200:
                 raise LLMError(f"LLM API error {resp.status_code}: {resp.text}")
             data = resp.json()

--- a/tests/test_index_indexer.py
+++ b/tests/test_index_indexer.py
@@ -341,3 +341,43 @@ class TestIndexDiff:
 
         assert store.get_summary("old.py") is None
         store.close()
+
+
+class TestResolveIndexConcurrency:
+    """MIRA_INDEX_LLM_CONCURRENCY parsing must guard against bad values so a
+    misconfigured env can't deadlock the semaphore (0), crash at import
+    (non-int), or remove the concurrency cap (huge value). (Review findings
+    #1 config + #2 security.)
+    """
+
+    def _resolve(self, monkeypatch, value):
+        from mira.index.indexer import _resolve_index_concurrency
+
+        if value is None:
+            monkeypatch.delenv("MIRA_INDEX_LLM_CONCURRENCY", raising=False)
+        else:
+            monkeypatch.setenv("MIRA_INDEX_LLM_CONCURRENCY", value)
+        return _resolve_index_concurrency()
+
+    def test_unset_defaults_to_8(self, monkeypatch):
+        assert self._resolve(monkeypatch, None) == 8
+
+    def test_empty_string_defaults_to_8(self, monkeypatch):
+        assert self._resolve(monkeypatch, "") == 8
+
+    def test_valid_value_passes_through(self, monkeypatch):
+        assert self._resolve(monkeypatch, "4") == 4
+
+    def test_zero_is_clamped_to_one(self, monkeypatch):
+        # Semaphore(0) would deadlock indexing — must clamp up to 1.
+        assert self._resolve(monkeypatch, "0") == 1
+
+    def test_negative_is_clamped_to_one(self, monkeypatch):
+        assert self._resolve(monkeypatch, "-5") == 1
+
+    def test_huge_value_is_capped(self, monkeypatch):
+        assert self._resolve(monkeypatch, "100000") == 64
+
+    def test_non_integer_falls_back_to_8(self, monkeypatch):
+        # Must not raise ValueError at import on garbage input.
+        assert self._resolve(monkeypatch, "two") == 8

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -577,7 +577,9 @@ class TestParam400SelfHeal:
         config = LLMConfig(model="databricks-claude-opus-4-8")
         provider = LLMProvider(config)
 
-        err = self._err("Model us.anthropic.claude-opus-4-8 does not support the temperature parameter.")
+        err = self._err(
+            "Model us.anthropic.claude-opus-4-8 does not support the temperature parameter."
+        )
         ok = _mock_httpx_response(_make_response_json("done"))
         bodies, responses = [], [err, ok]
 
@@ -592,9 +594,7 @@ class TestParam400SelfHeal:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            result = await provider.complete(
-                [{"role": "user", "content": "hi"}], json_mode=False
-            )
+            result = await provider.complete([{"role": "user", "content": "hi"}], json_mode=False)
 
         assert result == "done"
         assert len(bodies) == 2

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -508,3 +508,138 @@ class TestReasoningFallback:
 
         assert len(posts) == 1  # no wasted reasoning attempt
         assert "reasoning" not in posts[0].kwargs["json"]
+
+
+class TestParam400SelfHeal:
+    """The provider self-heals on 400s for params some gateways reject
+    (e.g. Databricks-served Anthropic models), stripping the offending
+    param and remembering it per-model. OpenRouter never 400s on these,
+    so this behavior is additive and backward compatible.
+    """
+
+    def _err(self, message: str):
+        # json.dumps of this dict becomes resp.text, which the heal scans.
+        return _mock_httpx_response({"error_code": "BAD", "message": message}, status_code=400)
+
+    @pytest.mark.asyncio
+    async def test_response_format_400_is_healed_and_remembered(self):
+        config = LLMConfig(model="databricks-claude-sonnet-4-6")
+        provider = LLMProvider(config)
+
+        err = self._err("Response format type json_object is not supported for this model.")
+        ok = _mock_httpx_response(_make_response_json("{}"))
+        bodies, responses = [], [err, ok]
+
+        async def _record(*args, **kwargs):
+            # _post_chat mutates the same body dict across retries, so snapshot
+            # top-level keys at call time rather than reading call_args later.
+            bodies.append(dict(kwargs.get("json") or {}))
+            return responses.pop(0)
+
+        with patch("mira.llm.provider.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=_record)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await provider.complete([{"role": "user", "content": "hi"}], json_mode=True)
+
+        assert result == "{}"
+        assert len(bodies) == 2  # one 400, one healed retry
+        assert "response_format" in bodies[0]  # first attempt sent it
+        assert "response_format" not in bodies[1]  # retry dropped it
+        assert "databricks-claude-sonnet-4-6" in provider._no_response_format
+
+    @pytest.mark.asyncio
+    async def test_response_format_400_matches_underscore_phrasing(self):
+        # Finding #3: heal must match both "response format" and "response_format".
+        config = LLMConfig(model="some-model")
+        provider = LLMProvider(config)
+
+        err = self._err("unsupported parameter: response_format")  # underscore form
+        ok = _mock_httpx_response(_make_response_json("{}"))
+
+        with patch("mira.llm.provider.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=[err, ok])
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await provider.complete([{"role": "user", "content": "hi"}], json_mode=True)
+
+        assert result == "{}"
+        assert "some-model" in provider._no_response_format
+
+    @pytest.mark.asyncio
+    async def test_temperature_400_is_healed_and_remembered(self):
+        config = LLMConfig(model="databricks-claude-opus-4-8")
+        provider = LLMProvider(config)
+
+        err = self._err("Model us.anthropic.claude-opus-4-8 does not support the temperature parameter.")
+        ok = _mock_httpx_response(_make_response_json("done"))
+        bodies, responses = [], [err, ok]
+
+        async def _record(*args, **kwargs):
+            bodies.append(dict(kwargs.get("json") or {}))
+            return responses.pop(0)
+
+        with patch("mira.llm.provider.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(side_effect=_record)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            result = await provider.complete(
+                [{"role": "user", "content": "hi"}], json_mode=False
+            )
+
+        assert result == "done"
+        assert len(bodies) == 2
+        assert "temperature" in bodies[0]
+        assert "temperature" not in bodies[1]
+        assert "databricks-claude-opus-4-8" in provider._no_temperature
+
+    @pytest.mark.asyncio
+    async def test_send_temperature_false_omits_it_on_first_call(self):
+        # Proactive opt-out: no 400 needed, temperature never sent.
+        config = LLMConfig(model="databricks-claude-opus-4-8", send_temperature=False)
+        provider = LLMProvider(config)
+
+        ok = _mock_httpx_response(_make_response_json("ok"))
+
+        with patch("mira.llm.provider.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=ok)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await provider.complete([{"role": "user", "content": "hi"}])
+
+        posts = mock_client.post.call_args_list
+        assert len(posts) == 1  # no wasted 400/retry
+        assert "temperature" not in posts[0].kwargs["json"]
+
+    @pytest.mark.asyncio
+    async def test_default_path_still_sends_temperature_and_response_format(self):
+        # Backward-compat guard: default config (OpenRouter-style) is unchanged.
+        config = LLMConfig(model="anthropic/claude-sonnet-4-6")
+        provider = LLMProvider(config)
+
+        ok = _mock_httpx_response(_make_response_json("{}"))
+
+        with patch("mira.llm.provider.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post = AsyncMock(return_value=ok)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await provider.complete([{"role": "user", "content": "hi"}], json_mode=True)
+
+        body = mock_client.post.call_args_list[0].kwargs["json"]
+        assert body["temperature"] == 0.2
+        assert body["response_format"] == {"type": "json_object"}


### PR DESCRIPTION
## Summary

Makes Mira's `provider: openai` path work against the **Databricks AI Gateway** (the `mlflow/v1/chat/completions` endpoint) with Databricks-served Claude models, with no impact on the OpenRouter/OpenAI/Ollama paths.

Databricks-served Anthropic models reject several parameters Mira always sends, and the workspace FMAPI rate limit is easily exceeded by the default indexing concurrency. This PR addresses all three, plus tests.

## Changes

**`provider.py` — centralize 400-recovery (`_post_chat`)**
All three call paths (`_call_llm`, `_call_llm_with_tools`, `_call_llm_agentic`) now share one helper that, on a 400, strips the offending parameter, remembers it per-model, and retries. Covers the existing `tool_choice`/`reasoning` heals plus two new ones:
- `response_format=json_object` → Databricks Anthropic models only support `json_schema`; we drop it and rely on the prompt + the existing tolerant parser. The match handles both `"response_format"` and `"response format"` phrasings.
- `temperature` → rejected by these models; stripped and remembered.

Retry resilience bumped 3→6 attempts / 30s→60s ceiling to absorb per-minute rate limits.

**`config.py` / `provider.py` — `llm.send_temperature` (default `true`)**
Lets a deployment omit `temperature` proactively for gateways that reject it, skipping the wasted 400+retry. Self-heal remains as the safety net.

**`indexer.py` — `MIRA_INDEX_LLM_CONCURRENCY`**
Env-overridable indexing concurrency (default 8) so rate-limited gateways can throttle and avoid 429 storms. Parsed defensively: clamped to `[1, 64]`, falls back to 8 on a non-integer (no import-time crash, no `Semaphore(0)` deadlock).

## Backward compatibility

- **OpenRouter / OpenAI-compatible / Ollama / vLLM**: the first request is byte-identical to before — every new gate defaults to "include", and the 400-heals only fire on responses these endpoints don't produce.
- **Bedrock provider**: untouched.
- **Existing configs**: `send_temperature` defaults true; `MIRA_INDEX_LLM_CONCURRENCY` unset = the original 8. No config changes required.

## Tests

`tests/test_llm_provider.py::TestParam400SelfHeal` — `response_format` + `temperature` 400s are stripped/retried/remembered; underscore phrasing matches; `send_temperature=false` omits it up front; **the default path still sends both params unchanged** (backward-compat guard).

`tests/test_index_indexer.py::TestResolveIndexConcurrency` — clamps 0/negative→1, caps at 64, non-int→8, unset→8.

Full suite green (91 passed, 1 skipped on the affected modules); ruff check + format clean.

## How it was validated

Run live against a Databricks AI Gateway with `databricks-claude-opus-4-8` (review) and `databricks-claude-sonnet-4-6` (indexing): both the tool-calling review path and the json_mode indexing path self-heal and succeed; indexing at concurrency 2 stays under the rate limit.