### PR TITLE
Add Activity page: org-wide PR review feed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mira-reviewer"
-version = "0.4.0"
+version = "0.4.1"
 description = "AI-powered PR reviewer with low-noise filtering"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/mira/__init__.py
+++ b/src/mira/__init__.py
@@ -1,3 +1,3 @@
 """Mira — AI-powered PR reviewer."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -2201,9 +2201,7 @@ def list_activity(limit: int = 200, repo: str = "", q: str = "") -> ActivityResp
             try:
                 for e in store.list_review_events(limit=500):
                     if terms:
-                        haystack = (
-                            f"{e.pr_title} #{e.pr_number} {slug} {e.categories}".lower()
-                        )
+                        haystack = f"{e.pr_title} #{e.pr_number} {slug} {e.categories}".lower()
                         if not all(t in haystack for t in terms):
                             continue
                     events.append(
@@ -2229,9 +2227,7 @@ def list_activity(limit: int = 200, repo: str = "", q: str = "") -> ActivityResp
             finally:
                 store.close()
         except Exception:
-            logger.warning(
-                "Failed to read activity for %s", slug, exc_info=True
-            )
+            logger.warning("Failed to read activity for %s", slug, exc_info=True)
 
     events.sort(key=lambda ev: ev.created_at, reverse=True)
     return ActivityResponse(events=events[:limit], repos=repo_slugs)

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -50,7 +50,7 @@ def register_dashboard(app: FastAPI) -> None:
 
 # Standalone app — initialized at module load, but routes are registered at
 # the bottom of this file, *after* all @router decorators have run.
-app = FastAPI(title="Mira Dashboard API", version="0.4.0")
+app = FastAPI(title="Mira Dashboard API", version="0.4.1")
 
 _INDEX_DIR = os.environ.get("MIRA_INDEX_DIR", "/data/indexes")
 
@@ -187,6 +187,16 @@ class ReviewEventModel(BaseModel):
     duration_ms: int
     categories: str
     created_at: float
+
+
+class ActivityEventModel(ReviewEventModel):
+    owner: str
+    repo: str
+
+
+class ActivityResponse(BaseModel):
+    events: list[ActivityEventModel]
+    repos: list[str]
 
 
 class ReviewStatsModel(BaseModel):
@@ -2165,6 +2175,64 @@ def list_reviews(owner: str, repo: str, limit: int = 50) -> list[ReviewEventMode
             )
             for e in events
         ]
+
+
+@router.get("/api/activity", response_model=ActivityResponse)
+def list_activity(limit: int = 200, repo: str = "", q: str = "") -> ActivityResponse:
+    """Org-wide feed of review events across all repos.
+
+    Flattens per-repo review_events into a single list sorted by created_at
+    (newest first), attaching owner/repo to each. Supports an optional repo
+    filter ("owner/repo") and a case-insensitive search `q` matched across the
+    PR title, PR number, repo slug, and categories (multi-word queries AND).
+    """
+    terms = [t for t in q.lower().split() if t]
+
+    repos = _app_db.list_repos()
+    repo_slugs = sorted(f"{r.owner}/{r.repo}" for r in repos)
+
+    events: list[ActivityEventModel] = []
+    for repo_record in repos:
+        slug = f"{repo_record.owner}/{repo_record.repo}"
+        if repo and slug != repo:
+            continue
+        try:
+            store = IndexStore.open(repo_record.owner, repo_record.repo)
+            for e in store.list_review_events(limit=500):
+                if terms:
+                    haystack = (
+                        f"{e.pr_title} #{e.pr_number} {slug} {e.categories}".lower()
+                    )
+                    if not all(t in haystack for t in terms):
+                        continue
+                events.append(
+                    ActivityEventModel(
+                        id=e.id,
+                        pr_number=e.pr_number,
+                        pr_title=e.pr_title,
+                        pr_url=e.pr_url,
+                        comments_posted=e.comments_posted,
+                        blockers=e.blockers,
+                        warnings=e.warnings,
+                        suggestions=e.suggestions,
+                        files_reviewed=e.files_reviewed,
+                        lines_changed=e.lines_changed,
+                        tokens_used=e.tokens_used,
+                        duration_ms=e.duration_ms,
+                        categories=e.categories,
+                        created_at=e.created_at,
+                        owner=repo_record.owner,
+                        repo=repo_record.repo,
+                    )
+                )
+            store.close()
+        except Exception:
+            logger.warning(
+                "Failed to read activity for %s", slug, exc_info=True
+            )
+
+    events.sort(key=lambda ev: ev.created_at, reverse=True)
+    return ActivityResponse(events=events[:limit], repos=repo_slugs)
 
 
 # Wire dashboard routes + middleware onto the standalone app, after all

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -2198,34 +2198,36 @@ def list_activity(limit: int = 200, repo: str = "", q: str = "") -> ActivityResp
             continue
         try:
             store = IndexStore.open(repo_record.owner, repo_record.repo)
-            for e in store.list_review_events(limit=500):
-                if terms:
-                    haystack = (
-                        f"{e.pr_title} #{e.pr_number} {slug} {e.categories}".lower()
+            try:
+                for e in store.list_review_events(limit=500):
+                    if terms:
+                        haystack = (
+                            f"{e.pr_title} #{e.pr_number} {slug} {e.categories}".lower()
+                        )
+                        if not all(t in haystack for t in terms):
+                            continue
+                    events.append(
+                        ActivityEventModel(
+                            id=e.id,
+                            pr_number=e.pr_number,
+                            pr_title=e.pr_title,
+                            pr_url=e.pr_url,
+                            comments_posted=e.comments_posted,
+                            blockers=e.blockers,
+                            warnings=e.warnings,
+                            suggestions=e.suggestions,
+                            files_reviewed=e.files_reviewed,
+                            lines_changed=e.lines_changed,
+                            tokens_used=e.tokens_used,
+                            duration_ms=e.duration_ms,
+                            categories=e.categories,
+                            created_at=e.created_at,
+                            owner=repo_record.owner,
+                            repo=repo_record.repo,
+                        )
                     )
-                    if not all(t in haystack for t in terms):
-                        continue
-                events.append(
-                    ActivityEventModel(
-                        id=e.id,
-                        pr_number=e.pr_number,
-                        pr_title=e.pr_title,
-                        pr_url=e.pr_url,
-                        comments_posted=e.comments_posted,
-                        blockers=e.blockers,
-                        warnings=e.warnings,
-                        suggestions=e.suggestions,
-                        files_reviewed=e.files_reviewed,
-                        lines_changed=e.lines_changed,
-                        tokens_used=e.tokens_used,
-                        duration_ms=e.duration_ms,
-                        categories=e.categories,
-                        created_at=e.created_at,
-                        owner=repo_record.owner,
-                        repo=repo_record.repo,
-                    )
-                )
-            store.close()
+            finally:
+                store.close()
         except Exception:
             logger.warning(
                 "Failed to read activity for %s", slug, exc_info=True

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,0 +1,106 @@
+"""/api/activity flattens review events across all repos, newest first, and
+supports repo + search filtering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mira.dashboard import api
+from mira.dashboard.db import AppDatabase
+from mira.index.store import IndexStore
+
+
+@pytest.fixture
+def patched_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppDatabase:
+    monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+    db = AppDatabase(url="", admin_password="admin")
+    monkeypatch.setattr(api, "_app_db", db)
+    return db
+
+
+def _seed(db: AppDatabase) -> None:
+    db.register_repo("acme", "web")
+    db.register_repo("acme", "api")
+
+    web = IndexStore.open("acme", "web")
+    web.record_review(
+        pr_number=1,
+        pr_title="Fix auth redirect loop",
+        pr_url="https://github.com/acme/web/pull/1",
+        comments_posted=3,
+        blockers=1,
+        warnings=2,
+        suggestions=0,
+        categories="bug,security",
+        created_at=100.0,
+    )
+    web.record_review(
+        pr_number=2,
+        pr_title="Add dark mode",
+        pr_url="https://github.com/acme/web/pull/2",
+        comments_posted=1,
+        blockers=0,
+        warnings=0,
+        suggestions=1,
+        categories="style",
+        created_at=300.0,
+    )
+    web.close()
+
+    apirepo = IndexStore.open("acme", "api")
+    apirepo.record_review(
+        pr_number=7,
+        pr_title="Rate limit login endpoint",
+        pr_url="https://github.com/acme/api/pull/7",
+        comments_posted=2,
+        blockers=1,
+        warnings=1,
+        suggestions=0,
+        categories="security,performance",
+        created_at=200.0,
+    )
+    apirepo.close()
+
+
+def test_lists_all_repos_newest_first(patched_db: AppDatabase):
+    _seed(patched_db)
+    out = api.list_activity()
+
+    assert [(e.repo, e.pr_number) for e in out.events] == [
+        ("web", 2),  # created_at 300
+        ("api", 7),  # created_at 200
+        ("web", 1),  # created_at 100
+    ]
+    # owner/repo are attached to each flattened event
+    assert all(e.owner == "acme" for e in out.events)
+    assert set(out.repos) == {"acme/web", "acme/api"}
+
+
+def test_repo_filter_narrows_results(patched_db: AppDatabase):
+    _seed(patched_db)
+    out = api.list_activity(repo="acme/api")
+    assert [e.pr_number for e in out.events] == [7]
+    # repo dropdown still lists every repo, not just the filtered one
+    assert set(out.repos) == {"acme/web", "acme/api"}
+
+
+def test_search_matches_title_repo_and_category(patched_db: AppDatabase):
+    _seed(patched_db)
+
+    by_title = api.list_activity(q="dark")
+    assert [e.pr_number for e in by_title.events] == [2]
+
+    by_category = api.list_activity(q="security")
+    assert {e.pr_number for e in by_category.events} == {1, 7}
+
+    by_repo = api.list_activity(q="api")
+    assert [e.pr_number for e in by_repo.events] == [7]
+
+
+def test_search_ands_multiple_terms(patched_db: AppDatabase):
+    _seed(patched_db)
+    # "security" matches PRs 1 and 7; adding "web" narrows to just PR 1.
+    out = api.list_activity(q="security web")
+    assert [e.pr_number for e in out.events] == [1]

--- a/ui/mira/src/App.tsx
+++ b/ui/mira/src/App.tsx
@@ -6,6 +6,7 @@ import { SetupModal } from "@/components/dashboard/setup-modal"
 import { UninstallModal } from "@/components/dashboard/uninstall-modal"
 import { api } from "@/lib/api"
 import { useAuth } from "@/lib/auth"
+import { ActivityPage } from "@/pages/activity"
 import { DashboardPage } from "@/pages/dashboard"
 import { LearnedRulesPage } from "@/pages/learned-rules"
 import { LoginPage } from "@/pages/login"
@@ -195,6 +196,7 @@ export function App() {
           }
         >
           <Route index element={<DashboardPage />} />
+          <Route path="activity" element={<ActivityPage />} />
           <Route path="repos" element={<ReposPage />} />
           <Route path="repos/:owner/:repo" element={<RepoDetailPage />} />
           <Route path="packages" element={<PackagesPage />} />

--- a/ui/mira/src/components/dashboard/layout.tsx
+++ b/ui/mira/src/components/dashboard/layout.tsx
@@ -1,4 +1,5 @@
 import {
+  Activity,
   BookOpen,
   Brain,
   ChevronRight,
@@ -68,6 +69,7 @@ import { UserAvatar } from "@/components/ui/user-avatar"
 
 const navItems = [
   { to: "/", icon: LayoutDashboard, label: "Dashboard" },
+  { to: "/activity", icon: Activity, label: "Activity" },
   { to: "/repos", icon: Database, label: "Repositories" },
   { to: "/packages", icon: Package, label: "Packages" },
   { to: "/vulnerabilities", icon: ShieldAlert, label: "Vulnerabilities" },
@@ -86,6 +88,7 @@ const settingsSubItems = [
 ]
 
 const PAGE_LABELS: Record<string, string> = {
+  activity: "Activity",
   repos: "Repositories",
   packages: "Packages",
   vulnerabilities: "Vulnerabilities",
@@ -222,6 +225,11 @@ export function DashboardLayout() {
                   </div>
                   <div className="flex flex-col leading-tight">
                     <span className="text-sm font-semibold">Mira</span>
+                    {version && (
+                      <span className="text-[10px] text-muted-foreground tabular-nums">
+                        v{version}
+                      </span>
+                    )}
                   </div>
                 </a>
               </SidebarMenuButton>
@@ -296,11 +304,6 @@ export function DashboardLayout() {
           <SidebarMenu>
             <UserMenu />
           </SidebarMenu>
-          {version && (
-            <span className="px-2 pb-1 text-[10px] text-muted-foreground tabular-nums group-data-[collapsible=icon]:hidden">
-              v{version}
-            </span>
-          )}
         </SidebarFooter>
 
         <SidebarRail />

--- a/ui/mira/src/components/ui/github-icon.tsx
+++ b/ui/mira/src/components/ui/github-icon.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+// GitHub mark. lucide-react v1 dropped brand icons, so we ship the official
+// Octocat path as a small icon component that behaves like a lucide icon
+// (sized via className, inherits currentColor).
+function GitHubIcon({ className, ...props }: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className={cn("h-4 w-4", className)}
+      {...props}
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  )
+}
+
+export { GitHubIcon }

--- a/ui/mira/src/lib/api.ts
+++ b/ui/mira/src/lib/api.ts
@@ -3,6 +3,7 @@
 // re-exports the shared types, so `import { api, SomeType } from "@/lib/api"`
 // keeps working everywhere.
 
+import { activityApi } from "./api/activity"
 import { packagesApi } from "./api/packages"
 import { relationshipsApi } from "./api/relationships"
 import { reposApi } from "./api/repos"
@@ -17,6 +18,7 @@ import { webhooksApi } from "./api/webhooks"
 export * from "./api/types"
 
 export const api = {
+  ...activityApi,
   ...systemApi,
   ...settingsApi,
   ...statsApi,

--- a/ui/mira/src/lib/api/activity.ts
+++ b/ui/mira/src/lib/api/activity.ts
@@ -1,0 +1,16 @@
+import { fetchJson } from "./http"
+import type { ActivityResponse } from "./types"
+
+// Org-wide feed of review events across all repos.
+export const activityApi = {
+  listActivity: (params?: { limit?: number; repo?: string; q?: string }) => {
+    const qs = new URLSearchParams()
+    if (params?.limit != null) qs.set("limit", String(params.limit))
+    if (params?.repo) qs.set("repo", params.repo)
+    if (params?.q) qs.set("q", params.q)
+    const query = qs.toString()
+    return fetchJson<ActivityResponse>(
+      query ? `/api/activity?${query}` : "/api/activity"
+    )
+  },
+}

--- a/ui/mira/src/lib/api/types.ts
+++ b/ui/mira/src/lib/api/types.ts
@@ -162,6 +162,16 @@ export interface ReviewEventModel {
   created_at: number
 }
 
+export interface ActivityEventModel extends ReviewEventModel {
+  owner: string
+  repo: string
+}
+
+export interface ActivityResponse {
+  events: ActivityEventModel[]
+  repos: string[]
+}
+
 export interface ReviewStatsModel {
   total_reviews: number
   total_comments: number

--- a/ui/mira/src/pages/activity.tsx
+++ b/ui/mira/src/pages/activity.tsx
@@ -1,0 +1,511 @@
+import {
+  Activity as ActivityIcon,
+  ChevronDown,
+  ChevronsUpDown,
+  ChevronUp,
+  ExternalLink,
+  Search,
+  X,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { CartesianGrid, Line, LineChart, XAxis } from "recharts"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { GitHubIcon } from "@/components/ui/github-icon"
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { api, type ActivityEventModel } from "@/lib/api"
+import { useAsync, useDocumentTitle } from "@/lib/hooks"
+import { cn } from "@/lib/utils"
+
+const ALL_REPOS = "__all__"
+
+// Subtle inset ring shared by every pill on the page.
+const PILL_RING = "ring-1 ring-inset ring-foreground/10"
+
+// Per-severity color treatment (semantic, not the near-black primary).
+const SEVERITY_PILL: Record<string, string> = {
+  blocker:
+    "border-transparent bg-destructive/10 text-destructive ring-destructive/25",
+  warning:
+    "border-transparent bg-amber-500/15 text-amber-700 ring-amber-500/30 dark:text-amber-400",
+  suggestion:
+    "border-transparent bg-sky-500/15 text-sky-700 ring-sky-500/30 dark:text-sky-400",
+}
+
+const chartConfig = {
+  reviews: { label: "Reviews", color: "var(--chart-1)" },
+  comments: { label: "Issues", color: "var(--chart-2)" },
+} satisfies ChartConfig
+
+type SortKey =
+  | "repo"
+  | "pr_number"
+  | "created_at"
+  | "comments_posted"
+  | "severity"
+type SortDir = "asc" | "desc"
+
+// Rank a row by severity: blockers dominate, then warnings, then suggestions.
+function severityWeight(e: ActivityEventModel) {
+  return e.blockers * 1_000_000 + e.warnings * 1_000 + e.suggestions
+}
+
+function sortValue(e: ActivityEventModel, key: SortKey): string | number {
+  switch (key) {
+    case "repo":
+      return `${e.owner}/${e.repo}`.toLowerCase()
+    case "pr_number":
+      return e.pr_number
+    case "created_at":
+      return e.created_at
+    case "comments_posted":
+      return e.comments_posted
+    case "severity":
+      return severityWeight(e)
+  }
+}
+
+function formatChartDate(d: string) {
+  if (d.includes("W")) return `Week ${parseInt(d.split("W")[1])}`
+  if (d.length === 7) {
+    const [y, m] = d.split("-")
+    const months = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+    return `${months[parseInt(m) - 1]} ${y}`
+  }
+  const parts = d.split("-")
+  return `${parseInt(parts[1])}/${parseInt(parts[2])}`
+}
+
+function relativeTime(epochSeconds: number) {
+  const seconds = Math.floor(Date.now() / 1000 - epochSeconds)
+  if (seconds < 60) return "just now"
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days}d ago`
+  return new Date(epochSeconds * 1000).toLocaleDateString()
+}
+
+function formatTimestamp(epochSeconds: number) {
+  return new Date(epochSeconds * 1000).toLocaleString()
+}
+
+function splitCategories(categories: string): string[] {
+  return categories
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean)
+}
+
+function SeverityBadges({ event }: { event: ActivityEventModel }) {
+  const parts: { label: string; kind: keyof typeof SEVERITY_PILL }[] = []
+  if (event.blockers > 0) parts.push({ label: `${event.blockers} blocker${event.blockers > 1 ? "s" : ""}`, kind: "blocker" })
+  if (event.warnings > 0) parts.push({ label: `${event.warnings} warning${event.warnings > 1 ? "s" : ""}`, kind: "warning" })
+  if (event.suggestions > 0) parts.push({ label: `${event.suggestions} suggestion${event.suggestions > 1 ? "s" : ""}`, kind: "suggestion" })
+  if (parts.length === 0) return <span className="text-muted-foreground">—</span>
+  return (
+    <div className="flex flex-wrap gap-1">
+      {parts.map((p) => (
+        <Badge key={p.label} className={cn(PILL_RING, SEVERITY_PILL[p.kind])}>
+          {p.label}
+        </Badge>
+      ))}
+    </div>
+  )
+}
+
+export function ActivityPage() {
+  useDocumentTitle("Activity")
+
+  const [period, setPeriod] = useState<"day" | "week" | "month">("day")
+  const [search, setSearch] = useState("")
+  const [debouncedSearch, setDebouncedSearch] = useState("")
+  const [repo, setRepo] = useState<string>(ALL_REPOS)
+  // `selected` holds the row being shown; `panelOpen` drives the slide
+  // animation. We keep `selected` set during the close transition so the
+  // content doesn't vanish before the panel finishes sliding out.
+  const [selected, setSelected] = useState<ActivityEventModel | null>(null)
+  const [panelOpen, setPanelOpen] = useState(false)
+
+  const openDetail = (e: ActivityEventModel) => {
+    setSelected(e)
+    setPanelOpen(true)
+  }
+  const closeDetail = () => setPanelOpen(false)
+
+  // Debounce the search input so typing doesn't refetch per keystroke.
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 250)
+    return () => clearTimeout(t)
+  }, [search])
+
+  // Close the detail panel on Escape, like a native dialog.
+  useEffect(() => {
+    if (!panelOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeDetail()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [panelOpen])
+
+  const { data: timeseries, loading: chartLoading } = useAsync(
+    () => api.getTimeseries(period),
+    [period],
+  )
+
+  const { data: activity, loading } = useAsync(
+    () =>
+      api.listActivity({
+        q: debouncedSearch || undefined,
+        repo: repo === ALL_REPOS ? undefined : repo,
+      }),
+    [debouncedSearch, repo],
+  )
+
+  const events = useMemo(() => activity?.events ?? [], [activity?.events])
+  // Keep the repo list stable across searches: prefer the unfiltered list.
+  const repos = useMemo(() => activity?.repos ?? [], [activity?.repos])
+
+  // Client-side sort over the (≤200-row) result set. Default: newest first.
+  const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>({
+    key: "created_at",
+    dir: "desc",
+  })
+
+  const sortedEvents = useMemo(() => {
+    const dir = sort.dir === "asc" ? 1 : -1
+    return [...events].sort((a, b) => {
+      const av = sortValue(a, sort.key)
+      const bv = sortValue(b, sort.key)
+      if (av < bv) return -1 * dir
+      if (av > bv) return 1 * dir
+      return 0
+    })
+  }, [events, sort])
+
+  const toggleSort = (key: SortKey) =>
+    setSort((s) =>
+      s.key === key
+        ? { key, dir: s.dir === "asc" ? "desc" : "asc" }
+        : // Text sorts ascending first; numbers/dates descending first.
+          { key, dir: key === "repo" ? "asc" : "desc" },
+    )
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Activity</h1>
+          <p className="text-sm text-muted-foreground">
+            Every PR Mira has reviewed, across all repositories.
+          </p>
+        </div>
+        <div className="flex gap-1">
+          {(["day", "week", "month"] as const).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPeriod(p)}
+              className={`inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+                period === p
+                  ? "border-primary bg-primary/10 text-primary"
+                  : "border-input bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              }`}
+            >
+              {p === "day" ? "Daily" : p === "week" ? "Weekly" : "Monthly"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Top graph: reviews + issues found over time */}
+      <Card>
+        <CardContent className="pt-6">
+          {chartLoading ? (
+            <Skeleton className="h-[160px] w-full" />
+          ) : timeseries && timeseries.length > 0 ? (
+            <ChartContainer config={chartConfig} className="h-[160px] w-full">
+              <LineChart data={timeseries}>
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  dataKey="date"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={8}
+                  tickFormatter={formatChartDate}
+                />
+                <ChartTooltip content={<ChartTooltipContent />} />
+                <Line type="monotone" dataKey="reviews" stroke="var(--color-reviews)" strokeWidth={2} dot={false} />
+                <Line type="monotone" dataKey="comments" stroke="var(--color-comments)" strokeWidth={2} dot={false} />
+              </LineChart>
+            </ChartContainer>
+          ) : (
+            <div className="flex h-[160px] items-center justify-center text-sm text-muted-foreground">
+              No review activity yet.
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Search + repo filter */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search by PR title, number, repo, or category…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-8"
+          />
+        </div>
+        <Select value={repo} onValueChange={setRepo}>
+          <SelectTrigger className="sm:w-64">
+            <SelectValue placeholder="All repos" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_REPOS}>All repos</SelectItem>
+            {repos.map((r) => (
+              <SelectItem key={r} value={r}>
+                {r}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Table */}
+      {loading ? (
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      ) : events.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 py-12 text-center">
+            <ActivityIcon className="h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              {debouncedSearch || repo !== ALL_REPOS
+                ? "No reviews match your filters."
+                : "Mira hasn't reviewed any PRs yet."}
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="overflow-hidden py-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <SortHead label="Repo" sortKey="repo" sort={sort} onSort={toggleSort} />
+                <SortHead label="PR" sortKey="pr_number" sort={sort} onSort={toggleSort} />
+                <SortHead label="When" sortKey="created_at" sort={sort} onSort={toggleSort} />
+                <SortHead
+                  label="Comments"
+                  sortKey="comments_posted"
+                  sort={sort}
+                  onSort={toggleSort}
+                  align="right"
+                />
+                <SortHead label="Severity" sortKey="severity" sort={sort} onSort={toggleSort} />
+                <TableHead>Categories</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sortedEvents.map((e) => (
+                <TableRow
+                  key={`${e.owner}/${e.repo}#${e.id}`}
+                  data-active={
+                    panelOpen && selected?.id === e.id && selected?.repo === e.repo
+                  }
+                  className="cursor-pointer data-[active=true]:bg-muted/60"
+                  onClick={() => openDetail(e)}
+                >
+                  <TableCell className="whitespace-nowrap font-mono text-xs text-muted-foreground">
+                    {e.owner}/{e.repo}
+                  </TableCell>
+                  <TableCell className="max-w-xs">
+                    <div className="flex items-center gap-2">
+                      <GitHubIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                      <span className="font-medium">#{e.pr_number}</span>
+                      <span className="truncate text-muted-foreground">
+                        {e.pr_title}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap text-muted-foreground">
+                    {relativeTime(e.created_at)}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {e.comments_posted}
+                  </TableCell>
+                  <TableCell>
+                    <SeverityBadges event={e} />
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-wrap gap-1">
+                      {splitCategories(e.categories).map((c) => (
+                        <Badge key={c} variant="secondary" className={PILL_RING}>
+                          {c}
+                        </Badge>
+                      ))}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Card>
+      )}
+
+      {/* Detail panel — a custom right-anchored drawer. No dimming/blur
+          overlay; it sits below the top nav (top-12) and covers down to the
+          bottom edge, leaving the rest of the screen visible and usable. */}
+      <div
+        aria-hidden={!panelOpen}
+        className={cn(
+          "fixed right-0 top-12 bottom-0 z-30 flex w-full max-w-[640px] flex-col border-l bg-background shadow-2xl transition-transform duration-300 ease-in-out",
+          panelOpen ? "translate-x-0" : "pointer-events-none translate-x-full",
+        )}
+      >
+        {selected && (
+          <>
+            <div className="flex items-start justify-between gap-3 border-b p-6">
+              <div className="min-w-0 space-y-1">
+                <div className="flex items-center gap-2">
+                  <GitHubIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <h2 className="min-w-0 flex-1 truncate text-sm font-medium">
+                    #{selected.pr_number} {selected.pr_title}
+                  </h2>
+                  <a
+                    href={selected.pr_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label="Open PR on GitHub"
+                    title="Open PR on GitHub"
+                    className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </a>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {selected.owner}/{selected.repo} ·{" "}
+                  {formatTimestamp(selected.created_at)}
+                </p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={closeDetail}
+                aria-label="Close"
+              >
+                <X />
+              </Button>
+            </div>
+
+            <div className="flex-1 space-y-6 overflow-y-auto p-6">
+              <div>
+                <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">
+                  Findings
+                </h3>
+                <SeverityBadges event={selected} />
+              </div>
+
+              <dl className="grid grid-cols-2 gap-x-4 gap-y-3">
+                <Stat label="Comments posted" value={selected.comments_posted} />
+                <Stat label="Files reviewed" value={selected.files_reviewed} />
+                <Stat label="Lines changed" value={selected.lines_changed.toLocaleString()} />
+                <Stat label="Tokens used" value={selected.tokens_used.toLocaleString()} />
+                <Stat label="Duration" value={`${(selected.duration_ms / 1000).toFixed(1)}s`} />
+              </dl>
+
+              {splitCategories(selected.categories).length > 0 && (
+                <div>
+                  <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">
+                    Categories
+                  </h3>
+                  <div className="flex flex-wrap gap-1">
+                    {splitCategories(selected.categories).map((c) => (
+                      <Badge key={c} variant="secondary" className={PILL_RING}>
+                        {c}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SortHead({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  align = "left",
+}: {
+  label: string
+  sortKey: SortKey
+  sort: { key: SortKey; dir: SortDir }
+  onSort: (key: SortKey) => void
+  align?: "left" | "right"
+}) {
+  const active = sort.key === sortKey
+  const Icon = active ? (sort.dir === "asc" ? ChevronUp : ChevronDown) : ChevronsUpDown
+  return (
+    <TableHead className={align === "right" ? "text-right" : undefined}>
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        aria-label={`Sort by ${label}`}
+        className={cn(
+          "inline-flex items-center gap-1 transition-colors hover:text-foreground",
+          align === "right" && "flex-row-reverse",
+          active ? "text-foreground" : "text-muted-foreground",
+        )}
+      >
+        {label}
+        <Icon
+          className={cn(
+            "h-3.5 w-3.5",
+            active ? "text-foreground" : "text-muted-foreground/50",
+          )}
+        />
+      </button>
+    </TableHead>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="text-sm font-medium tabular-nums">{value}</dd>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Adds a new **Activity** nav item — a single place to see every PR Mira has reviewed across all repos, so users don't have to dig through GitHub.

## Backend

- New `GET /api/activity` endpoint that flattens `review_events` across all repos into one feed (newest first), attaching `owner`/`repo` to each event.
- Query params: `limit` (default 200), `repo` filter, and **server-side `q` search** — case-insensitive across PR title, number, repo slug, and categories, with multi-word terms ANDed.
- No schema changes/migrations; pure read aggregation reusing `list_review_events`.

## Frontend

- **Activity page** (`pages/activity.tsx`):
  - Compact reviews + issues-found line graph up top, with Daily/Weekly/Monthly toggle (reuses `/api/stats/timeseries`).
  - Debounced search bar (drives the server-side search) + repo filter dropdown.
  - **Sortable** table (Repo, PR, When, Comments, Severity); severity sorts by weighted blocker→warning→suggestion rank.
  - Custom right-anchored **detail drawer** — no dimming/blur overlay, sits below the top nav, wider; closes via X or Escape. Shows the full stored breakdown + a GitHub link by the (truncated) PR title.
- `GitHubIcon` component (lucide v1 dropped brand icons), used in the table and drawer.
- Semantic **severity pills** (amber warnings instead of near-black) with a subtle ring on all pills.
- Moved the version label up next to the sidebar logo.

## Version

Bumped to **0.4.1** (`__init__.py`, `pyproject.toml`, FastAPI app).

## Notes

- The detail panel shows stored *metrics* (counts, categories, tokens, etc.) — the DB doesn't persist individual comment bodies, so showing the actual warning text would require a live GitHub fetch (out of scope here).

## Tests

- `tests/test_activity.py` — flatten/sort, owner/repo attachment, repo filter, and search (title/repo/category + multi-word AND). All green.
- UI `tsc` typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)