### PR TITLE
0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Mira are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] — 2026-07-06
+
+### Added
+
+- **Activity page** — an org-wide feed of PR reviews with a filterable table and a per-PR detail timeline. (#145, #146, #147 — already in the 0.4.1 betas.)
+- **Backend-aware, searchable model pickers** — the dashboard's model dropdowns are now search bars that list the configured backend's live catalog (OpenRouter's tool-capable models, your Bedrock account's inference profiles, or a generic endpoint's `/models`), cached for an hour with the bundled registry as fallback. Any free-form model id can be typed directly, matching `mira.yaml`'s flexibility, and an **Inherit from deployment config** choice clears the dashboard override so `mira.yaml` is authoritative again. The effective model and its source (`dashboard setting` vs `mira.yaml`) are logged on every review, so an override is never silent. Closes #124.
+- **Current-generation models in the registry** — GPT-5 Nano/Mini, GPT-5.1 Codex/Codex Mini, GPT-4.1 Mini, Gemini 3 Flash (Preview), and Gemini 3.1 Flash Lite, with pricing verified against the live OpenRouter catalog. Closes #125.
+
+### Fixed
+
+- **Discord webhooks work via the Slack-compatible endpoint** — a `discord.com/api/webhooks/{id}/{token}/slack` URL is now detected as Slack format instead of falling through to generic JSON (which Discord rejects). Bare Discord URLs stay generic on purpose, so the test button surfaces the mismatch instead of silently guessing. Closes #158.
+- **Dependency-bump pushes refresh the vulnerability inventory** — push-triggered incremental indexing skipped manifests/lockfiles entirely (they're excluded from code indexing), so merging a lockfile-only PR left `package_manifests` stale and the Vulnerabilities page kept flagging already-fixed advisories until a full re-index. `index_diff` now routes changed/removed manifests through the same parse-and-store pass the full indexer uses and fires an immediate OSV poll. Closes #157.
+- **Global rules now reach reviews on Postgres deployments** — the review engine read global rules from a throwaway SQLite `AppDatabase()` instead of the configured `DATABASE_URL` backend, so dashboard-stored rules were silently ignored, a stray `_app.db` (with a default-password admin) was created in the index dir, and a DB connection leaked on every review. It now reuses the server's configured instance. Closes #123.
+
 ## [0.4.0] — 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Backend-aware, searchable model pickers** — the dashboard's model dropdowns are now search bars that list the configured backend's live catalog (OpenRouter's tool-capable models, your Bedrock account's inference profiles, or a generic endpoint's `/models`), cached for an hour with the bundled registry as fallback. Any free-form model id can be typed directly, matching `mira.yaml`'s flexibility, and an **Inherit from deployment config** choice clears the dashboard override so `mira.yaml` is authoritative again. The effective model and its source (`dashboard setting` vs `mira.yaml`) are logged on every review, so an override is never silent. Closes #124.
 - **Current-generation models in the registry** — GPT-5 Nano/Mini, GPT-5.1 Codex/Codex Mini, GPT-4.1 Mini, Gemini 3 Flash (Preview), and Gemini 3.1 Flash Lite, with pricing verified against the live OpenRouter catalog. Closes #125.
 
+### Changed
+
+- **`llm.base_url` is validated at config load** — non-http(s) schemes are rejected, and plain `http://` is allowed only for local endpoints (localhost, private IPs, dotless hostnames like docker-compose services); public hosts must use `https://`. A failed API-key lookup during a model-catalog fetch is now logged instead of silently sending an unauthenticated request.
+
 ### Fixed
 
 - **Discord webhooks work via the Slack-compatible endpoint** — a `discord.com/api/webhooks/{id}/{token}/slack` URL is now detected as Slack format instead of falling through to generic JSON (which Discord rejects). Bare Discord URLs stay generic on purpose, so the test button surfaces the mismatch instead of silently guessing. Closes #158.

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Mira talks to OpenRouter under the hood, so any model OpenRouter supports works.
 | OpenAI (cheap) | `openai/gpt-4o-mini` |
 | Google | `google/gemini-2.5-pro` |
 
-Set `OPENROUTER_API_KEY` once; one key works across every provider. See [`src/mira/llm/models.json`](src/mira/llm/models.json) for the full registry of models Mira recognises (with pricing and per-purpose recommendations).
+Set `OPENROUTER_API_KEY` once; one key works across every provider. The dashboard's model pickers list your backend's live catalog (OpenRouter, Bedrock, or any OpenAI-compatible endpoint's `/models`), are searchable, and accept any free-form model id — the same flexibility as `mira.yaml`. See [`src/mira/llm/models.json`](src/mira/llm/models.json) for the bundled registry that supplies pricing and per-purpose recommendations.
 
-**Adding your own models.** The dashboard's model dropdowns (and the validation behind them) come from that registry. To make a custom model selectable — e.g. DeepSeek or a local endpoint — point `MIRA_MODELS_JSON_PATH` at your own `models.json` (a volume mount works well). Its entries are **merged over** the bundled ones by model id, so you only list what you want to add or override:
+**Custom pricing and recommendations.** To give a custom model accurate cost estimates, a label, or a Recommended badge — e.g. DeepSeek or a local endpoint — point `MIRA_MODELS_JSON_PATH` at your own `models.json` (a volume mount works well). Its entries are **merged over** the bundled ones by model id, so you only list what you want to add or override:
 
 ```bash
 MIRA_MODELS_JSON_PATH=/config/models.json

--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from mira.exceptions import ConfigError
 
@@ -18,6 +20,18 @@ logger = logging.getLogger(__name__)
 # is accepted for backward compat with repos that committed it before the
 # 0.1.1 standardization on the .yaml extension.
 _DEFAULT_CONFIG_FILENAMES = (".mira.yaml", ".mira.yml")
+
+
+def _is_local_host(host: str) -> bool:
+    """Loopback, private/link-local IP literals, and dotless hostnames
+    (docker-compose services) — where a plain-http endpoint is legitimate."""
+    if host == "localhost" or "." not in host:
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return ip.is_loopback or ip.is_private or ip.is_link_local
 
 
 class LLMConfig(BaseModel):
@@ -48,6 +62,20 @@ class LLMConfig(BaseModel):
     # (env vars, instance profile, ECS task role, SSO).
     region: str = "us-east-1"
     aws_profile: str | None = None
+
+    @field_validator("base_url")
+    @classmethod
+    def _validate_base_url(cls, v: str) -> str:
+        parsed = urlparse(v)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            raise ValueError(f"llm.base_url must be an http(s) URL, got {v!r}")
+        if parsed.scheme == "http" and not _is_local_host(parsed.hostname):
+            raise ValueError(
+                f"llm.base_url {v!r} uses plain http to a public host — use https "
+                "(http is allowed only for localhost, private IPs, and dotless "
+                "hostnames like docker-compose services)"
+            )
+        return v
 
 
 class FilterConfig(BaseModel):

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -915,14 +915,14 @@ class ReviewEngine:
                 _rules_store.close()
 
                 try:
-                    from mira.dashboard.db import AppDatabase
+                    from mira.dashboard.api import _app_db
 
-                    _app_db = AppDatabase()
-                    for rule_text in _app_db.get_global_rules_text():
-                        parts = rule_text.split(": ", 1)
-                        title = parts[0] if len(parts) > 1 else "Global Rule"
-                        content = parts[1] if len(parts) > 1 else rule_text
-                        custom_rules.insert(0, {"title": title, "content": content})
+                    if _app_db is not None:
+                        for rule_text in _app_db.get_global_rules_text():
+                            parts = rule_text.split(": ", 1)
+                            title = parts[0] if len(parts) > 1 else "Global Rule"
+                            content = parts[1] if len(parts) > 1 else rule_text
+                            custom_rules.insert(0, {"title": title, "content": content})
                 except Exception:
                     pass
         except Exception:

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -372,6 +372,12 @@ class ModelOption(BaseModel):
 class ModelsResponse(BaseModel):
     indexing_model: str
     review_model: str
+    backend: str  # "openrouter" | "bedrock" | "openai-compatible"
+    indexing_source: str  # "dashboard" (DB override) | "config" (mira.yaml)
+    review_source: str
+    # What each model resolves to with no override — the "inherit" target.
+    config_indexing_model: str
+    config_review_model: str
     indexing_options: list[ModelOption]
     review_options: list[ModelOption]
     # Extended-thinking effort for reviews ("off"/"low"/"medium"/"high").
@@ -386,11 +392,10 @@ class ModelsUpdate(BaseModel):
 
 
 @router.get("/api/settings/models", response_model=ModelsResponse)
-def get_models() -> ModelsResponse:
+async def get_models() -> ModelsResponse:
     from mira.config import load_config
+    from mira.dashboard.model_catalog import active_backend, build_options, fetch_catalog
     from mira.dashboard.models_config import (
-        INDEXING_MODELS,
-        REVIEW_MODELS,
         THINKING_MODES,
         get_indexing_model,
         get_review_model,
@@ -398,15 +403,25 @@ def get_models() -> ModelsResponse:
     )
 
     config = load_config()
-    indexing = get_indexing_model(config.llm, _app_db.get_setting("indexing_model"))
-    review = get_review_model(config.llm, _app_db.get_setting("review_model"))
+    db_indexing = _app_db.get_setting("indexing_model")
+    db_review = _app_db.get_setting("review_model")
+    indexing = get_indexing_model(config.llm, db_indexing)
+    review = get_review_model(config.llm, db_review)
     thinking = get_review_thinking_mode(config.llm, _app_db.get_setting("review_thinking_mode"))
+
+    backend = active_backend(config.llm)
+    catalog = await fetch_catalog(config.llm)
 
     return ModelsResponse(
         indexing_model=indexing,
         review_model=review,
-        indexing_options=[ModelOption(**m) for m in INDEXING_MODELS],
-        review_options=[ModelOption(**m) for m in REVIEW_MODELS],
+        backend=backend,
+        indexing_source="dashboard" if db_indexing else "config",
+        review_source="dashboard" if db_review else "config",
+        config_indexing_model=get_indexing_model(config.llm),
+        config_review_model=get_review_model(config.llm),
+        indexing_options=[ModelOption(**m) for m in build_options(backend, catalog, "indexing")],
+        review_options=[ModelOption(**m) for m in build_options(backend, catalog, "review")],
         review_thinking_mode=thinking or "off",
         thinking_options=[ModelOption(**m) for m in THINKING_MODES],
     )
@@ -511,28 +526,18 @@ def set_global_settings(body: GlobalSettingsUpdate, request: Request) -> dict:
 @router.put("/api/settings/models")
 def set_models(body: ModelsUpdate) -> dict:
     from mira.dashboard.models_config import THINKING_MODE_VALUES
-    from mira.llm.registry import is_supported
 
-    # Reject unsupported or wrong-purpose models. Without this, an admin can
-    # silently configure a model that's broken (no JSON mode, missing from
-    # the registry, miscategorized for the role).
-    if not is_supported(body.indexing_model, purpose="indexing"):
-        raise HTTPException(
-            status_code=400,
-            detail=f"{body.indexing_model!r} is not a supported indexing model.",
-        )
-    if not is_supported(body.review_model, purpose="review"):
-        raise HTTPException(
-            status_code=400,
-            detail=f"{body.review_model!r} is not a supported review model.",
-        )
     if body.review_thinking_mode not in THINKING_MODE_VALUES:
         raise HTTPException(
             status_code=400,
             detail=f"{body.review_thinking_mode!r} is not a valid thinking mode.",
         )
-    _app_db.set_setting("indexing_model", body.indexing_model)
-    _app_db.set_setting("review_model", body.review_model)
+    # "" clears the override so mira.yaml is authoritative again. Any other id
+    # is stored as-is — the dashboard accepts the same free-form model ids as
+    # mira.yaml (the dropdown still guides toward registry models), and the
+    # registry falls back gracefully for pricing/limits of unknown ids.
+    _app_db.set_setting("indexing_model", body.indexing_model.strip())
+    _app_db.set_setting("review_model", body.review_model.strip())
     # Clear "off" to "" rather than persisting the literal — "off" is the
     # default, and a stored value would shadow a mira.yaml
     # `review_reasoning_effort` override. "" (not None — the column is NOT NULL)

--- a/src/mira/dashboard/model_catalog.py
+++ b/src/mira/dashboard/model_catalog.py
@@ -1,0 +1,159 @@
+"""Dynamic model catalog — lists models from the configured backend.
+
+The static registry (llm/models.json) uses OpenRouter-style ids, so a
+deployment on Bedrock or a generic OpenAI-compatible endpoint would be
+offered ids its backend can't serve. Detect the active backend, fetch its
+live model list (cached for an hour; failures for a minute), and fall back
+to the backend-filtered registry when the fetch fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import defaultdict
+
+import httpx
+
+from mira.config import LLMConfig
+from mira.llm import registry
+from mira.llm.provider import _get_api_key, _is_openrouter
+
+logger = logging.getLogger(__name__)
+
+_CATALOG_TTL = 3600.0
+_FAILURE_TTL = 60.0
+_cache: dict[str, tuple[float, list[dict] | None]] = {}
+_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+
+def active_backend(config: LLMConfig) -> str:
+    """Return "bedrock", "openrouter", or "openai-compatible"."""
+    if config.provider == "bedrock":
+        return "bedrock"
+    return "openrouter" if _is_openrouter(config.base_url) else "openai-compatible"
+
+
+def _norm(model_id: str) -> str:
+    # OpenRouter serves dash and dot forms of the same id as aliases
+    # (anthropic/claude-haiku-4-5 == anthropic/claude-haiku-4.5).
+    return model_id.lower().replace(".", "-")
+
+
+async def _fetch_openai_style(config: LLMConfig, tools_only: bool) -> list[dict]:
+    """GET {base_url}/models. With tools_only (OpenRouter), keep only
+    tool-calling models — Mira's review pass needs tool calling."""
+    headers = {}
+    try:
+        key = _get_api_key(config)
+    except Exception:
+        key = ""
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(f"{config.base_url.rstrip('/')}/models", headers=headers)
+    resp.raise_for_status()
+    out = []
+    for m in resp.json().get("data", []):
+        if tools_only and "tools" not in (m.get("supported_parameters") or []):
+            continue
+        out.append({"value": m["id"], "label": m.get("name") or m["id"]})
+    return out
+
+
+def _fetch_bedrock_sync(config: LLMConfig) -> list[dict]:
+    import boto3
+    from botocore.config import Config as BotoConfig
+
+    session = boto3.Session(profile_name=config.aws_profile, region_name=config.region)
+    client = session.client(
+        "bedrock",
+        config=BotoConfig(connect_timeout=5, read_timeout=15, retries={"max_attempts": 1}),
+    )
+    out = []
+    for p in client.list_inference_profiles().get("inferenceProfileSummaries", []):
+        out.append(
+            {
+                "value": p["inferenceProfileId"],
+                "label": p.get("inferenceProfileName") or p["inferenceProfileId"],
+            }
+        )
+    models = client.list_foundation_models(byOutputModality="TEXT", byInferenceType="ON_DEMAND")
+    for m in models.get("modelSummaries", []):
+        out.append({"value": m["modelId"], "label": m.get("modelName") or m["modelId"]})
+    return out
+
+
+async def fetch_catalog(config: LLMConfig) -> list[dict] | None:
+    """Live ``[{value, label}]`` list for the active backend, or None if
+    unavailable (no network, no boto3, no credentials, ...).
+
+    Successes are cached for an hour, failures for a minute — the settings
+    page must not re-block on a dead endpoint on every load. A per-key lock
+    coalesces concurrent cold-cache fetches (two tabs, the setup modal poll).
+    """
+    backend = active_backend(config)
+    if backend == "bedrock":
+        cache_key = f"bedrock:{config.region}:{config.aws_profile or ''}"
+    else:
+        cache_key = config.base_url
+
+    def cached() -> tuple[float, list[dict] | None] | None:
+        hit = _cache.get(cache_key)
+        if hit is None:
+            return None
+        ttl = _CATALOG_TTL if hit[1] is not None else _FAILURE_TTL
+        return hit if time.time() - hit[0] < ttl else None
+
+    if (hit := cached()) is not None:
+        return hit[1]
+    async with _locks[cache_key]:
+        if (hit := cached()) is not None:
+            return hit[1]
+        try:
+            if backend == "bedrock":
+                models = await asyncio.to_thread(_fetch_bedrock_sync, config)
+            elif backend == "openrouter":
+                models = await _fetch_openai_style(config, tools_only=True)
+            else:
+                models = await _fetch_openai_style(config, tools_only=False)
+        except Exception as exc:
+            logger.warning("Model catalog fetch failed (%s): %s", backend, exc)
+            models = None
+        _cache[cache_key] = (time.time(), models)
+        return models
+
+
+def build_options(backend: str, dynamic: list[dict] | None, purpose: str) -> list[dict]:
+    """Dropdown options for ``purpose``: registry entries matching the backend
+    (carrying the recommended flags) merged with the dynamic catalog.
+
+    Dynamic-only models have unknown capabilities, so they're offered for both
+    purposes. On a generic endpoint only its own list is trustworthy — registry
+    ids are OpenRouter-style — so the registry is used there only as fallback.
+    """
+    if backend == "openai-compatible" and dynamic is not None:
+        options = [{**d, "recommended": False} for d in dynamic]
+        options.sort(key=lambda m: m["label"].lower())
+        return options
+
+    wants_bedrock = backend == "bedrock"
+    options = []
+    for model_id, info in registry.all_models().items():
+        if (info.get("provider") == "bedrock") != wants_bedrock:
+            continue
+        if purpose not in (info.get("purposes") or []):
+            continue
+        options.append(
+            {
+                "value": model_id,
+                "label": info.get("label", model_id),
+                "recommended": purpose in (info.get("recommended_for") or []),
+            }
+        )
+    if dynamic is not None:
+        seen = {_norm(o["value"]) for o in options}
+        options += [{**d, "recommended": False} for d in dynamic if _norm(d["value"]) not in seen]
+    options.sort(key=lambda m: (not m["recommended"], m["label"].lower()))
+    return options

--- a/src/mira/dashboard/model_catalog.py
+++ b/src/mira/dashboard/model_catalog.py
@@ -47,7 +47,8 @@ async def _fetch_openai_style(config: LLMConfig, tools_only: bool) -> list[dict]
     headers = {}
     try:
         key = _get_api_key(config)
-    except Exception:
+    except Exception as exc:
+        logger.warning("Could not retrieve API key for model catalog fetch: %s", exc)
         key = ""
     if key:
         headers["Authorization"] = f"Bearer {key}"

--- a/src/mira/dashboard/models_config.py
+++ b/src/mira/dashboard/models_config.py
@@ -7,19 +7,16 @@ model there; this file picks it up automatically.
 
 from __future__ import annotations
 
+import logging
+
 from mira.config import LLMConfig
 from mira.llm import registry
 
-# ── Backwards-compatible accessors ──
-# Older imports of MODEL_PRICING / INDEXING_MODELS / REVIEW_MODELS still
-# work; they now derive from the registry.
+logger = logging.getLogger(__name__)
 
 MODEL_PRICING: dict[str, tuple[float, float]] = {
     model_id: registry.pricing(model_id) for model_id in registry.all_models()
 }
-
-INDEXING_MODELS = registry.models_for_purpose("indexing")
-REVIEW_MODELS = registry.models_for_purpose("review")
 
 # Thinking-mode options for the review model. "off" disables extended thinking
 # (today's behavior); low/medium/high map to OpenRouter's unified
@@ -106,31 +103,35 @@ def llm_config_for(purpose: str, base: LLMConfig) -> LLMConfig:
     """Return an LLMConfig with the appropriate model set for the given purpose.
 
     Reads the DB setting first (via _app_db), falls back to config fields.
+    Logs the effective model and where it came from, so a dashboard override
+    shadowing mira.yaml is visible instead of silent (issue #124).
     """
-    # Thinking mode only applies to reviews; other purposes leave it off.
-    thinking_mode: str | None = None
+    db_model: str | None = None
+    db_thinking: str | None = None
     try:
         from mira.dashboard.api import _app_db
 
-        if purpose == "indexing":
-            db_val = _app_db.get_setting("indexing_model")
-            resolved = get_indexing_model(base, db_val)
-        elif purpose == "review":
-            db_val = _app_db.get_setting("review_model")
-            resolved = get_review_model(base, db_val)
-            thinking_mode = get_review_thinking_mode(
-                base, _app_db.get_setting("review_thinking_mode")
-            )
-        else:
-            resolved = base.model
+        if _app_db is not None:
+            if purpose == "indexing":
+                db_model = _app_db.get_setting("indexing_model")
+            elif purpose == "review":
+                db_model = _app_db.get_setting("review_model")
+                db_thinking = _app_db.get_setting("review_thinking_mode")
     except Exception:
-        # DB not available — fall back to config fields
-        if purpose == "indexing":
-            resolved = base.indexing_model or base.model
-        elif purpose == "review":
-            resolved = base.review_model or base.model
-            thinking_mode = get_review_thinking_mode(base)
-        else:
-            resolved = base.model
+        pass  # DB not available — resolve from config fields alone
 
+    # Thinking mode only applies to reviews; other purposes leave it off.
+    thinking_mode: str | None = None
+    if purpose == "indexing":
+        resolved = get_indexing_model(base, db_model)
+        config_model = base.indexing_model
+    elif purpose == "review":
+        resolved = get_review_model(base, db_model)
+        config_model = base.review_model
+        thinking_mode = get_review_thinking_mode(base, db_thinking)
+    else:
+        return base.model_copy(update={"reasoning_effort": None})
+
+    source = "dashboard setting" if db_model else ("mira.yaml" if config_model else "default")
+    logger.info("%s model: %s (source: %s)", purpose.capitalize(), resolved, source)
     return base.model_copy(update={"model": resolved, "reasoning_effort": thinking_mode})

--- a/src/mira/index/indexer.py
+++ b/src/mira/index/indexer.py
@@ -812,6 +812,26 @@ async def _index_conventions(
         logger.warning("Failed to persist conventions for %s/%s: %s", owner, repo, exc)
 
 
+def _store_manifest_file(store: IndexStore, path: str, content: str) -> int:
+    """Parse one manifest and replace its package rows. An empty parse still
+    replaces, so stale entries for the path are dropped. Returns package count."""
+    packages = parse_manifest(path, content)
+    store.replace_manifest_packages(
+        path,
+        [
+            {
+                "name": pkg.name,
+                "kind": pkg.kind,
+                "version": pkg.version,
+                "file_path": pkg.file_path,
+                "is_dev": pkg.is_dev,
+            }
+            for pkg in packages
+        ],
+    )
+    return len(packages)
+
+
 async def _index_manifests(
     owner: str,
     repo: str,
@@ -848,25 +868,7 @@ async def _index_manifests(
         if content is None:
             continue
         live.add(path)
-        packages = parse_manifest(path, content)
-        if not packages:
-            # Still replace with empty so stale entries for this path are dropped.
-            store.replace_manifest_packages(path, [])
-            continue
-        store.replace_manifest_packages(
-            path,
-            [
-                {
-                    "name": pkg.name,
-                    "kind": pkg.kind,
-                    "version": pkg.version,
-                    "file_path": pkg.file_path,
-                    "is_dev": pkg.is_dev,
-                }
-                for pkg in packages
-            ],
-        )
-        total_packages += len(packages)
+        total_packages += _store_manifest_file(store, path, content)
 
     # Drop manifest entries whose source file disappeared from the repo.
     store.clear_manifest_packages_for_missing_files(live)
@@ -978,6 +980,41 @@ async def _summarize_directories(store: IndexStore, llm: Any, semaphore: asyncio
     await asyncio.gather(*(_process_chunk(c) for c in chunks))
 
 
+async def _refresh_manifests_incremental(
+    owner: str,
+    repo: str,
+    token: str,
+    branch: str,
+    store: IndexStore,
+    changed_paths: list[str] | None,
+    removed_paths: list[str] | None,
+) -> int:
+    """Refresh package rows for manifests touched by a push. Returns the
+    number of manifest files updated or cleared."""
+    changed = [p for p in changed_paths or [] if is_manifest(p)]
+    removed = [p for p in removed_paths or [] if is_manifest(p)]
+    for path in removed:
+        store.replace_manifest_packages(path, [])
+
+    touched = len(removed)
+    if changed:
+        fetch_sem = asyncio.Semaphore(_FILE_FETCH_SEMAPHORE)
+        contents = await asyncio.gather(
+            *(
+                _fetch_file_content(owner, repo, p, token, ref=branch, semaphore=fetch_sem)
+                for p in changed
+            )
+        )
+        for path, content in zip(changed, contents, strict=False):
+            if content is None:
+                continue
+            _store_manifest_file(store, path, content)
+            touched += 1
+    if touched:
+        logger.info("Refreshed %d manifest file(s) for %s/%s", touched, owner, repo)
+    return touched
+
+
 async def index_diff(
     owner: str,
     repo: str,
@@ -1003,6 +1040,19 @@ async def index_diff(
     if removed_paths:
         store.remove_paths(removed_paths)
         logger.info("Removed %d deleted files from index", len(removed_paths))
+
+    # Manifests/lockfiles are excluded from code indexing but feed the package
+    # inventory — a dependency-bump push usually touches nothing else (#157).
+    try:
+        touched = await _refresh_manifests_incremental(
+            owner, repo, token, branch, store, changed_paths, removed_paths
+        )
+        if touched:
+            from mira.security.poller import poll_repo as _vuln_poll_repo
+
+            asyncio.create_task(_vuln_poll_repo(owner, repo))
+    except Exception as exc:
+        logger.warning("Manifest refresh failed for %s/%s: %s", owner, repo, exc)
 
     if not changed_paths:
         return 0

--- a/src/mira/llm/models.json
+++ b/src/mira/llm/models.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Mira's supported-models registry. Only models listed here can be selected as the indexing or review model. Format mirrors a trimmed subset of LiteLLM's model_prices_and_context_window.json so users familiar with that file recognize the shape.",
+  "_comment": "Mira's model registry — labels, pricing, and per-purpose recommendations for the dashboard and cost estimates. Selection is not limited to this list: the dashboard merges the backend's live catalog and accepts free-form ids. Format mirrors a trimmed subset of LiteLLM's model_prices_and_context_window.json so users familiar with that file recognize the shape.",
   "_fields": {
     "label": "Display name shown in the dashboard dropdown.",
     "provider": "Underlying provider (anthropic, openai, google, etc.) — purely informational.",
@@ -67,6 +67,61 @@
     "purposes": ["review"],
     "recommended_for": []
   },
+  "openai/gpt-4.1-mini": {
+    "label": "GPT-4.1 Mini",
+    "provider": "openai",
+    "max_input_tokens": 1047576,
+    "max_output_tokens": 32768,
+    "input_cost_per_1m": 0.40,
+    "output_cost_per_1m": 1.60,
+    "supports_json_mode": true,
+    "purposes": ["indexing"],
+    "recommended_for": []
+  },
+  "openai/gpt-5-nano": {
+    "label": "GPT-5 Nano",
+    "provider": "openai",
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_1m": 0.05,
+    "output_cost_per_1m": 0.40,
+    "supports_json_mode": true,
+    "purposes": ["indexing"],
+    "recommended_for": []
+  },
+  "openai/gpt-5-mini": {
+    "label": "GPT-5 Mini",
+    "provider": "openai",
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_1m": 0.25,
+    "output_cost_per_1m": 2.00,
+    "supports_json_mode": true,
+    "purposes": ["indexing", "review"],
+    "recommended_for": []
+  },
+  "openai/gpt-5.1-codex-mini": {
+    "label": "GPT-5.1 Codex Mini",
+    "provider": "openai",
+    "max_input_tokens": 400000,
+    "max_output_tokens": 100000,
+    "input_cost_per_1m": 0.25,
+    "output_cost_per_1m": 2.00,
+    "supports_json_mode": true,
+    "purposes": ["indexing", "review"],
+    "recommended_for": []
+  },
+  "openai/gpt-5.1-codex": {
+    "label": "GPT-5.1 Codex",
+    "provider": "openai",
+    "max_input_tokens": 400000,
+    "max_output_tokens": 128000,
+    "input_cost_per_1m": 1.25,
+    "output_cost_per_1m": 10.00,
+    "supports_json_mode": true,
+    "purposes": ["review"],
+    "recommended_for": []
+  },
   "google/gemini-2.5-flash": {
     "label": "Gemini 2.5 Flash",
     "provider": "google",
@@ -87,6 +142,28 @@
     "output_cost_per_1m": 10.00,
     "supports_json_mode": true,
     "purposes": ["review"],
+    "recommended_for": []
+  },
+  "google/gemini-3-flash-preview": {
+    "label": "Gemini 3 Flash (Preview)",
+    "provider": "google",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65535,
+    "input_cost_per_1m": 0.50,
+    "output_cost_per_1m": 3.00,
+    "supports_json_mode": true,
+    "purposes": ["indexing", "review"],
+    "recommended_for": []
+  },
+  "google/gemini-3.1-flash-lite": {
+    "label": "Gemini 3.1 Flash Lite",
+    "provider": "google",
+    "max_input_tokens": 1048576,
+    "max_output_tokens": 65536,
+    "input_cost_per_1m": 0.25,
+    "output_cost_per_1m": 1.50,
+    "supports_json_mode": true,
+    "purposes": ["indexing"],
     "recommended_for": []
   },
   "minimax/MiniMax-M2.7": {

--- a/src/mira/llm/registry.py
+++ b/src/mira/llm/registry.py
@@ -1,8 +1,11 @@
-"""Supported-model registry — single source of truth for capabilities and pricing.
+"""Model registry — labels, capabilities, and pricing for known models.
 
 Backed by ``models.json``. Adding a new model is a one-line registry entry
-plus a release note; no other code needs to change. To deny a model entirely,
-remove its entry — the dashboard validation and dropdown derive from this file.
+plus a release note; no other code needs to change. Entries supply the
+dashboard's labels, per-purpose lists, Recommended badges, and cost-estimate
+pricing, and serve as the dropdown fallback when the backend's live catalog
+can't be fetched (see ``dashboard/model_catalog.py``). The registry does not
+restrict selection — the dashboard accepts free-form ids, like ``mira.yaml``.
 
 Operators can extend or override the bundled list at runtime by pointing
 ``MIRA_MODELS_JSON_PATH`` at their own ``models.json`` (e.g. a volume mount):

--- a/src/mira/outbound_webhooks.py
+++ b/src/mira/outbound_webhooks.py
@@ -87,8 +87,14 @@ class WebhookConfig(BaseModel):
 
 def detect_format(url: str) -> str:
     """Classify a webhook URL as ``"slack"``, ``"teams"`` or ``"generic"``."""
-    host = (urlparse(url).hostname or "").lower()
+    parsed = urlparse(url)
+    host = (parsed.hostname or "").lower()
     if host == "hooks.slack.com":
+        return "slack"
+    # Discord's Slack-compatible variant (…/webhooks/{id}/{token}/slack).
+    # A bare Discord URL expects Discord's own schema, which Mira doesn't
+    # emit — leave it "generic" so the test button surfaces the 400 loudly.
+    if host in ("discord.com", "discordapp.com") and parsed.path.rstrip("/").endswith("/slack"):
         return "slack"
     # Classic Teams connector (*.webhook.office.com) and the newer Teams
     # Workflows endpoints (Power Automate / Logic Apps, *.logic.azure.com).

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,43 @@ def _reset_global_defaults(monkeypatch: pytest.MonkeyPatch):
         mira_config._global_defaults = saved
 
 
+class TestBaseUrlValidation:
+    """base_url is trusted deployment input, but obvious misconfigurations
+    (non-http schemes, plain http to a public host) fail loudly at load."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://openrouter.ai/api/v1",
+            "https://api.together.xyz/v1",
+            "http://localhost:11434/v1",
+            "http://127.0.0.1:8000/v1",
+            "http://ollama:11434/v1",
+            "http://10.0.0.5:8000/v1",
+        ],
+    )
+    def test_accepted(self, url):
+        from mira.config import LLMConfig
+
+        assert LLMConfig(base_url=url).base_url == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://openrouter.ai/api/v1",
+            "file:///etc/passwd",
+            "openrouter.ai/api/v1",
+            "",
+            "http://api.example.com/v1",
+        ],
+    )
+    def test_rejected(self, url):
+        from mira.config import LLMConfig
+
+        with pytest.raises(ValueError):
+            LLMConfig(base_url=url)
+
+
 class TestLoadConfig:
     def test_default_config(self):
         config = load_config()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1665,3 +1665,50 @@ class TestDropOrphanKeyIssues:
     def test_empty_key_issues_returns_empty(self):
         comments = [self._comment(line=10)]
         assert _drop_orphan_key_issues([], comments) == []
+
+
+class TestGlobalRules:
+    """Global rules must come from the shared app DB (issue #123), not a
+    throwaway SQLite AppDatabase() that ignores DATABASE_URL."""
+
+    def _capture_build(self):
+        from mira.llm.prompts.review import build_review_prompt
+
+        return patch("mira.core.engine.build_review_prompt", wraps=build_review_prompt)
+
+    @pytest.mark.asyncio
+    async def test_global_rules_read_from_shared_app_db(
+        self, mock_llm, mock_provider, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+
+        mock_db = MagicMock()
+        mock_db.get_global_rules_text.return_value = ["Security: Never log tokens"]
+        mock_db.get_last_reviewed_sha.return_value = ""
+        mock_db.get_repo.return_value = None
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        engine = ReviewEngine(config=MiraConfig(), llm=mock_llm, provider=mock_provider)
+        with self._capture_build() as mock_build:
+            await engine.review_pr("https://github.com/test/repo/pull/1")
+
+        _, kwargs = mock_build.call_args_list[0]
+        assert kwargs["custom_rules"][0] == {
+            "title": "Security",
+            "content": "Never log tokens",
+        }
+        # No throwaway AppDatabase() → no stray SQLite file in the index dir.
+        assert not (tmp_path / "_app.db").exists()
+
+    @pytest.mark.asyncio
+    async def test_no_app_db_degrades_cleanly(self, mock_llm, mock_provider, monkeypatch, tmp_path):
+        monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+        monkeypatch.setattr("mira.dashboard.api._app_db", None)
+
+        engine = ReviewEngine(config=MiraConfig(), llm=mock_llm, provider=mock_provider)
+        with self._capture_build() as mock_build:
+            await engine.review_pr("https://github.com/test/repo/pull/1")
+
+        _, kwargs = mock_build.call_args_list[0]
+        assert not kwargs["custom_rules"]
+        assert not (tmp_path / "_app.db").exists()

--- a/tests/test_index_indexer.py
+++ b/tests/test_index_indexer.py
@@ -313,6 +313,92 @@ class TestIndexDiff:
         assert store.get_summary("src/utils.py") is not None
         store.close()
 
+    async def test_index_diff_refreshes_changed_lockfile(self, tmp_path):
+        """A lockfile-only push must refresh the package inventory even though
+        lockfiles are excluded from code indexing (#157)."""
+        import asyncio
+
+        store = IndexStore(str(tmp_path / "test.db"))
+        store.replace_manifest_packages(
+            "package-lock.json",
+            [
+                {
+                    "name": "lodash",
+                    "kind": "npm",
+                    "version": "4.17.20",
+                    "file_path": "package-lock.json",
+                    "is_dev": False,
+                }
+            ],
+        )
+
+        lock = json.dumps(
+            {
+                "name": "app",
+                "lockfileVersion": 3,
+                "packages": {"node_modules/lodash": {"version": "4.17.21"}},
+            }
+        )
+        mock_llm = AsyncMock()
+        mock_llm.complete = AsyncMock(return_value='{"files": []}')
+
+        with (
+            patch("mira.index.indexer._fetch_file_content", return_value=lock),
+            patch("mira.security.poller.poll_repo", new=AsyncMock()) as poll,
+        ):
+            count = await index_diff(
+                owner="test",
+                repo="repo",
+                token="fake-token",
+                config=MiraConfig(),
+                store=store,
+                llm=mock_llm,
+                changed_paths=["package-lock.json"],
+            )
+            await asyncio.sleep(0)  # let the fire-and-forget vuln poll run
+
+        # Not code-indexed (excluded), but the inventory picked up the bump.
+        assert count == 0
+        versions = {(p.name, p.version) for p in store.list_manifest_packages()}
+        assert ("lodash", "4.17.21") in versions
+        assert ("lodash", "4.17.20") not in versions
+        mock_llm.complete.assert_not_called()
+        poll.assert_called_once_with("test", "repo")
+        store.close()
+
+    async def test_index_diff_clears_removed_manifest(self, tmp_path):
+        """Deleting a manifest in a push drops its package rows."""
+        store = IndexStore(str(tmp_path / "test.db"))
+        store.replace_manifest_packages(
+            "poetry.lock",
+            [
+                {
+                    "name": "requests",
+                    "kind": "pypi",
+                    "version": "2.31.0",
+                    "file_path": "poetry.lock",
+                    "is_dev": False,
+                }
+            ],
+        )
+
+        mock_llm = AsyncMock()
+        mock_llm.complete = AsyncMock(return_value='{"files": []}')
+
+        with patch("mira.security.poller.poll_repo", new=AsyncMock()):
+            await index_diff(
+                owner="test",
+                repo="repo",
+                token="fake-token",
+                config=MiraConfig(),
+                store=store,
+                llm=mock_llm,
+                removed_paths=["poetry.lock"],
+            )
+
+        assert store.list_manifest_packages() == []
+        store.close()
+
     async def test_index_diff_removes_deleted(self, tmp_path):
         store = IndexStore(str(tmp_path / "test.db"))
         from mira.index.store import FileSummary

--- a/tests/test_model_catalog.py
+++ b/tests/test_model_catalog.py
@@ -1,0 +1,122 @@
+"""Tests for the backend-aware dynamic model catalog."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from mira.config import LLMConfig
+from mira.dashboard import model_catalog
+from mira.dashboard.model_catalog import active_backend, build_options, fetch_catalog
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    model_catalog._cache.clear()
+    yield
+    model_catalog._cache.clear()
+
+
+class TestActiveBackend:
+    def test_default_is_openrouter(self):
+        assert active_backend(LLMConfig()) == "openrouter"
+
+    def test_bedrock_provider(self):
+        assert active_backend(LLMConfig(provider="bedrock")) == "bedrock"
+
+    def test_generic_endpoint(self):
+        assert (
+            active_backend(LLMConfig(base_url="http://localhost:11434/v1")) == "openai-compatible"
+        )
+
+
+class TestBuildOptions:
+    def test_registry_filtered_by_backend(self):
+        openrouter = [m["value"] for m in build_options("openrouter", None, "review")]
+        bedrock = [m["value"] for m in build_options("bedrock", None, "review")]
+        assert "anthropic/claude-sonnet-4-6" in openrouter
+        assert "us.anthropic.claude-sonnet-4-6-v1:0" not in openrouter
+        assert "us.anthropic.claude-sonnet-4-6-v1:0" in bedrock
+        assert "anthropic/claude-sonnet-4-6" not in bedrock
+
+    def test_dynamic_merged_and_deduped_against_registry(self):
+        dynamic = [
+            {"value": "anthropic/claude-sonnet-4.6", "label": "Anthropic: Claude Sonnet 4.6"},
+            {"value": "mistralai/mistral-large-3", "label": "Mistral Large 3"},
+        ]
+        options = build_options("openrouter", dynamic, "review")
+        values = [m["value"] for m in options]
+        # Dot-form alias of a registry id is dropped; genuinely new model kept.
+        assert "anthropic/claude-sonnet-4.6" not in values
+        assert "anthropic/claude-sonnet-4-6" in values
+        assert "mistralai/mistral-large-3" in values
+
+    def test_generic_endpoint_uses_dynamic_only(self):
+        dynamic = [{"value": "llama-3.3-70b", "label": "llama-3.3-70b"}]
+        values = [m["value"] for m in build_options("openai-compatible", dynamic, "review")]
+        assert values == ["llama-3.3-70b"]
+
+    def test_generic_endpoint_falls_back_to_registry(self):
+        values = [m["value"] for m in build_options("openai-compatible", None, "review")]
+        assert "anthropic/claude-sonnet-4-6" in values
+
+    def test_recommended_sort_first(self):
+        options = build_options("openrouter", None, "indexing")
+        assert options[0]["recommended"] is True
+
+
+class TestFetchCatalog:
+    @pytest.mark.asyncio
+    async def test_failure_returns_none_and_is_cached(self, monkeypatch: pytest.MonkeyPatch):
+        calls = 0
+
+        async def boom(config, tools_only):
+            nonlocal calls
+            calls += 1
+            raise RuntimeError("no network")
+
+        monkeypatch.setattr(model_catalog, "_fetch_openai_style", boom)
+        assert await fetch_catalog(LLMConfig()) is None
+        # A dead endpoint must not re-block every settings-page load.
+        assert await fetch_catalog(LLMConfig()) is None
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_result_is_cached(self, monkeypatch: pytest.MonkeyPatch):
+        calls = 0
+
+        async def fake(config, tools_only):
+            nonlocal calls
+            calls += 1
+            return [{"value": "m", "label": "m"}]
+
+        monkeypatch.setattr(model_catalog, "_fetch_openai_style", fake)
+        assert await fetch_catalog(LLMConfig()) == [{"value": "m", "label": "m"}]
+        assert await fetch_catalog(LLMConfig()) == [{"value": "m", "label": "m"}]
+        assert calls == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cold_fetches_coalesce(self, monkeypatch: pytest.MonkeyPatch):
+        calls = 0
+
+        async def slow(config, tools_only):
+            nonlocal calls
+            calls += 1
+            await asyncio.sleep(0.01)
+            return [{"value": "m", "label": "m"}]
+
+        monkeypatch.setattr(model_catalog, "_fetch_openai_style", slow)
+        results = await asyncio.gather(*(fetch_catalog(LLMConfig()) for _ in range(5)))
+        assert all(r == [{"value": "m", "label": "m"}] for r in results)
+        assert calls == 1
+
+    def test_bedrock_cache_key_includes_profile(self):
+        # Switching aws_profile must not serve the previous account's catalog.
+        a = LLMConfig(provider="bedrock", aws_profile="account-a")
+        b = LLMConfig(provider="bedrock", aws_profile="account-b")
+        assert a.region == b.region
+        # Keys derived the same way fetch_catalog does.
+        key_a = f"bedrock:{a.region}:{a.aws_profile or ''}"
+        key_b = f"bedrock:{b.region}:{b.aws_profile or ''}"
+        assert key_a != key_b

--- a/tests/test_models_settings.py
+++ b/tests/test_models_settings.py
@@ -1,0 +1,112 @@
+"""Tests for model override visibility and clearing (issue #124).
+
+Covers:
+- `llm_config_for` logging the effective model and its source.
+- `set_models` accepting "" (inherit from config) and free-form model ids.
+- `get_models` reporting the override source and the config-resolved models.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from mira.config import LLMConfig
+from mira.dashboard.api import ModelsUpdate, get_models, set_models
+from mira.dashboard.db import AppDatabase
+from mira.dashboard.models_config import llm_config_for
+
+
+@pytest.fixture
+def in_memory_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppDatabase:
+    """Fresh per-test SQLite DB swapped in for the module-level `_app_db`."""
+    monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+    db = AppDatabase(url="", admin_password="admin")
+    monkeypatch.setattr("mira.dashboard.api._app_db", db)
+    return db
+
+
+class TestEffectiveModelLogging:
+    def test_dashboard_override_logged_as_source(
+        self, in_memory_db: AppDatabase, caplog: pytest.LogCaptureFixture
+    ):
+        in_memory_db.set_setting("review_model", "custom/model-x")
+        with caplog.at_level(logging.INFO, logger="mira.dashboard.models_config"):
+            resolved = llm_config_for("review", LLMConfig(review_model="openai/gpt-5.1"))
+        assert resolved.model == "custom/model-x"
+        assert "Review model: custom/model-x (source: dashboard setting)" in caplog.text
+
+    def test_config_model_logged_as_mira_yaml(
+        self, in_memory_db: AppDatabase, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(logging.INFO, logger="mira.dashboard.models_config"):
+            resolved = llm_config_for("review", LLMConfig(review_model="openai/gpt-5.1"))
+        assert resolved.model == "openai/gpt-5.1"
+        assert "Review model: openai/gpt-5.1 (source: mira.yaml)" in caplog.text
+
+    def test_fallback_model_logged_as_default(
+        self, in_memory_db: AppDatabase, caplog: pytest.LogCaptureFixture
+    ):
+        with caplog.at_level(logging.INFO, logger="mira.dashboard.models_config"):
+            llm_config_for("indexing", LLMConfig(model="anthropic/claude-sonnet-4-6"))
+        assert "Indexing model: anthropic/claude-sonnet-4-6 (source: default)" in caplog.text
+
+
+class TestSetModelsInheritAndCustom:
+    def test_empty_value_clears_override(self, in_memory_db: AppDatabase):
+        in_memory_db.set_setting("review_model", "anthropic/claude-sonnet-4-6")
+        body = ModelsUpdate(indexing_model="", review_model="")
+        assert set_models(body) == {"ok": True}
+        assert in_memory_db.get_setting("review_model") == ""
+        # Cleared override → config is authoritative again.
+        cfg = LLMConfig(review_model="openai/gpt-5.1")
+        assert llm_config_for("review", cfg).model == "openai/gpt-5.1"
+
+    def test_non_registry_model_accepted(self, in_memory_db: AppDatabase):
+        body = ModelsUpdate(
+            indexing_model="local/llama-3.3-70b",
+            review_model="openai/gpt-5.1-codex-mini",
+        )
+        assert set_models(body) == {"ok": True}
+        assert in_memory_db.get_setting("review_model") == "openai/gpt-5.1-codex-mini"
+        assert llm_config_for("review", LLMConfig()).model == "openai/gpt-5.1-codex-mini"
+
+
+@pytest.fixture
+def no_catalog_fetch(monkeypatch: pytest.MonkeyPatch):
+    """Keep get_models off the network and hermetic — default config,
+    static registry options only (a developer's env/mira.yaml must not
+    leak into assertions)."""
+    from mira.config import MiraConfig
+
+    async def _none(config):
+        return None
+
+    monkeypatch.setattr("mira.dashboard.model_catalog.fetch_catalog", _none)
+    monkeypatch.setattr("mira.config.load_config", lambda *a, **kw: MiraConfig())
+
+
+class TestGetModelsSource:
+    @pytest.mark.asyncio
+    async def test_reports_dashboard_source_and_config_target(
+        self, in_memory_db: AppDatabase, no_catalog_fetch
+    ):
+        in_memory_db.set_setting("review_model", "custom/model-x")
+        resp = await get_models()
+        assert resp.review_source == "dashboard"
+        assert resp.review_model == "custom/model-x"
+        assert resp.indexing_source == "config"
+        # The inherit target ignores the override.
+        assert resp.config_review_model != "custom/model-x"
+
+    @pytest.mark.asyncio
+    async def test_reports_config_source_without_override(
+        self, in_memory_db: AppDatabase, no_catalog_fetch
+    ):
+        resp = await get_models()
+        assert resp.review_source == "config"
+        assert resp.indexing_source == "config"
+        assert resp.review_model == resp.config_review_model
+        assert resp.backend == "openrouter"

--- a/tests/test_outbound_webhooks.py
+++ b/tests/test_outbound_webhooks.py
@@ -78,6 +78,17 @@ class TestFormatDetection:
         # Subdomain-confusion guard: must not match without the leading dot.
         assert nf.detect_format("https://evilwebhook.office.com/x") == "generic"
 
+    def test_discord_slack_variant(self):
+        assert nf.detect_format("https://discord.com/api/webhooks/123/tok/slack") == "slack"
+        assert nf.detect_format("https://discordapp.com/api/webhooks/123/tok/slack/") == "slack"
+
+    def test_bare_discord_url_stays_generic(self):
+        # Discord's own schema isn't emitted — generic makes the 400 visible.
+        assert nf.detect_format("https://discord.com/api/webhooks/123/tok") == "generic"
+
+    def test_discord_lookalike_host_is_not_slack(self):
+        assert nf.detect_format("https://evildiscord.com/api/webhooks/1/t/slack") == "generic"
+
     def test_mask_hides_middle(self):
         masked = nf.mask_url("https://hooks.slack.com/services/T0/B0/abcd1234")
         assert masked == "https://hooks.slack.com/…1234"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from mira.llm import registry
 
 
@@ -60,3 +62,38 @@ class TestRegistryRegression:
         review = registry.models_for_purpose("review")
         values = [m["value"] for m in review]
         assert "anthropic/claude-sonnet-4-6" in values
+
+
+class TestCurrentGenerationModels:
+    """GPT-5.x / Gemini 3.x additions (issue #125) — ids and pricing verified
+    against the live OpenRouter catalog."""
+
+    @pytest.mark.parametrize(
+        ("model_id", "pricing", "purposes"),
+        [
+            ("openai/gpt-4.1-mini", (0.40, 1.60), ["indexing"]),
+            ("openai/gpt-5-nano", (0.05, 0.40), ["indexing"]),
+            ("openai/gpt-5-mini", (0.25, 2.00), ["indexing", "review"]),
+            ("openai/gpt-5.1-codex-mini", (0.25, 2.00), ["indexing", "review"]),
+            ("openai/gpt-5.1-codex", (1.25, 10.00), ["review"]),
+            ("google/gemini-3-flash-preview", (0.50, 3.00), ["indexing", "review"]),
+            ("google/gemini-3.1-flash-lite", (0.25, 1.50), ["indexing"]),
+        ],
+    )
+    def test_registered_with_pricing_and_purposes(self, model_id, pricing, purposes):
+        assert registry.pricing(model_id) == pricing
+        for purpose in purposes:
+            assert registry.is_supported(model_id, purpose=purpose)
+            assert model_id in [m["value"] for m in registry.models_for_purpose(purpose)]
+
+    def test_recommended_defaults_unchanged(self):
+        indexing = registry.models_for_purpose("indexing")
+        review = registry.models_for_purpose("review")
+        assert [m["value"] for m in indexing if m["recommended"]] == [
+            "anthropic/claude-haiku-4-5",
+            "us.anthropic.claude-haiku-4-5-v1:0",
+        ]
+        assert [m["value"] for m in review if m["recommended"]] == [
+            "anthropic/claude-sonnet-4-6",
+            "us.anthropic.claude-sonnet-4-6-v1:0",
+        ]

--- a/ui/mira/src/components/model-combobox.tsx
+++ b/ui/mira/src/components/model-combobox.tsx
@@ -1,0 +1,181 @@
+import { useRef, useState, type ReactNode } from "react"
+
+import { Input } from "@/components/ui/input"
+
+export type ModelOption = {
+  value: string
+  label: string
+  recommended?: boolean
+}
+
+function ComboboxItem({
+  onPick,
+  highlighted,
+  onHover,
+  children,
+}: {
+  onPick: () => void
+  highlighted: boolean
+  onHover: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={highlighted}
+      ref={(el) => {
+        if (highlighted) el?.scrollIntoView({ block: "nearest" })
+      }}
+      className={`flex w-full items-center px-2 py-1.5 text-left text-sm ${
+        highlighted ? "bg-accent text-accent-foreground" : ""
+      }`}
+      onMouseDown={(e) => {
+        e.preventDefault()
+        onPick()
+      }}
+      onMouseEnter={onHover}
+    >
+      {children}
+    </button>
+  )
+}
+
+// Searchable model picker. Typing filters the backend's catalog; arrows +
+// Enter or click select; free-form ids commit via the "Use …" row. When
+// `configModel` is set, an "Inherit from deployment config" row is pinned
+// first and selecting it yields value "".
+export function ModelCombobox({
+  value,
+  onChange,
+  options,
+  configModel,
+}: {
+  value: string
+  onChange: (v: string) => void
+  options: ModelOption[]
+  configModel?: string
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const [highlight, setHighlight] = useState(-1)
+
+  const selected =
+    value === "" && configModel !== undefined
+      ? `Inherit from deployment config (${configModel})`
+      : (options.find((o) => o.value === value)?.label ?? value)
+  const q = query.trim().toLowerCase()
+  const filtered = q
+    ? options.filter((o) => `${o.label} ${o.value}`.toLowerCase().includes(q))
+    : options
+  const showInherit = configModel !== undefined
+  const custom =
+    query.trim() && !filtered.some((o) => o.value === query.trim())
+      ? query.trim()
+      : null
+  const rowCount = (showInherit ? 1 : 0) + filtered.length + (custom ? 1 : 0)
+
+  const pick = (v: string) => {
+    onChange(v)
+    inputRef.current?.blur()
+  }
+
+  const pickAt = (i: number) => {
+    if (showInherit && i === 0) return pick("")
+    const j = i - (showInherit ? 1 : 0)
+    if (j < filtered.length) return pick(filtered[j].value)
+    if (custom) return pick(custom)
+  }
+
+  // Row index of the first catalog option (after the inherit row, if any).
+  const firstOption = showInherit ? 1 : 0
+
+  return (
+    <div className="relative">
+      <Input
+        ref={inputRef}
+        role="combobox"
+        aria-expanded={open}
+        value={open ? query : selected}
+        placeholder="Search models…"
+        onFocus={() => {
+          setOpen(true)
+          setQuery("")
+          setHighlight(-1)
+        }}
+        onBlur={() => setOpen(false)}
+        onChange={(e) => {
+          setQuery(e.target.value)
+          setOpen(true)
+          setHighlight(-1)
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown") {
+            e.preventDefault()
+            setHighlight((h) => Math.min(h + 1, rowCount - 1))
+          } else if (e.key === "ArrowUp") {
+            e.preventDefault()
+            setHighlight((h) => Math.max(h - 1, 0))
+          } else if (e.key === "Enter") {
+            if (highlight >= 0) pickAt(highlight)
+            else if (query.trim())
+              // Prefer the top visible match; raw text only when nothing matches.
+              pickAt(filtered.length > 0 ? firstOption : rowCount - 1)
+          } else if (e.key === "Escape") {
+            inputRef.current?.blur()
+          }
+        }}
+      />
+      {open && (
+        <div
+          role="listbox"
+          className="absolute z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md"
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          {showInherit && (
+            <ComboboxItem
+              onPick={() => pick("")}
+              highlighted={highlight === 0}
+              onHover={() => setHighlight(0)}
+            >
+              Inherit from deployment config
+              <span className="ml-2 font-mono text-xs text-muted-foreground">
+                {configModel}
+              </span>
+            </ComboboxItem>
+          )}
+          {filtered.map((opt, i) => (
+            <ComboboxItem
+              key={opt.value}
+              onPick={() => pick(opt.value)}
+              highlighted={highlight === firstOption + i}
+              onHover={() => setHighlight(firstOption + i)}
+            >
+              <span className="truncate">{opt.label}</span>
+              {opt.value !== opt.label && (
+                <span className="ml-2 truncate font-mono text-xs text-muted-foreground">
+                  {opt.value}
+                </span>
+              )}
+              {opt.recommended && (
+                <span className="ml-auto pl-2 text-xs text-muted-foreground">
+                  Recommended
+                </span>
+              )}
+            </ComboboxItem>
+          ))}
+          {custom && (
+            <ComboboxItem
+              onPick={() => pick(custom)}
+              highlighted={highlight === rowCount - 1}
+              onHover={() => setHighlight(rowCount - 1)}
+            >
+              Use “{custom}”
+            </ComboboxItem>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/mira/src/lib/api/settings.ts
+++ b/ui/mira/src/lib/api/settings.ts
@@ -6,6 +6,11 @@ export const settingsApi = {
     fetchJson<{
       indexing_model: string
       review_model: string
+      backend: string
+      indexing_source: "dashboard" | "config"
+      review_source: "dashboard" | "config"
+      config_indexing_model: string
+      config_review_model: string
       indexing_options: {
         value: string
         label: string

--- a/ui/mira/src/pages/settings.tsx
+++ b/ui/mira/src/pages/settings.tsx
@@ -1,6 +1,7 @@
 import { Loader2 } from "lucide-react"
 import { useEffect, useState } from "react"
 
+import { ModelCombobox, type ModelOption } from "@/components/model-combobox"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -28,18 +29,16 @@ export function SettingsPage() {
   const { user: currentUser } = useAuth()
   const { section = "models" } = useParams()
 
+  // "" = inherit from deployment config; anything else is a model id.
   const [indexingModel, setIndexingModel] = useState("")
   const [reviewModel, setReviewModel] = useState("")
-  const [indexingOptions, setIndexingOptions] = useState<
-    { value: string; label: string; recommended?: boolean }[]
-  >([])
-  const [reviewOptions, setReviewOptions] = useState<
-    { value: string; label: string; recommended?: boolean }[]
-  >([])
+  const [configIndexingModel, setConfigIndexingModel] = useState("")
+  const [configReviewModel, setConfigReviewModel] = useState("")
+  const [backend, setBackend] = useState("")
+  const [indexingOptions, setIndexingOptions] = useState<ModelOption[]>([])
+  const [reviewOptions, setReviewOptions] = useState<ModelOption[]>([])
   const [thinkingMode, setThinkingMode] = useState("off")
-  const [thinkingOptions, setThinkingOptions] = useState<
-    { value: string; label: string; recommended?: boolean }[]
-  >([])
+  const [thinkingOptions, setThinkingOptions] = useState<ModelOption[]>([])
   const [savingModels, setSavingModels] = useState(false)
   const [modelsSaved, setModelsSaved] = useState(false)
 
@@ -66,8 +65,11 @@ export function SettingsPage() {
   useEffect(() => {
     if (!currentUser?.is_admin) return
     api.getModels().then((m) => {
-      setIndexingModel(m.indexing_model)
-      setReviewModel(m.review_model)
+      setIndexingModel(m.indexing_source === "config" ? "" : m.indexing_model)
+      setReviewModel(m.review_source === "config" ? "" : m.review_model)
+      setConfigIndexingModel(m.config_indexing_model)
+      setConfigReviewModel(m.config_review_model)
+      setBackend(m.backend)
       setIndexingOptions(m.indexing_options)
       setReviewOptions(m.review_options)
       setThinkingMode(m.review_thinking_mode)
@@ -317,28 +319,23 @@ export function SettingsPage() {
             <CardTitle>Models</CardTitle>
             <CardDescription>
               Choose models for indexing and PR reviews
+              {backend &&
+                ` — listed from ${
+                  { openrouter: "OpenRouter", bedrock: "AWS Bedrock" }[
+                    backend
+                  ] ?? "your configured endpoint"
+                }`}
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="space-y-2">
               <label className="text-sm font-medium">Indexing Model</label>
-              <Select value={indexingModel} onValueChange={setIndexingModel}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {indexingOptions.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>
-                      {opt.label}
-                      {opt.recommended && (
-                        <span className="ml-2 text-xs text-muted-foreground">
-                          Recommended
-                        </span>
-                      )}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <ModelCombobox
+                value={indexingModel}
+                onChange={setIndexingModel}
+                options={indexingOptions}
+                configModel={configIndexingModel}
+              />
               <p className="text-xs text-muted-foreground">
                 Used to summarize files when building the code index. A cheaper
                 model is recommended since it runs over every file.
@@ -346,23 +343,12 @@ export function SettingsPage() {
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium">Review Model</label>
-              <Select value={reviewModel} onValueChange={setReviewModel}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {reviewOptions.map((opt) => (
-                    <SelectItem key={opt.value} value={opt.value}>
-                      {opt.label}
-                      {opt.recommended && (
-                        <span className="ml-2 text-xs text-muted-foreground">
-                          Recommended
-                        </span>
-                      )}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <ModelCombobox
+                value={reviewModel}
+                onChange={setReviewModel}
+                options={reviewOptions}
+                configModel={configReviewModel}
+              />
               <p className="text-xs text-muted-foreground">
                 Used to analyze PRs and post review comments. A more powerful
                 model gives better review quality.

--- a/ui/mira/src/pages/setup.tsx
+++ b/ui/mira/src/pages/setup.tsx
@@ -2,6 +2,7 @@ import { Loader2 } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useNavigate } from "react-router"
 
+import { ModelCombobox, type ModelOption } from "@/components/model-combobox"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -10,36 +11,29 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
 import { api } from "@/lib/api"
 import { useDocumentTitle } from "@/lib/hooks"
-
-type ModelOption = {
-  value: string
-  label: string
-  recommended?: boolean
-}
 
 export function SetupPage() {
   useDocumentTitle("Setup")
   const navigate = useNavigate()
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  // "" = inherit from deployment config — an untouched save must not
+  // convert mira.yaml-sourced models into dashboard overrides.
   const [indexingModel, setIndexingModel] = useState("")
   const [reviewModel, setReviewModel] = useState("")
+  const [configIndexingModel, setConfigIndexingModel] = useState("")
+  const [configReviewModel, setConfigReviewModel] = useState("")
   const [indexingOptions, setIndexingOptions] = useState<ModelOption[]>([])
   const [reviewOptions, setReviewOptions] = useState<ModelOption[]>([])
 
   useEffect(() => {
     api.getModels().then((data) => {
-      setIndexingModel(data.indexing_model)
-      setReviewModel(data.review_model)
+      setIndexingModel(data.indexing_source === "config" ? "" : data.indexing_model)
+      setReviewModel(data.review_source === "config" ? "" : data.review_model)
+      setConfigIndexingModel(data.config_indexing_model)
+      setConfigReviewModel(data.config_review_model)
       setIndexingOptions(data.indexing_options)
       setReviewOptions(data.review_options)
       setLoading(false)
@@ -82,23 +76,12 @@ export function SetupPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Select value={indexingModel} onValueChange={setIndexingModel}>
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {indexingOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                  {opt.recommended && (
-                    <span className="ml-2 text-xs text-muted-foreground">
-                      Recommended
-                    </span>
-                  )}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <ModelCombobox
+            value={indexingModel}
+            onChange={setIndexingModel}
+            options={indexingOptions}
+            configModel={configIndexingModel}
+          />
         </CardContent>
       </Card>
 
@@ -111,23 +94,12 @@ export function SetupPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Select value={reviewModel} onValueChange={setReviewModel}>
-            <SelectTrigger>
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {reviewOptions.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                  {opt.recommended && (
-                    <span className="ml-2 text-xs text-muted-foreground">
-                      Recommended
-                    </span>
-                  )}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <ModelCombobox
+            value={reviewModel}
+            onChange={setReviewModel}
+            options={reviewOptions}
+            configModel={configReviewModel}
+          />
         </CardContent>
       </Card>
 

--- a/ui/mira/src/pages/webhooks.tsx
+++ b/ui/mira/src/pages/webhooks.tsx
@@ -85,7 +85,8 @@ export function WebhooksPage() {
           <h1 className="text-2xl font-semibold tracking-tight">Webhooks</h1>
           <p className="text-sm text-muted-foreground">
             Send a webhook to any HTTPS endpoint when Mira reviews a PR or
-            finishes indexing. Slack and Teams URLs are auto-formatted.
+            finishes indexing. Slack, Teams, and Discord (…/slack) URLs are
+            auto-formatted.
           </p>
         </div>
         {webhooks.length > 0 && (


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary

- Activity page
- Enhanced model selection for providers like OpenRouter
- Fixes https://github.com/miracodeai/mira/issues/123, https://github.com/miracodeai/mira/issues/124, https://github.com/miracodeai/mira/issues/125, https://github.com/miracodeai/mira/issues/157, https://github.com/miracodeai/mira/issues/158

## Test plan

<!-- How did you verify this works? -->
- CI tests, on test instance

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
