### PR TITLE
Added learnings approval process

### DIFF
--- a/scripts/play_learning.py
+++ b/scripts/play_learning.py
@@ -262,8 +262,11 @@ async def run(scenario: Scenario, *, owner: str = "play", repo: str = "demo") ->
     n_llm = await synthesize_from_human_reviews(store, llm)
     print(f"LLM rules upserted: {n_llm}")
 
-    # 4. Inspect rules
+    # 4. Inspect rules — approve them first so the review step injects them
+    # (synthesized rules land quarantined as pending)
     _print_header("Step 3 — learned rules now in store")
+    for r in store.list_learned_rules():
+        store.set_learned_rule_status(r.id, "approved")
     rules = store.list_active_learned_rules()
     if not rules:
         print("(none)")

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -1604,11 +1604,13 @@ class RuleCreate(BaseModel):
 
 
 class LearnedRuleModel(BaseModel):
+    id: int
     rule_text: str
     source_signal: str  # "reject_pattern" | "accept_pattern" | "human_pattern"
     category: str
     path_pattern: str = ""
     sample_count: int = 0
+    status: str = "approved"  # "pending" | "approved" | "declined"
     updated_at: float = 0.0
 
 
@@ -1617,25 +1619,74 @@ class OrgLearnedRuleModel(LearnedRuleModel):
     repo: str
 
 
+class LearnedRuleStatusUpdate(BaseModel):
+    status: str  # "approved" | "declined"
+
+
+class LearnedRuleTextUpdate(BaseModel):
+    rule_text: str
+
+
+def _learned_rule_model(r) -> LearnedRuleModel:
+    return LearnedRuleModel(
+        id=r.id,
+        rule_text=r.rule_text,
+        source_signal=r.source_signal,
+        category=r.category,
+        path_pattern=r.path_pattern,
+        sample_count=r.sample_count,
+        status=r.status,
+        updated_at=r.updated_at,
+    )
+
+
 @router.get(
     "/api/repos/{owner}/{repo}/learned-rules",
     response_model=list[LearnedRuleModel],
 )
 def list_repo_learned_rules(owner: str, repo: str) -> list[LearnedRuleModel]:
-    """Active learned rules synthesized from feedback signals on this repo."""
+    """All learned rules for this repo, including pending and declined."""
     with _open_store(owner, repo) as store:
-        rules = store.list_active_learned_rules()
-        return [
-            LearnedRuleModel(
-                rule_text=r.rule_text,
-                source_signal=r.source_signal,
-                category=r.category,
-                path_pattern=r.path_pattern,
-                sample_count=r.sample_count,
-                updated_at=r.updated_at,
-            )
-            for r in rules
-        ]
+        return [_learned_rule_model(r) for r in store.list_learned_rules()]
+
+
+@router.patch(
+    "/api/repos/{owner}/{repo}/learned-rules/{rule_id}/status",
+    response_model=LearnedRuleModel,
+)
+def set_learned_rule_status(
+    owner: str, repo: str, rule_id: int, body: LearnedRuleStatusUpdate
+) -> LearnedRuleModel:
+    if body.status not in ("approved", "declined"):
+        raise HTTPException(status_code=400, detail="Status must be 'approved' or 'declined'")
+    with _open_store(owner, repo) as store:
+        if not store.get_learned_rule(rule_id):
+            raise HTTPException(status_code=404, detail="Learning not found")
+        r = store.set_learned_rule_status(rule_id, body.status)
+        return _learned_rule_model(r)
+
+
+@router.put(
+    "/api/repos/{owner}/{repo}/learned-rules/{rule_id}",
+    response_model=LearnedRuleModel,
+)
+def update_learned_rule(
+    owner: str, repo: str, rule_id: int, body: LearnedRuleTextUpdate
+) -> LearnedRuleModel:
+    if not body.rule_text.strip():
+        raise HTTPException(status_code=400, detail="Rule text cannot be empty")
+    with _open_store(owner, repo) as store:
+        if not store.get_learned_rule(rule_id):
+            raise HTTPException(status_code=404, detail="Learning not found")
+        r = store.update_learned_rule_text(rule_id, body.rule_text.strip())
+        return _learned_rule_model(r)
+
+
+@router.delete("/api/repos/{owner}/{repo}/learned-rules/{rule_id}")
+def delete_learned_rule(owner: str, repo: str, rule_id: int) -> dict:
+    with _open_store(owner, repo) as store:
+        store.delete_learned_rule(rule_id)
+        return {"ok": True}
 
 
 @router.get("/api/learned-rules", response_model=list[OrgLearnedRuleModel])
@@ -1655,11 +1706,13 @@ def list_org_learned_rules(limit: int = 500) -> list[OrgLearnedRuleModel]:
         OrgLearnedRuleModel(
             owner=r["owner"],
             repo=r["repo"],
+            id=r["id"],
             rule_text=r["rule_text"],
             source_signal=r["source_signal"],
             category=r["category"],
             path_pattern=r["path_pattern"],
             sample_count=r["sample_count"],
+            status=r["status"],
             updated_at=r["updated_at"] or 0.0,
         )
         for r in rows

--- a/src/mira/index/pg_store.py
+++ b/src/mira/index/pg_store.py
@@ -141,6 +141,7 @@ CREATE TABLE IF NOT EXISTS learned_rules (
     path_pattern TEXT NOT NULL DEFAULT '',
     sample_count INTEGER NOT NULL DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
+    status TEXT NOT NULL DEFAULT 'approved',
     created_at DOUBLE PRECISION NOT NULL DEFAULT 0,
     updated_at DOUBLE PRECISION NOT NULL DEFAULT 0
 );
@@ -205,6 +206,10 @@ def _get_conn(url: str):
                 cur.execute(
                     "ALTER TABLE files ADD COLUMN IF NOT EXISTS loc INTEGER NOT NULL DEFAULT 0"
                 )
+                cur.execute(
+                    "ALTER TABLE learned_rules ADD COLUMN IF NOT EXISTS "
+                    "status TEXT NOT NULL DEFAULT 'approved'"
+                )
             _schema_initialized = True
         return _pg_conn
 
@@ -216,8 +221,8 @@ def list_learned_rules_org_wide(url: str, limit: int = 1000) -> list[dict]:
     conn = _get_conn(url)
     with conn.cursor() as cur:
         cur.execute(
-            "SELECT owner, repo, rule_text, source_signal, category, "
-            "path_pattern, sample_count, updated_at "
+            "SELECT owner, repo, id, rule_text, source_signal, category, "
+            "path_pattern, sample_count, status, updated_at "
             "FROM learned_rules WHERE active = 1 "
             "ORDER BY sample_count DESC, updated_at DESC LIMIT %s",
             (limit,),
@@ -227,12 +232,14 @@ def list_learned_rules_org_wide(url: str, limit: int = 1000) -> list[dict]:
         {
             "owner": r[0],
             "repo": r[1],
-            "rule_text": r[2],
-            "source_signal": r[3],
-            "category": r[4],
-            "path_pattern": r[5],
-            "sample_count": r[6],
-            "updated_at": r[7],
+            "id": r[2],
+            "rule_text": r[3],
+            "source_signal": r[4],
+            "category": r[5],
+            "path_pattern": r[6],
+            "sample_count": r[7],
+            "status": r[8],
+            "updated_at": r[9],
         }
         for r in rows
     ]
@@ -1024,34 +1031,33 @@ class PgIndexStore(_StoreSharedMixin):
     ) -> LearnedRuleRow:
         now = time.time()
         existing = self._fetchone(
-            "SELECT id FROM learned_rules WHERE owner=%s AND repo=%s "
+            "SELECT id, status FROM learned_rules WHERE owner=%s AND repo=%s "
             "AND category=%s AND path_pattern=%s",
             (self._owner, self._repo, category, path_pattern),
         )
         if existing:
             with self._conn.cursor() as cur:
-                cur.execute(
-                    "UPDATE learned_rules SET rule_text=%s, source_signal=%s, "
-                    "sample_count=%s, updated_at=%s WHERE id=%s",
-                    (rule_text, source_signal, sample_count, now, existing[0]),
-                )
+                if existing[1] == "pending":
+                    cur.execute(
+                        "UPDATE learned_rules SET rule_text=%s, source_signal=%s, "
+                        "sample_count=%s, updated_at=%s WHERE id=%s",
+                        (rule_text, source_signal, sample_count, now, existing[0]),
+                    )
+                else:
+                    # Approved/declined rows keep their text (and any manual
+                    # edits); only the evidence counters refresh.
+                    cur.execute(
+                        "UPDATE learned_rules SET sample_count=%s, updated_at=%s WHERE id=%s",
+                        (sample_count, now, existing[0]),
+                    )
             self._conn.commit()
-            return LearnedRuleRow(
-                id=existing[0],
-                rule_text=rule_text,
-                source_signal=source_signal,
-                category=category,
-                path_pattern=path_pattern,
-                sample_count=sample_count,
-                created_at=now,
-                updated_at=now,
-            )
+            return self.get_learned_rule(existing[0])  # type: ignore[return-value]
         with self._conn.cursor() as cur:
             cur.execute(
                 "INSERT INTO learned_rules "
                 "(owner, repo, rule_text, source_signal, category, path_pattern, "
-                "sample_count, active, created_at, updated_at) "
-                "VALUES (%s, %s, %s, %s, %s, %s, %s, 1, %s, %s) RETURNING id",
+                "sample_count, active, status, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, 1, 'pending', %s, %s) RETURNING id",
                 (
                     self._owner,
                     self._repo,
@@ -1073,32 +1079,84 @@ class PgIndexStore(_StoreSharedMixin):
             category=category,
             path_pattern=path_pattern,
             sample_count=sample_count,
+            status="pending",
             created_at=now,
             updated_at=now,
         )
 
+    _LEARNED_RULE_COLS = (
+        "id, rule_text, source_signal, category, path_pattern, "
+        "sample_count, active, status, created_at, updated_at"
+    )
+
+    @staticmethod
+    def _learned_rule_row(r: tuple) -> LearnedRuleRow:
+        return LearnedRuleRow(
+            id=r[0],
+            rule_text=r[1],
+            source_signal=r[2],
+            category=r[3],
+            path_pattern=r[4],
+            sample_count=r[5],
+            active=bool(r[6]),
+            status=r[7],
+            created_at=r[8],
+            updated_at=r[9],
+        )
+
     def list_active_learned_rules(self) -> list[LearnedRuleRow]:
         rows = self._fetchall(
-            "SELECT id, rule_text, source_signal, category, path_pattern, "
-            "sample_count, active, created_at, updated_at "
+            f"SELECT {self._LEARNED_RULE_COLS} "
             "FROM learned_rules WHERE owner=%s AND repo=%s AND active=1 "
-            "ORDER BY sample_count DESC",
+            "AND status='approved' ORDER BY sample_count DESC",
             (self._owner, self._repo),
         )
-        return [
-            LearnedRuleRow(
-                id=r[0],
-                rule_text=r[1],
-                source_signal=r[2],
-                category=r[3],
-                path_pattern=r[4],
-                sample_count=r[5],
-                active=bool(r[6]),
-                created_at=r[7],
-                updated_at=r[8],
+        return [self._learned_rule_row(r) for r in rows]
+
+    def list_learned_rules(self) -> list[LearnedRuleRow]:
+        """All learned rules regardless of status."""
+        rows = self._fetchall(
+            f"SELECT {self._LEARNED_RULE_COLS} "
+            "FROM learned_rules WHERE owner=%s AND repo=%s ORDER BY sample_count DESC",
+            (self._owner, self._repo),
+        )
+        return [self._learned_rule_row(r) for r in rows]
+
+    def get_learned_rule(self, rule_id: int) -> LearnedRuleRow | None:
+        row = self._fetchone(
+            f"SELECT {self._LEARNED_RULE_COLS} "
+            "FROM learned_rules WHERE owner=%s AND repo=%s AND id=%s",
+            (self._owner, self._repo, rule_id),
+        )
+        return self._learned_rule_row(row) if row else None
+
+    def set_learned_rule_status(self, rule_id: int, status: str) -> LearnedRuleRow | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE learned_rules SET status=%s, updated_at=%s "
+                "WHERE owner=%s AND repo=%s AND id=%s",
+                (status, time.time(), self._owner, self._repo, rule_id),
             )
-            for r in rows
-        ]
+        self._conn.commit()
+        return self.get_learned_rule(rule_id)
+
+    def update_learned_rule_text(self, rule_id: int, rule_text: str) -> LearnedRuleRow | None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE learned_rules SET rule_text=%s, updated_at=%s "
+                "WHERE owner=%s AND repo=%s AND id=%s",
+                (rule_text, time.time(), self._owner, self._repo, rule_id),
+            )
+        self._conn.commit()
+        return self.get_learned_rule(rule_id)
+
+    def delete_learned_rule(self, rule_id: int) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM learned_rules WHERE owner=%s AND repo=%s AND id=%s",
+                (self._owner, self._repo, rule_id),
+            )
+        self._conn.commit()
 
     def replace_manifest_packages(
         self,

--- a/src/mira/index/store.py
+++ b/src/mira/index/store.py
@@ -113,6 +113,7 @@ CREATE TABLE IF NOT EXISTS learned_rules (
     path_pattern TEXT NOT NULL DEFAULT '',
     sample_count INTEGER NOT NULL DEFAULT 0,
     active INTEGER NOT NULL DEFAULT 1,
+    status TEXT NOT NULL DEFAULT 'approved',
     created_at REAL NOT NULL DEFAULT 0,
     updated_at REAL NOT NULL DEFAULT 0
 );
@@ -241,6 +242,7 @@ class LearnedRuleRow:
     path_pattern: str
     sample_count: int
     active: bool = True
+    status: str = "approved"  # 'pending' | 'approved' | 'declined'
     created_at: float = 0.0
     updated_at: float = 0.0
 
@@ -292,6 +294,11 @@ class IndexStore(_StoreSharedMixin):
         cols = {r[1] for r in self._conn.execute("PRAGMA table_info(files)").fetchall()}
         if "loc" not in cols:
             self._conn.execute("ALTER TABLE files ADD COLUMN loc INTEGER NOT NULL DEFAULT 0")
+        lr_cols = {r[1] for r in self._conn.execute("PRAGMA table_info(learned_rules)").fetchall()}
+        if "status" not in lr_cols:
+            self._conn.execute(
+                "ALTER TABLE learned_rules ADD COLUMN status TEXT NOT NULL DEFAULT 'approved'"
+            )
         self._conn.commit()
 
     @classmethod
@@ -878,30 +885,29 @@ class IndexStore(_StoreSharedMixin):
     ) -> LearnedRuleRow:
         now = time.time()
         existing = self._conn.execute(
-            "SELECT id FROM learned_rules WHERE category = ? AND path_pattern = ?",
+            "SELECT id, status FROM learned_rules WHERE category = ? AND path_pattern = ?",
             (category, path_pattern),
         ).fetchone()
         if existing:
-            self._conn.execute(
-                "UPDATE learned_rules SET rule_text = ?, source_signal = ?, "
-                "sample_count = ?, updated_at = ? WHERE id = ?",
-                (rule_text, source_signal, sample_count, now, existing[0]),
-            )
+            if existing[1] == "pending":
+                self._conn.execute(
+                    "UPDATE learned_rules SET rule_text = ?, source_signal = ?, "
+                    "sample_count = ?, updated_at = ? WHERE id = ?",
+                    (rule_text, source_signal, sample_count, now, existing[0]),
+                )
+            else:
+                # Approved/declined rows keep their text (and any manual edits);
+                # only the evidence counters refresh.
+                self._conn.execute(
+                    "UPDATE learned_rules SET sample_count = ?, updated_at = ? WHERE id = ?",
+                    (sample_count, now, existing[0]),
+                )
             self._conn.commit()
-            return LearnedRuleRow(
-                id=existing[0],
-                rule_text=rule_text,
-                source_signal=source_signal,
-                category=category,
-                path_pattern=path_pattern,
-                sample_count=sample_count,
-                created_at=now,
-                updated_at=now,
-            )
+            return self.get_learned_rule(existing[0])  # type: ignore[return-value]
         cur = self._conn.execute(
             "INSERT INTO learned_rules "
             "(rule_text, source_signal, category, path_pattern, sample_count, "
-            "active, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 1, ?, ?)",
+            "active, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 1, 'pending', ?, ?)",
             (rule_text, source_signal, category, path_pattern, sample_count, now, now),
         )
         self._conn.commit()
@@ -912,30 +918,71 @@ class IndexStore(_StoreSharedMixin):
             category=category,
             path_pattern=path_pattern,
             sample_count=sample_count,
+            status="pending",
             created_at=now,
             updated_at=now,
         )
 
+    _LEARNED_RULE_COLS = (
+        "id, rule_text, source_signal, category, path_pattern, "
+        "sample_count, active, status, created_at, updated_at"
+    )
+
+    @staticmethod
+    def _learned_rule_row(r: tuple) -> LearnedRuleRow:
+        return LearnedRuleRow(
+            id=r[0],
+            rule_text=r[1],
+            source_signal=r[2],
+            category=r[3],
+            path_pattern=r[4],
+            sample_count=r[5],
+            active=bool(r[6]),
+            status=r[7],
+            created_at=r[8],
+            updated_at=r[9],
+        )
+
     def list_active_learned_rules(self) -> list[LearnedRuleRow]:
         rows = self._conn.execute(
-            "SELECT id, rule_text, source_signal, category, path_pattern, "
-            "sample_count, active, created_at, updated_at "
-            "FROM learned_rules WHERE active = 1 ORDER BY sample_count DESC"
+            f"SELECT {self._LEARNED_RULE_COLS} FROM learned_rules "
+            "WHERE active = 1 AND status = 'approved' ORDER BY sample_count DESC"
         ).fetchall()
-        return [
-            LearnedRuleRow(
-                id=r[0],
-                rule_text=r[1],
-                source_signal=r[2],
-                category=r[3],
-                path_pattern=r[4],
-                sample_count=r[5],
-                active=bool(r[6]),
-                created_at=r[7],
-                updated_at=r[8],
-            )
-            for r in rows
-        ]
+        return [self._learned_rule_row(r) for r in rows]
+
+    def list_learned_rules(self) -> list[LearnedRuleRow]:
+        """All learned rules regardless of status."""
+        rows = self._conn.execute(
+            f"SELECT {self._LEARNED_RULE_COLS} FROM learned_rules ORDER BY sample_count DESC"
+        ).fetchall()
+        return [self._learned_rule_row(r) for r in rows]
+
+    def get_learned_rule(self, rule_id: int) -> LearnedRuleRow | None:
+        row = self._conn.execute(
+            f"SELECT {self._LEARNED_RULE_COLS} FROM learned_rules WHERE id = ?",
+            (rule_id,),
+        ).fetchone()
+        return self._learned_rule_row(row) if row else None
+
+    def set_learned_rule_status(self, rule_id: int, status: str) -> LearnedRuleRow | None:
+        self._conn.execute(
+            "UPDATE learned_rules SET status = ?, updated_at = ? WHERE id = ?",
+            (status, time.time(), rule_id),
+        )
+        self._conn.commit()
+        return self.get_learned_rule(rule_id)
+
+    def update_learned_rule_text(self, rule_id: int, rule_text: str) -> LearnedRuleRow | None:
+        self._conn.execute(
+            "UPDATE learned_rules SET rule_text = ?, updated_at = ? WHERE id = ?",
+            (rule_text, time.time(), rule_id),
+        )
+        self._conn.commit()
+        return self.get_learned_rule(rule_id)
+
+    def delete_learned_rule(self, rule_id: int) -> None:
+        self._conn.execute("DELETE FROM learned_rules WHERE id = ?", (rule_id,))
+        self._conn.commit()
 
     def replace_manifest_packages(
         self,
@@ -1269,22 +1316,29 @@ def list_learned_rules_org_wide_sqlite(limit: int = 500) -> list[dict]:
         try:
             conn = sqlite3.connect(db_path)
             try:
+                # Raw connection bypasses IndexStore migrations; older repo DBs
+                # may not have the status column yet.
+                cols = {r[1] for r in conn.execute("PRAGMA table_info(learned_rules)").fetchall()}
+                has_status = "status" in cols
+                status_col = "status" if has_status else "'approved'"
                 cur = conn.execute(
-                    "SELECT rule_text, source_signal, category, path_pattern, "
-                    "sample_count, updated_at FROM learned_rules WHERE active = 1 "
-                    "ORDER BY updated_at DESC"
+                    f"SELECT id, rule_text, source_signal, category, path_pattern, "
+                    f"sample_count, {status_col}, updated_at FROM learned_rules "
+                    "WHERE active = 1 ORDER BY updated_at DESC"
                 )
                 for r in cur.fetchall():
                     rows.append(
                         {
                             "owner": owner,
                             "repo": repo,
-                            "rule_text": r[0],
-                            "source_signal": r[1],
-                            "category": r[2],
-                            "path_pattern": r[3],
-                            "sample_count": r[4],
-                            "updated_at": r[5],
+                            "id": r[0],
+                            "rule_text": r[1],
+                            "source_signal": r[2],
+                            "category": r[3],
+                            "path_pattern": r[4],
+                            "sample_count": r[5],
+                            "status": r[6],
+                            "updated_at": r[7],
                         }
                     )
             finally:

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -461,5 +461,6 @@ class LearnedRule:
     path_pattern: str  # e.g. 'tests/**' or '' for all
     sample_count: int
     active: bool = True
+    status: str = "approved"  # 'pending' | 'approved' | 'declined'
     created_at: float = 0.0
     updated_at: float = 0.0

--- a/tests/evals/test_eval_learning.py
+++ b/tests/evals/test_eval_learning.py
@@ -66,6 +66,13 @@ def _engine() -> tuple[ReviewEngine, LLMProvider]:
     return engine, llm
 
 
+def _approve_all(store: IndexStore) -> None:
+    """Synthesized rules land quarantined as pending; evals exercise the
+    approved path."""
+    for r in store.list_learned_rules():
+        store.set_learned_rule_status(r.id, "approved")
+
+
 def _fake_pr_info(owner: str, repo: str) -> PRInfo:
     return PRInfo(
         title="Eval PR",
@@ -94,6 +101,7 @@ class TestSynthesis:
         n_pat = synthesize_rules(store)
         _, llm = _engine()
         n_llm = await synthesize_from_human_reviews(store, llm)
+        _approve_all(store)
         store.close()
 
         assert n_pat + n_llm >= 1, "no rules emerged from null-check feedback"
@@ -117,6 +125,7 @@ class TestSynthesis:
         synthesize_rules(store)
         _, llm = _engine()
         n_llm = await synthesize_from_human_reviews(store, llm)
+        _approve_all(store)
         store.close()
 
         assert n_llm >= 1, "LLM did not produce a rule from 8 'where are the tests' comments"
@@ -145,6 +154,7 @@ class TestRulesInfluenceReview:
         synthesize_rules(store)
         engine, llm = _engine()
         await synthesize_from_human_reviews(store, llm)
+        _approve_all(store)
         store.close()
 
         engine._pr_info = _fake_pr_info(owner, repo)
@@ -177,6 +187,7 @@ class TestRulesInfluenceReview:
         synthesize_rules(store)
         engine, llm = _engine()
         await synthesize_from_human_reviews(store, llm)
+        _approve_all(store)
 
         # Part A — deterministic: at least one learned rule must be persisted
         # and retrievable via the same code path the engine uses at review time.

--- a/tests/test_learned_rules_api.py
+++ b/tests/test_learned_rules_api.py
@@ -1,0 +1,104 @@
+"""Learned-rules quarantine endpoints: list includes pending rules,
+approve/decline, edit, and delete."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from fastapi import HTTPException
+
+from mira.dashboard import api
+from mira.index.store import IndexStore
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    s = IndexStore(str(tmp_path / "t.db"))
+
+    @contextmanager
+    def fake_open_store(owner, repo):
+        yield s
+
+    monkeypatch.setattr(api, "_open_store", fake_open_store)
+    yield s
+    s.close()
+
+
+def _seed(store) -> int:
+    row = store.upsert_learned_rule(
+        rule_text="Avoid raw SQL in controllers.",
+        source_signal="human_pattern",
+        category="human_review",
+        path_pattern="",
+        sample_count=3,
+    )
+    return row.id
+
+
+def test_list_includes_pending_with_id_and_status(store):
+    rule_id = _seed(store)
+    out = api.list_repo_learned_rules("acme", "web")
+    assert len(out) == 1
+    assert out[0].id == rule_id
+    assert out[0].status == "pending"
+
+
+def test_approve_and_decline(store):
+    rule_id = _seed(store)
+    out = api.set_learned_rule_status(
+        "acme", "web", rule_id, api.LearnedRuleStatusUpdate(status="approved")
+    )
+    assert out.status == "approved"
+    assert store.get_learned_rules_text() == ["Avoid raw SQL in controllers."]
+
+    out = api.set_learned_rule_status(
+        "acme", "web", rule_id, api.LearnedRuleStatusUpdate(status="declined")
+    )
+    assert out.status == "declined"
+    assert store.get_learned_rules_text() == []
+
+
+def test_status_rejects_invalid_value(store):
+    rule_id = _seed(store)
+    with pytest.raises(HTTPException) as exc:
+        api.set_learned_rule_status(
+            "acme", "web", rule_id, api.LearnedRuleStatusUpdate(status="pending")
+        )
+    assert exc.value.status_code == 400
+
+
+def test_status_404_on_missing_rule(store):
+    with pytest.raises(HTTPException) as exc:
+        api.set_learned_rule_status(
+            "acme", "web", 999, api.LearnedRuleStatusUpdate(status="approved")
+        )
+    assert exc.value.status_code == 404
+
+
+def test_update_rule_text(store):
+    rule_id = _seed(store)
+    out = api.update_learned_rule(
+        "acme", "web", rule_id, api.LearnedRuleTextUpdate(rule_text="  New wording  ")
+    )
+    assert out.rule_text == "New wording"
+    assert out.status == "pending"  # editing never changes status
+
+
+def test_update_rejects_empty_text(store):
+    rule_id = _seed(store)
+    with pytest.raises(HTTPException) as exc:
+        api.update_learned_rule("acme", "web", rule_id, api.LearnedRuleTextUpdate(rule_text="   "))
+    assert exc.value.status_code == 400
+
+
+def test_update_404_on_missing_rule(store):
+    with pytest.raises(HTTPException) as exc:
+        api.update_learned_rule("acme", "web", 999, api.LearnedRuleTextUpdate(rule_text="x"))
+    assert exc.value.status_code == 404
+
+
+def test_delete(store):
+    rule_id = _seed(store)
+    assert api.delete_learned_rule("acme", "web", rule_id) == {"ok": True}
+    assert store.list_learned_rules() == []

--- a/tests/test_merge_learning.py
+++ b/tests/test_merge_learning.py
@@ -136,7 +136,7 @@ class TestSynthesizeRules:
             _fb(store, signal="rejected", category="style", pr=i)
         n = synthesize_rules(store)
         assert n >= 1
-        rules = store.list_active_learned_rules()
+        rules = store.list_learned_rules()
         assert any(r.source_signal == "reject_pattern" for r in rules)
 
     def test_positive_rule_on_high_accept_rate(self, store):
@@ -145,7 +145,7 @@ class TestSynthesizeRules:
             _fb(store, signal="accepted", category="bug", pr=i)
         n = synthesize_rules(store)
         assert n >= 1
-        rules = store.list_active_learned_rules()
+        rules = store.list_learned_rules()
         assert any(r.source_signal == "accept_pattern" and r.category == "bug" for r in rules)
 
     def test_low_accept_rate_no_positive_rule(self, store):
@@ -155,7 +155,7 @@ class TestSynthesizeRules:
         for i in range(3, 6):
             _fb(store, signal="rejected", category="clarity", pr=i)
         synthesize_rules(store)
-        rules = store.list_active_learned_rules()
+        rules = store.list_learned_rules()
         assert not any(r.source_signal == "accept_pattern" for r in rules)
 
     def test_reject_pattern_suppresses_accept_rule(self, store):
@@ -166,7 +166,7 @@ class TestSynthesizeRules:
         for i in range(5, 15):
             _fb(store, signal="accepted", category="style", pr=i)
         synthesize_rules(store)
-        rules = store.list_active_learned_rules()
+        rules = store.list_learned_rules()
         # Only the reject_pattern rule should exist for this category.
         style_rules = [r for r in rules if r.category == "style"]
         assert all(r.source_signal == "reject_pattern" for r in style_rules)
@@ -175,6 +175,109 @@ class TestSynthesizeRules:
         for i in range(5):
             _fb(store, signal="rejected", category="", pr=i)
         assert synthesize_rules(store) == 0
+
+
+# ── Quarantine (status lifecycle) ──
+
+
+class TestLearnedRuleQuarantine:
+    def _synthesize_reject_rule(self, store, count=5, start_pr=0):
+        for i in range(start_pr, start_pr + count):
+            _fb(store, signal="rejected", category="style", pr=i)
+        synthesize_rules(store)
+        return next(r for r in store.list_learned_rules() if r.source_signal == "reject_pattern")
+
+    def test_new_rules_are_pending_and_not_applied(self, store):
+        rule = self._synthesize_reject_rule(store)
+        assert rule.status == "pending"
+        assert store.list_active_learned_rules() == []
+        assert store.get_learned_rules_text() == []
+
+    def test_approve_makes_rule_applied(self, store):
+        rule = self._synthesize_reject_rule(store)
+        updated = store.set_learned_rule_status(rule.id, "approved")
+        assert updated.status == "approved"
+        assert [r.id for r in store.list_active_learned_rules()] == [rule.id]
+        assert store.get_learned_rules_text() == [rule.rule_text]
+
+    def test_decline_persists_across_resynthesis(self, store):
+        rule = self._synthesize_reject_rule(store)
+        store.set_learned_rule_status(rule.id, "declined")
+        # More feedback and another synthesis pass must not resurrect it.
+        self._synthesize_reject_rule(store, count=3, start_pr=100)
+        after = store.get_learned_rule(rule.id)
+        assert after.status == "declined"
+        assert after.sample_count > rule.sample_count
+        assert store.list_active_learned_rules() == []
+
+    def test_approved_rule_keeps_manual_edits_on_resynthesis(self, store):
+        rule = self._synthesize_reject_rule(store)
+        store.set_learned_rule_status(rule.id, "approved")
+        store.update_learned_rule_text(rule.id, "my custom wording")
+        self._synthesize_reject_rule(store, count=3, start_pr=100)
+        after = store.get_learned_rule(rule.id)
+        assert after.status == "approved"
+        assert after.rule_text == "my custom wording"
+        assert after.sample_count > rule.sample_count
+
+    def test_pending_rule_text_refreshed_on_resynthesis(self, store):
+        rule = self._synthesize_reject_rule(store)
+        self._synthesize_reject_rule(store, count=3, start_pr=100)
+        after = store.get_learned_rule(rule.id)
+        assert after.status == "pending"
+        assert after.rule_text != rule.rule_text  # embeds the new reject count
+
+    def test_edit_does_not_change_status(self, store):
+        rule = self._synthesize_reject_rule(store)
+        updated = store.update_learned_rule_text(rule.id, "edited")
+        assert updated.rule_text == "edited"
+        assert updated.status == "pending"
+
+    def test_delete_then_resynthesis_creates_fresh_pending(self, store):
+        rule = self._synthesize_reject_rule(store)
+        store.set_learned_rule_status(rule.id, "approved")
+        store.delete_learned_rule(rule.id)
+        assert store.get_learned_rule(rule.id) is None
+        fresh = self._synthesize_reject_rule(store, count=3, start_pr=100)
+        assert fresh.status == "pending"
+
+    def test_migration_grandfathers_existing_rows_as_approved(self, tmp_path):
+        import sqlite3
+        import time
+
+        # Build a legacy DB with a pre-status learned_rules table.
+        db_path = str(tmp_path / "legacy.db")
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE learned_rules ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "rule_text TEXT NOT NULL DEFAULT '', "
+            "source_signal TEXT NOT NULL DEFAULT '', "
+            "category TEXT NOT NULL DEFAULT '', "
+            "path_pattern TEXT NOT NULL DEFAULT '', "
+            "sample_count INTEGER NOT NULL DEFAULT 0, "
+            "active INTEGER NOT NULL DEFAULT 1, "
+            "created_at REAL NOT NULL DEFAULT 0, "
+            "updated_at REAL NOT NULL DEFAULT 0)"
+        )
+        now = time.time()
+        conn.execute(
+            "INSERT INTO learned_rules (rule_text, source_signal, category, "
+            "path_pattern, sample_count, created_at, updated_at) "
+            "VALUES ('old rule', 'reject_pattern', 'style', '', 5, ?, ?)",
+            (now, now),
+        )
+        conn.commit()
+        conn.close()
+
+        s = IndexStore(db_path)
+        try:
+            rules = s.list_learned_rules()
+            assert len(rules) == 1
+            assert rules[0].status == "approved"
+            assert s.get_learned_rules_text() == ["old rule"]
+        finally:
+            s.close()
 
 
 # ── synthesize_from_human_reviews (LLM) ──
@@ -227,7 +330,7 @@ class TestSynthesizeFromHumanReviews:
         assert n == 2
         llm.complete.assert_called_once()
         # Verify stored as human_pattern source
-        rules = store.list_active_learned_rules()
+        rules = store.list_learned_rules()
         human_rules = [r for r in rules if r.source_signal == "human_pattern"]
         assert len(human_rules) == 2
 
@@ -555,11 +658,12 @@ async def test_handle_pr_merged_end_to_end(tmp_path, monkeypatch):
     # LLM was invoked exactly once for this merge.
     fake_llm.complete.assert_called_once()
 
-    # One human_pattern rule stored.
-    rules = store.list_active_learned_rules()
+    # One human_pattern rule stored, quarantined as pending.
+    rules = store.list_learned_rules()
     human_rules = [r for r in rules if r.source_signal == "human_pattern"]
     assert len(human_rules) == 1
     assert "raw sql" in human_rules[0].rule_text.lower()
+    assert human_rules[0].status == "pending"
 
     # ── Dedup on retry ──
     fake_llm.complete.reset_mock()

--- a/ui/mira/src/lib/api/rules.ts
+++ b/ui/mira/src/lib/api/rules.ts
@@ -10,6 +10,25 @@ export const rulesApi = {
   listRepoLearnedRules: (owner: string, repo: string) =>
     fetchJson<LearnedRuleModel[]>(`/api/repos/${owner}/${repo}/learned-rules`),
 
+  setLearnedRuleStatus: (
+    owner: string,
+    repo: string,
+    id: number,
+    status: "approved" | "declined"
+  ) =>
+    patchJson<LearnedRuleModel>(
+      `/api/repos/${owner}/${repo}/learned-rules/${id}/status`,
+      { status }
+    ),
+
+  updateLearnedRule: (owner: string, repo: string, id: number, rule_text: string) =>
+    putJson<LearnedRuleModel>(`/api/repos/${owner}/${repo}/learned-rules/${id}`, {
+      rule_text,
+    }),
+
+  deleteLearnedRule: (owner: string, repo: string, id: number) =>
+    deleteJson(`/api/repos/${owner}/${repo}/learned-rules/${id}`),
+
   // Global rules
   listGlobalRules: () => fetchJson<RuleModel[]>("/api/rules/global"),
 

--- a/ui/mira/src/lib/api/types.ts
+++ b/ui/mira/src/lib/api/types.ts
@@ -107,11 +107,13 @@ export interface VulnerabilitySummary {
 }
 
 export interface LearnedRuleModel {
+  id: number
   rule_text: string
   source_signal: string
   category: string
   path_pattern: string
   sample_count: number
+  status: "pending" | "approved" | "declined"
   updated_at: number
 }
 

--- a/ui/mira/src/pages/learned-rules.tsx
+++ b/ui/mira/src/pages/learned-rules.tsx
@@ -1,8 +1,19 @@
-import { Brain, Sparkles } from "lucide-react"
-import { useMemo } from "react"
+import {
+  Brain,
+  Check,
+  ChevronDown,
+  Pencil,
+  ShieldQuestion,
+  Sparkles,
+  Trash2,
+  Undo2,
+  X,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
 import { Link } from "react-router"
 
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -10,6 +21,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { ConfirmButton } from "@/components/ui/confirm-button"
+import { Textarea } from "@/components/ui/textarea"
 import { api, type OrgLearnedRuleModel } from "@/lib/api"
 import { useAsync, useDocumentTitle } from "@/lib/hooks"
 
@@ -25,44 +43,196 @@ const SIGNAL_STYLE: Record<string, string> = {
   human_pattern: "text-violet-300 border-violet-500/40 bg-violet-500/10",
 }
 
+const ruleKey = (r: OrgLearnedRuleModel) => `${r.owner}/${r.repo}#${r.id}`
+
 export function LearnedRulesPage() {
   useDocumentTitle("Learnings")
-  const { data: rules, loading } = useAsync(
-    () => api.listLearnedRules().catch(() => []),
-    [],
-  )
+  const [rules, setRules] = useState<OrgLearnedRuleModel[]>([])
+  const [loading, setLoading] = useState(true)
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+  const [editingText, setEditingText] = useState("")
   const { data: version } = useAsync(
     () => api.getVersion().catch(() => null),
     [],
   )
   const botName = version?.bot_name ?? "miracodeai"
 
+  useEffect(() => {
+    api
+      .listLearnedRules()
+      .then(setRules)
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [])
+
+  const pending = useMemo(() => rules.filter((r) => r.status === "pending"), [rules])
+  const approved = useMemo(() => rules.filter((r) => r.status === "approved"), [rules])
+  const declined = useMemo(() => rules.filter((r) => r.status === "declined"), [rules])
+
   // Group by (owner/repo) so the page reads "what Mira learned about each repo"
   const grouped = useMemo(() => {
     const map = new Map<string, OrgLearnedRuleModel[]>()
-    for (const r of rules ?? []) {
+    for (const r of approved) {
       const key = `${r.owner}/${r.repo}`
       const list = map.get(key)
       if (list) list.push(r)
       else map.set(key, [r])
     }
     return [...map.entries()].sort((a, b) => b[1].length - a[1].length)
-  }, [rules])
+  }, [approved])
 
-  const totalRules = rules?.length ?? 0
+  const totalRules = approved.length
   const reposWithRules = grouped.length
+
+  const setStatus = async (
+    rule: OrgLearnedRuleModel,
+    status: "approved" | "declined",
+  ) => {
+    const updated = await api.setLearnedRuleStatus(rule.owner, rule.repo, rule.id, status)
+    setRules((prev) =>
+      prev.map((r) => (ruleKey(r) === ruleKey(rule) ? { ...r, ...updated } : r)),
+    )
+  }
+
+  const startEdit = (rule: OrgLearnedRuleModel) => {
+    setEditingKey(ruleKey(rule))
+    setEditingText(rule.rule_text)
+  }
+
+  const saveEdit = async (rule: OrgLearnedRuleModel) => {
+    if (!editingText.trim()) return
+    const updated = await api.updateLearnedRule(
+      rule.owner,
+      rule.repo,
+      rule.id,
+      editingText.trim(),
+    )
+    setRules((prev) =>
+      prev.map((r) => (ruleKey(r) === ruleKey(rule) ? { ...r, ...updated } : r)),
+    )
+    setEditingKey(null)
+  }
+
+  const remove = async (rule: OrgLearnedRuleModel) => {
+    await api.deleteLearnedRule(rule.owner, rule.repo, rule.id)
+    setRules((prev) => prev.filter((r) => ruleKey(r) !== ruleKey(rule)))
+  }
+
+  const ruleMeta = (rule: OrgLearnedRuleModel, showRepo = false) => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge
+        variant="outline"
+        className={`text-[10px] ${SIGNAL_STYLE[rule.source_signal] ?? ""}`}
+      >
+        {SIGNAL_LABEL[rule.source_signal] ?? rule.source_signal}
+      </Badge>
+      {showRepo && (
+        <Link
+          to={`/repos/${rule.owner}/${rule.repo}`}
+          className="font-mono text-xs text-muted-foreground hover:underline"
+        >
+          {rule.owner}/{rule.repo}
+        </Link>
+      )}
+      {rule.category && (
+        <span className="text-xs font-medium text-muted-foreground">
+          {rule.category}
+        </span>
+      )}
+      {rule.path_pattern && !rule.path_pattern.startsWith("__llm_pattern") && (
+        <span className="font-mono text-xs text-muted-foreground">
+          {rule.path_pattern}
+        </span>
+      )}
+      <span className="ml-auto text-xs text-muted-foreground">
+        {rule.sample_count} sample{rule.sample_count !== 1 ? "s" : ""}
+      </span>
+    </div>
+  )
+
+  const ruleEditor = (rule: OrgLearnedRuleModel) => (
+    <div className="space-y-2">
+      <Textarea
+        className="min-h-[80px] text-sm"
+        value={editingText}
+        onChange={(e) => setEditingText(e.target.value)}
+      />
+      <div className="flex gap-2">
+        <Button size="sm" onClick={() => saveEdit(rule)} disabled={!editingText.trim()}>
+          Save
+        </Button>
+        <Button size="sm" variant="ghost" onClick={() => setEditingKey(null)}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
 
   return (
     <div className="space-y-6 p-6">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Learnings</h1>
         <p className="text-sm text-muted-foreground">
-          What Mira has learned from your team's PR feedback. These inject into
-          every review automatically — no configuration needed.
+          What Mira has learned from your team's PR feedback. Approved learnings
+          inject into every review automatically.
         </p>
       </div>
 
-      {!loading && totalRules === 0 ? (
+      {pending.length > 0 && (
+        <Card className="border-amber-500/40">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <ShieldQuestion className="h-4 w-4 text-amber-400" />
+              <CardTitle className="text-base">Pending approval</CardTitle>
+              <Badge
+                variant="outline"
+                className="border-amber-500/40 bg-amber-500/10 tabular-nums text-amber-300"
+              >
+                {pending.length}
+              </Badge>
+            </div>
+            <CardDescription>
+              New learnings land here and only apply to reviews once approved.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {pending.map((rule) => (
+                <div key={ruleKey(rule)} className="space-y-1.5 rounded-lg border p-3">
+                  {ruleMeta(rule, true)}
+                  {editingKey === ruleKey(rule) ? (
+                    ruleEditor(rule)
+                  ) : (
+                    <p className="text-sm text-foreground/90">{rule.rule_text}</p>
+                  )}
+                  <div className="flex gap-2 pt-1">
+                    <Button size="sm" onClick={() => setStatus(rule, "approved")}>
+                      <Check className="mr-1 h-3 w-3" /> Approve
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setStatus(rule, "declined")}
+                    >
+                      <X className="mr-1 h-3 w-3" /> Decline
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-8 w-8"
+                      onClick={() => startEdit(rule)}
+                    >
+                      <Pencil className="h-3 w-3" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {!loading && rules.length === 0 ? (
         <Card>
           <CardContent className="space-y-3 py-12 text-center">
             <Brain className="mx-auto h-8 w-8 text-muted-foreground" />
@@ -82,7 +252,7 @@ export function LearnedRulesPage() {
               <Sparkles className="h-3.5 w-3.5 text-muted-foreground" />
               <span className="font-semibold tabular-nums">{totalRules}</span>
               <span className="text-muted-foreground">
-                rule{totalRules !== 1 ? "s" : ""} across {reposWithRules}{" "}
+                approved rule{totalRules !== 1 ? "s" : ""} across {reposWithRules}{" "}
                 repo{reposWithRules !== 1 ? "s" : ""}
               </span>
             </div>
@@ -115,37 +285,43 @@ export function LearnedRulesPage() {
                   </CardHeader>
                   <CardContent>
                     <div className="space-y-3">
-                      {repoRules.map((rule, i) => (
+                      {repoRules.map((rule) => (
                         <div
-                          key={`${rule.category}-${rule.path_pattern}-${i}`}
+                          key={ruleKey(rule)}
                           className="space-y-1.5 rounded-lg border p-3"
                         >
-                          <div className="flex flex-wrap items-center gap-2">
-                            <Badge
-                              variant="outline"
-                              className={`text-[10px] ${SIGNAL_STYLE[rule.source_signal] ?? ""}`}
-                            >
-                              {SIGNAL_LABEL[rule.source_signal] ??
-                                rule.source_signal}
-                            </Badge>
-                            {rule.category && (
-                              <span className="text-xs font-medium text-muted-foreground">
-                                {rule.category}
-                              </span>
-                            )}
-                            {rule.path_pattern && (
-                              <span className="font-mono text-xs text-muted-foreground">
-                                {rule.path_pattern}
-                              </span>
-                            )}
-                            <span className="ml-auto text-xs text-muted-foreground">
-                              {rule.sample_count}{" "}
-                              sample{rule.sample_count !== 1 ? "s" : ""}
-                            </span>
-                          </div>
-                          <p className="text-sm text-foreground/90">
-                            {rule.rule_text}
-                          </p>
+                          {ruleMeta(rule)}
+                          {editingKey === ruleKey(rule) ? (
+                            ruleEditor(rule)
+                          ) : (
+                            <div className="flex items-start gap-2">
+                              <p className="flex-1 text-sm text-foreground/90">
+                                {rule.rule_text}
+                              </p>
+                              <div className="flex gap-1">
+                                <Button
+                                  size="icon"
+                                  variant="ghost"
+                                  className="h-8 w-8"
+                                  onClick={() => startEdit(rule)}
+                                >
+                                  <Pencil className="h-3 w-3" />
+                                </Button>
+                                <ConfirmButton
+                                  size="icon"
+                                  variant="ghost"
+                                  className="h-8 w-8"
+                                  destructive
+                                  dialogTitle="Delete learning?"
+                                  dialogDescription="This forgets the learning entirely. It may be re-synthesized as pending from future feedback. To suppress it permanently, decline it instead."
+                                  confirmLabel="Delete"
+                                  onConfirm={() => remove(rule)}
+                                >
+                                  <Trash2 className="h-3 w-3" />
+                                </ConfirmButton>
+                              </div>
+                            </div>
+                          )}
                         </div>
                       ))}
                     </div>
@@ -155,6 +331,55 @@ export function LearnedRulesPage() {
             })}
           </div>
         </>
+      )}
+
+      {declined.length > 0 && (
+        <Collapsible>
+          <CollapsibleTrigger className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground">
+            <ChevronDown className="h-3.5 w-3.5" />
+            Declined ({declined.length})
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="mt-3 space-y-3">
+              {declined.map((rule) => (
+                <div
+                  key={ruleKey(rule)}
+                  className="space-y-1.5 rounded-lg border p-3 opacity-50"
+                >
+                  {ruleMeta(rule, true)}
+                  <div className="flex items-start gap-2">
+                    <p className="flex-1 text-sm text-foreground/90">
+                      {rule.rule_text}
+                    </p>
+                    <div className="flex gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8"
+                        title="Restore"
+                        onClick={() => setStatus(rule, "approved")}
+                      >
+                        <Undo2 className="h-3 w-3" />
+                      </Button>
+                      <ConfirmButton
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8"
+                        destructive
+                        dialogTitle="Delete learning?"
+                        dialogDescription="This forgets the learning entirely. It may be re-synthesized as pending from future feedback."
+                        confirmLabel="Delete"
+                        onConfirm={() => remove(rule)}
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </ConfirmButton>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
       )}
     </div>
   )


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary

- Added new learnings review/approval process

## Test plan

See CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
