### PR TITLE
New beta release pipeline

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,18 +1,17 @@
-name: Release
+name: Release (beta)
 
-# Gated release: pushing a v* tag runs the eval gate first; the container is
-# built and pushed ONLY if the evals pass. This is the ordering that matters —
-# evals run *before* the artifact ships, never alongside it.
+# Same gated flow as Release, but for prerelease tags (v1.2.3-beta1, -beta2, …).
+# Evals run first; the beta container ships only if they pass. Beta images are
+# tagged with the full prerelease version and never get the `latest` tag.
 on:
   push:
-    tags: ["v*", "!v*-beta*"]
+    tags: ["v*-beta*"]
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # Gate: the stable eval suite (excludes the noisy benchmark scorecard).
   evals:
     uses: ./.github/workflows/evals.yml
     secrets: inherit
@@ -38,9 +37,9 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: latest=false
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push
         uses: docker/build-push-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 # evals run *before* the artifact ships, never alongside it.
 on:
   push:
-    tags: ["v*", "!v*-beta*"]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Before opening this PR, please ensure:
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary

<!-- 1-3 bullets on what changed and why -->
- Added new beta release pipeline for beta releases of Mira

## Test plan

CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
