### PR TITLE
Bump TypeScript version to 6.0.3

### DIFF
--- a/ui/mira/package-lock.json
+++ b/ui/mira/package-lock.json
@@ -41,7 +41,7 @@
         "globals": "^17.7.0",
         "prettier": "^3.8.4",
         "prettier-plugin-tailwindcss": "^0.8.0",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.62.0",
         "vite": "^8.0.16"
       }
@@ -8522,9 +8522,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/ui/mira/package.json
+++ b/ui/mira/package.json
@@ -45,7 +45,7 @@
     "globals": "^17.7.0",
     "prettier": "^3.8.4",
     "prettier-plugin-tailwindcss": "^0.8.0",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.62.0",
     "vite": "^8.0.16"
   }

--- a/ui/mira/tsconfig.app.json
+++ b/ui/mira/tsconfig.app.json
@@ -23,7 +23,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/ui/mira/tsconfig.json
+++ b/ui/mira/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
Before opening this PR, please ensure:
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary

- Bumps TypeScript version to 6.0.3

## Test plan
- Local build & CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
