### PR TITLE
Fix GitHub repo sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,7 @@ All notable changes to Mira are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- **Stale PostgreSQL connections after idle** — `AppDatabase` and `pg_store` keep
-  long-lived psycopg handles that can go dead behind poolers or `idle_session_timeout`.
-  A new `mira.db.postgres` module adds `ReconnectingCursor`, which retries once on
-  `OperationalError` for `execute` and `executemany` (covering dashboard API routes,
-  indexing, and the vulnerability poller) without adding per-query liveness probes.
-- **`/health` reflects Postgres availability** — when `DATABASE_URL` is Postgres,
-  the endpoint runs a one-shot `SELECT 1` on a dedicated connection that is always
-  closed afterward, and returns HTTP 503 if the database is unreachable.
-
-## [0.6.0] — 2026-07-09
+## [0.6.0] — 2026-07-10
 
 ### Added
 
@@ -32,6 +19,21 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - **Malformed LLM JSON is recovered instead of dropped.** Responses that leak Anthropic tool-call XML (`</parameter></invoke>`) or arrive with an unbalanced brace are now repaired before parsing, so a chunk's comments are no longer lost when a model's output strays from clean JSON. Affects both the main and security passes.
+- **Stale PostgreSQL connections after idle** — `AppDatabase` and `pg_store` keep
+  long-lived psycopg handles that can go dead behind poolers or `idle_session_timeout`.
+  A new `mira.db.postgres` module adds `ReconnectingCursor`, which retries once on
+  `OperationalError` for `execute` and `executemany` (covering dashboard API routes,
+  indexing, and the vulnerability poller) without adding per-query liveness probes.
+- **`/health` reflects Postgres availability** — when `DATABASE_URL` is Postgres,
+  the endpoint runs a one-shot `SELECT 1` on a dedicated connection that is always
+  closed afterward, and returns HTTP 503 if the database is unreachable.
+- **Creating or editing a learning requires authentication** — the learned-rule
+  create and update endpoints now return 401 for unauthenticated requests instead
+  of proceeding with an anonymous author.
+- **Dashboard setup and repo sync respect a repo's platform** — completing setup
+  writes index mode and status to the correct `(platform, owner, repo)` row (GitLab
+  repos could previously not be opted out of initial indexing), and the GitHub repo
+  sync no longer targets GitLab rows when pruning stale repos.
 
 ## [0.5.1] — 2026-07-09
 
@@ -256,6 +258,7 @@ Initial public release.
 - `handle_push_index` now updates `updated_at` after incremental re-indexing
   so the "Indexed X ago" timestamp tracks reality.
 
+[0.6.0]: https://github.com/miracodeai/mira/releases/tag/v0.6.0
 [0.5.1]: https://github.com/miracodeai/mira/releases/tag/v0.5.1
 [0.5.0]: https://github.com/miracodeai/mira/releases/tag/v0.5.0
 [0.4.1]: https://github.com/miracodeai/mira/releases/tag/v0.4.1

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -399,7 +399,7 @@ class PendingUninstallModel(BaseModel):
 
 
 class SetupRequest(BaseModel):
-    repos: list[dict]  # [{"owner": "x", "repo": "y", "enabled": true}]
+    repos: list[dict]  # [{"owner": "x", "repo": "y", "platform": "github", "enabled": true}]
     index_mode: str  # "full" or "light"
 
 

--- a/src/mira/dashboard/routers/admin.py
+++ b/src/mira/dashboard/routers/admin.py
@@ -399,11 +399,12 @@ async def complete_setup(body: SetupRequest) -> dict:
     enabled_count = 0
     for r in body.repos:
         owner, repo = r["owner"], r["repo"]
+        platform = r.get("platform", "github")
         enabled = r.get("enabled", True)
         mode = body.index_mode if enabled else "none"
-        _api._app_db.set_repo_index_mode(owner, repo, mode)
+        _api._app_db.set_repo_index_mode(owner, repo, mode, platform=platform)
         if enabled:
-            _api._app_db.set_repo_status(owner, repo, "indexing")
+            _api._app_db.set_repo_status(owner, repo, "indexing", platform=platform)
             enabled_count += 1
 
     _api._app_db.mark_setup_complete()

--- a/src/mira/dashboard/routers/repos.py
+++ b/src/mira/dashboard/routers/repos.py
@@ -115,7 +115,7 @@ async def sync_repos() -> dict:
             if db_repo.platform != "github":
                 continue
             if (db_repo.owner, db_repo.repo) not in actual_repos:
-                _api._app_db.delete_repo(db_repo.owner, db_repo.repo)
+                _api._app_db.delete_repo(db_repo.owner, db_repo.repo, platform=db_repo.platform)
                 removed += 1
 
     return {

--- a/src/mira/dashboard/routers/repos.py
+++ b/src/mira/dashboard/routers/repos.py
@@ -111,6 +111,9 @@ async def sync_repos() -> dict:
     removed = 0
     if installations_reachable and actual_repos:
         for db_repo in _api._app_db.list_repos():
+            # This sync only reconciles GitHub installations — leave GitLab rows alone.
+            if db_repo.platform != "github":
+                continue
             if (db_repo.owner, db_repo.repo) not in actual_repos:
                 _api._app_db.delete_repo(db_repo.owner, db_repo.repo)
                 removed += 1

--- a/tests/test_repos_sync.py
+++ b/tests/test_repos_sync.py
@@ -1,0 +1,70 @@
+"""Dashboard repo routes must stay platform-aware: the GitHub sync prune
+leaves GitLab rows alone, and setup writes target the right platform row."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mira.dashboard import api
+from mira.dashboard.api import SetupRequest
+from mira.dashboard.db import AppDatabase
+from mira.dashboard.routers.admin import complete_setup
+from mira.dashboard.routers.repos import sync_repos
+
+
+@pytest.fixture
+def db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppDatabase:
+    monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+    monkeypatch.setenv("MIRA_GITHUB_APP_ID", "1")
+    monkeypatch.setenv("MIRA_GITHUB_PRIVATE_KEY", "key")
+    db = AppDatabase(url="", admin_password="admin")
+    monkeypatch.setattr(api, "_app_db", db)
+    return db
+
+
+@pytest.mark.asyncio
+async def test_sync_prunes_stale_github_but_leaves_gitlab(db: AppDatabase) -> None:
+    db.register_repo("acme", "web", installation_id=1)
+    db.register_repo("acme", "old", installation_id=1)
+    db.register_repo("grp", "proj", platform="gitlab")
+
+    auth = AsyncMock()
+    auth.list_installations.return_value = [{"id": 1}]
+    auth.list_installation_repos.return_value = [{"full_name": "acme/web", "private": False}]
+
+    with (
+        patch("mira.platforms.github.auth.GitHubAppAuth", return_value=auth),
+        patch("mira.platforms.github.webhook._count_files_for_repos", new=AsyncMock()),
+    ):
+        result = await sync_repos()
+
+    assert result["removed"] == 1
+    remaining = {(r.platform, r.owner, r.repo) for r in db.list_repos()}
+    assert remaining == {("github", "acme", "web"), ("gitlab", "grp", "proj")}
+
+
+@pytest.mark.asyncio
+async def test_complete_setup_writes_to_platform_rows(db: AppDatabase) -> None:
+    db.register_repo("acme", "web")
+    db.register_repo("grp", "proj", platform="gitlab")
+
+    with patch("mira.dashboard.routers.admin._run_initial_indexing", new=AsyncMock()):
+        await complete_setup(
+            SetupRequest(
+                repos=[
+                    {"owner": "acme", "repo": "web", "platform": "github", "enabled": True},
+                    {"owner": "grp", "repo": "proj", "platform": "gitlab", "enabled": False},
+                ],
+                index_mode="full",
+            )
+        )
+
+    gh = db.get_repo("acme", "web")
+    gl = db.get_repo("grp", "proj", platform="gitlab")
+    assert gh is not None and gh.status == "indexing" and gh.index_mode == "full"
+    # The disabled GitLab repo must be opted out on its own row, not a
+    # phantom github one — otherwise the initial indexer picks it up.
+    assert gl is not None and gl.index_mode == "none" and gl.status == "pending"

--- a/ui/mira/src/components/dashboard/setup-modal.tsx
+++ b/ui/mira/src/components/dashboard/setup-modal.tsx
@@ -87,6 +87,7 @@ export function SetupModal({
       repos.map((r) => ({
         owner: r.owner,
         repo: r.repo,
+        platform: r.platform,
         enabled: true,
       })),
       "full",
@@ -100,7 +101,7 @@ export function SetupModal({
     // table after each call.
     api
       .completeSetup(
-        repos.map((r) => ({ owner: r.owner, repo: r.repo, enabled: false })),
+        repos.map((r) => ({ owner: r.owner, repo: r.repo, platform: r.platform, enabled: false })),
         "full",
       )
       .finally(() => onComplete())

--- a/ui/mira/src/lib/api/system.ts
+++ b/ui/mira/src/lib/api/system.ts
@@ -11,7 +11,7 @@ export const systemApi = {
     ),
 
   completeSetup: (
-    repos: { owner: string; repo: string; enabled: boolean }[],
+    repos: { owner: string; repo: string; platform: string; enabled: boolean }[],
     index_mode: string
   ) =>
     postJson<{ status: string; repos: number }>("/api/setup/complete", {

--- a/ui/mira/src/lib/api/types.ts
+++ b/ui/mira/src/lib/api/types.ts
@@ -4,6 +4,7 @@
 export interface RepoListItem {
   owner: string
   repo: string
+  platform: string
   status: string
   index_mode: string
   file_count: number


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary
- Fix for GitHub repo syncing

## Test plan

CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
