### PR TITLE
Activity: theme-aware scrollbar on detail panel timeline

### DIFF
--- a/ui/mira/src/pages/activity.tsx
+++ b/ui/mira/src/pages/activity.tsx
@@ -696,7 +696,7 @@ export function ActivityPage() {
               </Button>
             </div>
 
-            <div className="flex-1 space-y-6 overflow-y-auto p-6">
+            <div className="themed-scrollbar flex-1 space-y-6 overflow-y-auto p-6">
               {/* Summary — findings + totals across all review passes */}
               <div>
                 <h3 className="mb-2 text-xs font-medium uppercase text-muted-foreground">


### PR DESCRIPTION
Super-small fix. The detail panel body (summary + timeline) scrolls when it gets long, but was using the default browser scrollbar. Apply the same `themed-scrollbar` utility the activity table uses so it adapts to light/dark.

One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)