### PR TITLE
fix(review): PR-scope round 2+ incremental diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Mira are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project
 follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Round 2+ incremental reviews stay PR-scoped** — push deltas are intersected with the PR/MR file set so merging the base branch no longer re-reviews upstream changes. Rebase/force-push falls back to the full PR diff.
+
 ## [0.6.0] — 2026-07-10
 
 ### Added

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -373,6 +373,8 @@ class ReviewEngine:
 
         threads_checked, llm_resolved, unresolved_threads, thread_decisions = thread_result
 
+        pr_diff_text = diff_text
+
         _lines_changed = sum(
             1 for line in diff_text.splitlines() if line.startswith("+") or line.startswith("-")
         )
@@ -423,9 +425,11 @@ class ReviewEngine:
         except Exception as exc:
             logger.warning("Failed to compute review round: %s", exc)
 
-        # Round 2+ uses incremental diff to avoid re-flagging untouched files.
-        if review_round >= 2 and pr_info.head_sha:
+        # Round 2+ uses a PR-scoped push delta so merge-from-base does not
+        # re-review upstream files outside the PR/MR file set.
+        if review_round >= 2 and pr_info.head_sha and not is_review_rest:
             try:
+                from mira.core.incremental_diff import intersect_push_diff_with_pr
                 from mira.dashboard.api import _app_db
 
                 last_sha = _app_db.get_last_reviewed_sha(
@@ -435,35 +439,50 @@ class ReviewEngine:
                     platform=pr_info.platform,
                 )
                 if last_sha and last_sha != pr_info.head_sha:
-                    incremental = await self.provider.get_compare_diff(
-                        pr_info,
-                        last_sha,
-                        pr_info.head_sha,
-                    )
-                    if incremental.strip():
+                    if not await self.provider.is_ancestor(
+                        pr_info, last_sha, pr_info.head_sha
+                    ):
                         logger.info(
-                            "Round %d incremental diff %s..%s on PR %s (was %d chars, now %d)",
+                            "Round %d: %s not ancestor of %s on %s — full PR diff",
                             review_round,
                             last_sha[:8],
                             pr_info.head_sha[:8],
                             pr_info.url,
-                            len(diff_text),
-                            len(incremental),
                         )
-                        diff_text = incremental
                     else:
-                        logger.info(
-                            "Round %d: no new commits since %s on PR %s, skipping review",
-                            review_round,
-                            last_sha[:8],
-                            pr_info.url,
+                        push_delta = await self.provider.get_compare_diff(
+                            pr_info,
+                            last_sha,
+                            pr_info.head_sha,
                         )
-                        diff_text = ""
+                        scoped = intersect_push_diff_with_pr(pr_diff_text, push_delta)
+                        if scoped.strip():
+                            logger.info(
+                                "Round %d PR-scoped incremental %s..%s on %s "
+                                "(push %d chars → scoped %d chars, PR %d chars)",
+                                review_round,
+                                last_sha[:8],
+                                pr_info.head_sha[:8],
+                                pr_info.url,
+                                len(push_delta),
+                                len(scoped),
+                                len(pr_diff_text),
+                            )
+                            diff_text = scoped
+                        else:
+                            logger.info(
+                                "Round %d: no PR-scoped changes since %s on %s, skipping",
+                                review_round,
+                                last_sha[:8],
+                                pr_info.url,
+                            )
+                            diff_text = ""
             except Exception as exc:
                 logger.warning(
-                    "Incremental diff fetch failed, falling back to full diff: %s",
+                    "Incremental diff failed, falling back to full PR diff: %s",
                     exc,
                 )
+                diff_text = pr_diff_text
 
         team_conventions = ""
         try:

--- a/src/mira/core/incremental_diff.py
+++ b/src/mira/core/incremental_diff.py
@@ -1,0 +1,42 @@
+"""PR-scoped incremental diff — clamp push deltas to the PR/MR file set."""
+
+from __future__ import annotations
+
+import re
+
+from mira.core.diff_parser import parse_diff
+
+_DIFF_FILE_RE = re.compile(r"^diff --git a/(.*?) b/(.*?)$", re.MULTILINE)
+
+
+def pr_file_paths(pr_diff: str) -> set[str]:
+    """Paths present in a platform PR/MR unified diff."""
+    return {f.path for f in parse_diff(pr_diff).files}
+
+
+def intersect_push_diff_with_pr(pr_diff: str, push_diff: str) -> str:
+    """Keep only push-delta files that are also in the PR diff.
+
+    Round 2+ reviews fetch ``last_reviewed_sha..head`` via the compare API,
+    which can include upstream files after a merge-from-base. Intersecting
+    with the PR file set matches GitHub/GitLab "Files changed" scope.
+    """
+    allowed = pr_file_paths(pr_diff)
+    if not allowed or not push_diff.strip():
+        return ""
+
+    chunks: list[str] = []
+    for part in re.split(r"(?=^diff --git )", push_diff, flags=re.MULTILINE):
+        part = part.strip("\n")
+        if not part:
+            continue
+        m = _DIFF_FILE_RE.search(part)
+        if not m:
+            continue
+        b_path = m.group(2)
+        a_path = m.group(1)
+        if b_path in allowed or (b_path == "dev/null" and a_path in allowed):
+            chunks.append(part)
+    if not chunks:
+        return ""
+    return "\n".join(chunks) + "\n"

--- a/src/mira/providers/base.py
+++ b/src/mira/providers/base.py
@@ -93,6 +93,16 @@ class BaseProvider(abc.ABC):
         """Diff between two commits, for incremental (round 2+) reviews."""
         return ""
 
+    async def is_ancestor(
+        self, pr_info: PRInfo, ancestor_sha: str, descendant_sha: str
+    ) -> bool:
+        """True when ancestor_sha is on the history path to descendant_sha."""
+        if not ancestor_sha or not descendant_sha:
+            return False
+        if ancestor_sha == descendant_sha:
+            return True
+        return True
+
     async def get_all_bot_threads(
         self, pr_info: PRInfo, bot_login: str | None = None
     ) -> list[BotThreadRecord]:

--- a/src/mira/providers/github.py
+++ b/src/mira/providers/github.py
@@ -238,6 +238,40 @@ class GitHubProvider(BaseProvider):
         except Exception as e:
             raise ProviderError(f"Failed to fetch compare diff: {e}") from e
 
+    async def is_ancestor(
+        self, pr_info: PRInfo, ancestor_sha: str, descendant_sha: str
+    ) -> bool:
+        """True when ancestor_sha is reachable from descendant_sha (rebase detection)."""
+        if not ancestor_sha or not descendant_sha:
+            return False
+        if ancestor_sha == descendant_sha:
+            return True
+        url = (
+            f"{_GITHUB_API_URL}/repos/{pr_info.owner}/{pr_info.repo}"
+            f"/compare/{ancestor_sha}...{descendant_sha}"
+        )
+        headers = {
+            "Authorization": f"token {self._token}",
+            "Accept": "application/vnd.github+json",
+        }
+
+        @_retry_transient
+        async def _fetch() -> bool:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(url, headers=headers, follow_redirects=True)
+                if resp.status_code == 404:
+                    return False
+                resp.raise_for_status()
+                data = resp.json()
+            merge_base = (data.get("merge_base_commit") or {}).get("sha", "")
+            status = data.get("status", "")
+            return merge_base == ancestor_sha or status in {"ahead", "identical"}
+
+        try:
+            return await _fetch()
+        except Exception as e:
+            raise ProviderError(f"Failed to check commit ancestry: {e}") from e
+
     async def post_review(
         self,
         pr_info: PRInfo,

--- a/src/mira/providers/gitlab.py
+++ b/src/mira/providers/gitlab.py
@@ -188,6 +188,29 @@ class GitLabProvider(BaseProvider):
         except Exception as e:
             raise ProviderError(f"Failed to fetch compare diff: {e}") from e
 
+    async def is_ancestor(
+        self, pr_info: PRInfo, ancestor_sha: str, descendant_sha: str
+    ) -> bool:
+        """True when ancestor_sha is reachable from descendant_sha (rebase detection)."""
+        if not ancestor_sha or not descendant_sha:
+            return False
+        if ancestor_sha == descendant_sha:
+            return True
+        url = (
+            f"{self._project(pr_info)}/repository/compare"
+            f"?from={ancestor_sha}&to={descendant_sha}"
+        )
+        try:
+            resp = await self._request("GET", url, ok=(200, 404))
+        except ProviderError as exc:
+            raise ProviderError(f"Failed to check commit ancestry: {exc}") from exc
+        if resp.status_code == 404:
+            return False
+        data = resp.json()
+        if data.get("compare_same_ref"):
+            return True
+        return bool(data.get("diffs") or data.get("commits"))
+
     async def get_file_content(self, pr_info: PRInfo, path: str, ref: str) -> str:
         """Raw file content at a ref — used to verify a thread's fix landed."""
         url = (

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1302,6 +1302,7 @@ class TestIncrementalDiff:
         )
         mock_provider.get_pr_diff = AsyncMock(return_value=full_diff)
         mock_provider.get_compare_diff = AsyncMock(return_value=incremental)
+        mock_provider.is_ancestor = AsyncMock(return_value=True)
         mock_provider.get_unresolved_bot_threads = AsyncMock(return_value=[])
         mock_provider.get_all_bot_threads = AsyncMock(return_value=threads)
         mock_provider.find_bot_comment = AsyncMock(return_value=None)
@@ -1311,13 +1312,31 @@ class TestIncrementalDiff:
         return mock_provider
 
     @pytest.mark.asyncio
-    async def test_round_2_uses_incremental_when_sha_stored(self, monkeypatch):
-        """If a last_reviewed_sha exists for this PR, fetch and use the
-        incremental diff (last_sha..head_sha) instead of the full PR diff."""
+    async def test_round_2_uses_pr_scoped_incremental_when_sha_stored(self, monkeypatch):
+        """Round 2 intersects push delta with PR file paths."""
         from mira.core.engine import ReviewEngine
 
+        pr_diff = """diff --git a/src/mira/db/postgres.py b/src/mira/db/postgres.py
+index 1111111..2222222 100644
+--- a/src/mira/db/postgres.py
++++ b/src/mira/db/postgres.py
+@@ -1 +1 @@
+-old
++new
+"""
+        push_delta = pr_diff + """
+diff --git a/src/mira/dashboard/routers/repos.py b/src/mira/dashboard/routers/repos.py
+index 3333333..4444444 100644
+--- a/src/mira/dashboard/routers/repos.py
++++ b/src/mira/dashboard/routers/repos.py
+@@ -1 +1 @@
+-upstream
++upstream-main
+"""
         mock_provider = self._provider_with_threads_and_compare(
             threads=[self._make_thread()],
+            full_diff=pr_diff,
+            incremental=push_delta,
         )
 
         mock_db = MagicMock()
@@ -1344,12 +1363,143 @@ class TestIncrementalDiff:
         )
         await engine.review_pr("https://github.com/o/r/pull/1")
 
-        # Compare API was called with the right SHAs and result was used.
         mock_provider.get_compare_diff.assert_awaited_once()
         args = mock_provider.get_compare_diff.call_args
         assert args.args[1] == "OLD_SHA"
         assert args.args[2] == "HEAD_SHA"
-        assert captured["diff_text"] == "INCR"
+        assert "postgres.py" in captured["diff_text"]
+        assert "repos.py" not in captured["diff_text"]
+
+    @pytest.mark.asyncio
+    async def test_round_2_skips_when_scoped_empty_after_merge_main(self, monkeypatch):
+        """Merge-from-base with no PR-scoped file changes skips the review."""
+        from mira.core.engine import ReviewEngine
+
+        pr_diff = """diff --git a/src/mira/db/postgres.py b/src/mira/db/postgres.py
+index 1111111..2222222 100644
+--- a/src/mira/db/postgres.py
++++ b/src/mira/db/postgres.py
+@@ -1 +1 @@
+-old
++new
+"""
+        upstream_only = """diff --git a/src/mira/dashboard/routers/repos.py b/src/mira/dashboard/routers/repos.py
+index 3333333..4444444 100644
+--- a/src/mira/dashboard/routers/repos.py
++++ b/src/mira/dashboard/routers/repos.py
+@@ -1 +1 @@
+-upstream
++upstream-main
+"""
+        mock_provider = self._provider_with_threads_and_compare(
+            threads=[self._make_thread()],
+            full_diff=pr_diff,
+            incremental=upstream_only,
+        )
+
+        mock_db = MagicMock()
+        mock_db.get_last_reviewed_sha = MagicMock(return_value="OLD_SHA")
+        mock_db.get_repo = MagicMock(return_value=None)
+        mock_db.set_last_reviewed_sha = MagicMock()
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        captured: dict = {}
+
+        async def fake_internal(self, diff_text, **kwargs):
+            captured["diff_text"] = diff_text
+            from mira.models import ReviewResult
+
+            return ReviewResult(comments=[], summary="")
+
+        monkeypatch.setattr(ReviewEngine, "_review_diff_internal", fake_internal)
+
+        engine = ReviewEngine(
+            config=MiraConfig(),
+            llm=AsyncMock(),
+            provider=mock_provider,
+            bot_name="mira",
+        )
+        await engine.review_pr("https://github.com/o/r/pull/1")
+
+        assert captured.get("diff_text") == ""
+
+    @pytest.mark.asyncio
+    async def test_round_2_uses_full_pr_diff_on_rebase(self, monkeypatch):
+        """Force-push / rebase falls back to the full PR diff."""
+        from mira.core.engine import ReviewEngine
+
+        mock_provider = self._provider_with_threads_and_compare(
+            threads=[self._make_thread()],
+            full_diff="FULL",
+            incremental="INCR",
+        )
+        mock_provider.is_ancestor = AsyncMock(return_value=False)
+
+        mock_db = MagicMock()
+        mock_db.get_last_reviewed_sha = MagicMock(return_value="OLD_SHA")
+        mock_db.get_repo = MagicMock(return_value=None)
+        mock_db.set_last_reviewed_sha = MagicMock()
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        captured: dict = {}
+
+        async def fake_internal(self, diff_text, **kwargs):
+            captured["diff_text"] = diff_text
+            from mira.models import ReviewResult
+
+            return ReviewResult(comments=[], summary="")
+
+        monkeypatch.setattr(ReviewEngine, "_review_diff_internal", fake_internal)
+
+        engine = ReviewEngine(
+            config=MiraConfig(),
+            llm=AsyncMock(),
+            provider=mock_provider,
+            bot_name="mira",
+        )
+        await engine.review_pr("https://github.com/o/r/pull/1")
+
+        mock_provider.get_compare_diff.assert_not_called()
+        assert captured["diff_text"] == "FULL"
+
+    @pytest.mark.asyncio
+    async def test_review_rest_ignores_incremental(self, monkeypatch):
+        """review-rest keeps the full PR diff even when bot threads exist."""
+        from mira.core.engine import ReviewEngine
+
+        mock_provider = self._provider_with_threads_and_compare(
+            threads=[self._make_thread()],
+            full_diff="FULL",
+            incremental="INCR",
+        )
+
+        mock_db = MagicMock()
+        mock_db.get_last_reviewed_sha = MagicMock(return_value="OLD_SHA")
+        mock_db.get_repo = MagicMock(return_value=None)
+        mock_db.set_last_reviewed_sha = MagicMock()
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        captured: dict = {}
+
+        async def fake_internal(self, diff_text, **kwargs):
+            captured["diff_text"] = diff_text
+            from mira.models import ReviewResult
+
+            return ReviewResult(comments=[], summary="")
+
+        monkeypatch.setattr(ReviewEngine, "_review_diff_internal", fake_internal)
+
+        engine = ReviewEngine(
+            config=MiraConfig(),
+            llm=AsyncMock(),
+            provider=mock_provider,
+            bot_name="mira",
+        )
+        engine._review_only_paths = ["src/a.py"]
+        await engine.review_pr("https://github.com/o/r/pull/1")
+
+        mock_provider.get_compare_diff.assert_not_called()
+        assert captured["diff_text"] == "FULL"
 
     @pytest.mark.asyncio
     async def test_round_2_falls_back_to_full_diff_when_no_sha(self, monkeypatch):
@@ -1450,6 +1600,91 @@ class TestIncrementalDiff:
         mock_db.set_last_reviewed_sha.assert_called_once_with(
             "o", "r", 1, "HEAD_SHA", platform="github"
         )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failing_method", ["is_ancestor", "get_compare_diff"])
+    async def test_round_2_falls_back_to_full_pr_on_incremental_failure(
+        self, monkeypatch, failing_method
+    ):
+        """Incremental fetch failures fall back to the full PR diff."""
+        from mira.core.engine import ReviewEngine
+
+        mock_provider = self._provider_with_threads_and_compare(
+            threads=[self._make_thread()],
+            full_diff="FULL_PR",
+            incremental="SHOULD_NOT_USE",
+        )
+        if failing_method == "is_ancestor":
+            mock_provider.is_ancestor = AsyncMock(side_effect=RuntimeError("ancestry down"))
+        else:
+            mock_provider.get_compare_diff = AsyncMock(side_effect=RuntimeError("compare down"))
+
+        mock_db = MagicMock()
+        mock_db.get_last_reviewed_sha = MagicMock(return_value="OLD_SHA")
+        mock_db.get_repo = MagicMock(return_value=None)
+        mock_db.set_last_reviewed_sha = MagicMock()
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        captured: dict = {}
+
+        async def fake_internal(self, diff_text, **kwargs):
+            captured["diff_text"] = diff_text
+            from mira.models import ReviewResult
+
+            return ReviewResult(comments=[], summary="")
+
+        monkeypatch.setattr(ReviewEngine, "_review_diff_internal", fake_internal)
+
+        engine = ReviewEngine(
+            config=MiraConfig(),
+            llm=AsyncMock(),
+            provider=mock_provider,
+            bot_name="mira",
+        )
+        await engine.review_pr("https://github.com/o/r/pull/1")
+
+        if failing_method == "is_ancestor":
+            mock_provider.get_compare_diff.assert_not_called()
+        assert captured["diff_text"] == "FULL_PR"
+
+    @pytest.mark.asyncio
+    async def test_round_2_keeps_full_pr_when_head_unchanged(self, monkeypatch):
+        """No new commits since last review — skip compare, keep PR diff."""
+        from mira.core.engine import ReviewEngine
+
+        mock_provider = self._provider_with_threads_and_compare(
+            threads=[self._make_thread()],
+            full_diff="FULL_PR",
+            incremental="INCR",
+        )
+
+        mock_db = MagicMock()
+        mock_db.get_last_reviewed_sha = MagicMock(return_value="HEAD_SHA")
+        mock_db.get_repo = MagicMock(return_value=None)
+        mock_db.set_last_reviewed_sha = MagicMock()
+        monkeypatch.setattr("mira.dashboard.api._app_db", mock_db)
+
+        captured: dict = {}
+
+        async def fake_internal(self, diff_text, **kwargs):
+            captured["diff_text"] = diff_text
+            from mira.models import ReviewResult
+
+            return ReviewResult(comments=[], summary="")
+
+        monkeypatch.setattr(ReviewEngine, "_review_diff_internal", fake_internal)
+
+        engine = ReviewEngine(
+            config=MiraConfig(),
+            llm=AsyncMock(),
+            provider=mock_provider,
+            bot_name="mira",
+        )
+        await engine.review_pr("https://github.com/o/r/pull/1")
+
+        mock_provider.is_ancestor.assert_not_called()
+        mock_provider.get_compare_diff.assert_not_called()
+        assert captured["diff_text"] == "FULL_PR"
 
 
 class TestSelfCritique:

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -1069,6 +1069,65 @@ class TestResolveThreads:
         assert count == 1
 
 
+class TestIsAncestor:
+    @pytest.mark.asyncio
+    async def test_missing_sha_is_not_ancestor(self):
+        provider = GitHubProvider.__new__(GitHubProvider)
+        provider._token = "test-token"
+        pr_info = _make_pr_info()
+        assert await provider.is_ancestor(pr_info, "", "head") is False
+
+    @pytest.mark.asyncio
+    async def test_404_compare_is_not_ancestor(self):
+        provider = GitHubProvider.__new__(GitHubProvider)
+        provider._token = "test-token"
+        pr_info = _make_pr_info()
+
+        async def _mock_get(self, url, **kwargs):
+            return httpx.Response(404, request=httpx.Request("GET", url))
+
+        with patch.object(httpx.AsyncClient, "get", _mock_get):
+            assert await provider.is_ancestor(pr_info, "old", "new") is False
+
+    @pytest.mark.asyncio
+    async def test_ahead_compare_is_ancestor(self):
+        provider = GitHubProvider.__new__(GitHubProvider)
+        provider._token = "test-token"
+        pr_info = _make_pr_info()
+
+        async def _mock_get(self, url, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "status": "ahead",
+                    "merge_base_commit": {"sha": "old"},
+                },
+                request=httpx.Request("GET", url),
+            )
+
+        with patch.object(httpx.AsyncClient, "get", _mock_get):
+            assert await provider.is_ancestor(pr_info, "old", "new") is True
+
+    @pytest.mark.asyncio
+    async def test_diverged_compare_is_not_ancestor(self):
+        provider = GitHubProvider.__new__(GitHubProvider)
+        provider._token = "test-token"
+        pr_info = _make_pr_info()
+
+        async def _mock_get(self, url, **kwargs):
+            return httpx.Response(
+                200,
+                json={
+                    "status": "diverged",
+                    "merge_base_commit": {"sha": "unrelated"},
+                },
+                request=httpx.Request("GET", url),
+            )
+
+        with patch.object(httpx.AsyncClient, "get", _mock_get):
+            assert await provider.is_ancestor(pr_info, "old", "new") is False
+
+
 class TestGetFileContent:
     @pytest.mark.asyncio
     async def test_returns_decoded_content(self):

--- a/tests/test_gitlab_provider.py
+++ b/tests/test_gitlab_provider.py
@@ -243,6 +243,36 @@ class TestCompareDiff:
         assert out == ""
 
 
+class TestIsAncestor:
+    @pytest.mark.asyncio
+    async def test_missing_sha_is_not_ancestor(self):
+        assert await GitLabProvider("tok").is_ancestor(_PR, "", "head") is False
+
+    @pytest.mark.asyncio
+    async def test_404_compare_is_not_ancestor(self):
+        def handler(method, url, **kw):
+            return _FakeResp(status=404)
+
+        with _patch(handler):
+            assert await GitLabProvider("tok").is_ancestor(_PR, "old", "new") is False
+
+    @pytest.mark.asyncio
+    async def test_compare_with_diffs_is_ancestor(self):
+        def handler(method, url, **kw):
+            return _FakeResp(json_data={"diffs": [{"diff": "@@\n"}]})
+
+        with _patch(handler):
+            assert await GitLabProvider("tok").is_ancestor(_PR, "old", "new") is True
+
+    @pytest.mark.asyncio
+    async def test_empty_compare_is_not_ancestor(self):
+        def handler(method, url, **kw):
+            return _FakeResp(json_data={"diffs": [], "commits": []})
+
+        with _patch(handler):
+            assert await GitLabProvider("tok").is_ancestor(_PR, "old", "new") is False
+
+
 class TestResolveThreads:
     @pytest.mark.asyncio
     async def test_puts_resolved_true(self):

--- a/tests/test_incremental_diff.py
+++ b/tests/test_incremental_diff.py
@@ -1,0 +1,126 @@
+"""Tests for PR-scoped incremental diff helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from mira.core.incremental_diff import intersect_push_diff_with_pr
+
+_PR_POSTGRES = """diff --git a/src/mira/db/postgres.py b/src/mira/db/postgres.py
+index 1111111..2222222 100644
+--- a/src/mira/db/postgres.py
++++ b/src/mira/db/postgres.py
+@@ -1 +1 @@
+-old
++new
+"""
+
+_UPSTREAM_REPOS = """diff --git a/src/mira/dashboard/routers/repos.py b/src/mira/dashboard/routers/repos.py
+index 3333333..4444444 100644
+--- a/src/mira/dashboard/routers/repos.py
++++ b/src/mira/dashboard/routers/repos.py
+@@ -1 +1 @@
+-upstream
++upstream-main
+"""
+
+_ENGINE = """diff --git a/src/mira/core/engine.py b/src/mira/core/engine.py
+index 1111111..2222222 100644
+--- a/src/mira/core/engine.py
++++ b/src/mira/core/engine.py
+@@ -1 +1 @@
+-old
++new
+"""
+
+
+def test_intersect_keeps_pr_files_drops_upstream_merge():
+    push = _PR_POSTGRES + "\n" + _UPSTREAM_REPOS
+    scoped = intersect_push_diff_with_pr(_PR_POSTGRES, push)
+    assert "src/mira/db/postgres.py" in scoped
+    assert "repos.py" not in scoped
+
+
+def test_intersect_empty_when_push_only_upstream():
+    assert intersect_push_diff_with_pr(_PR_POSTGRES, _UPSTREAM_REPOS) == ""
+
+
+@pytest.mark.parametrize(
+    ("pr_diff", "push_diff"),
+    [
+        ("", _PR_POSTGRES),
+        (_PR_POSTGRES, ""),
+        (_PR_POSTGRES, "   \n\n  "),
+    ],
+)
+def test_intersect_empty_inputs(pr_diff, push_diff):
+    assert intersect_push_diff_with_pr(pr_diff, push_diff) == ""
+
+
+def test_intersect_partial_pr_files_in_push():
+    """Push only touches one of two PR files — keep just that chunk."""
+    pr = _PR_POSTGRES + "\n" + _ENGINE
+    scoped = intersect_push_diff_with_pr(pr, _PR_POSTGRES)
+    assert "postgres.py" in scoped
+    assert "engine.py" not in scoped
+
+
+def test_intersect_handles_renamed_path_in_header():
+    pr = """diff --git a/old/name.py b/src/new/name.py
+index 1111111..2222222 100644
+--- a/old/name.py
++++ b/src/new/name.py
+@@ -1 +1 @@
+-a
++b
+"""
+    push = """diff --git a/old/name.py b/src/new/name.py
+index 1111111..3333333 100644
+--- a/old/name.py
++++ b/src/new/name.py
+@@ -1 +1 @@
+-a
++c
+"""
+    scoped = intersect_push_diff_with_pr(pr, push)
+    assert "src/new/name.py" in scoped
+
+
+def test_intersect_new_file_uses_b_path():
+    pr = """diff --git a/dev/null b/src/new/module.py
+new file mode 100644
+--- /dev/null
++++ b/src/new/module.py
+@@ -0,0 +1 @@
++hello
+"""
+    push = """diff --git a/dev/null b/src/new/module.py
+new file mode 100644
+--- /dev/null
++++ b/src/new/module.py
+@@ -0,0 +1 @@
++world
+"""
+    scoped = intersect_push_diff_with_pr(pr, push)
+    assert "src/new/module.py" in scoped
+    assert "world" in scoped
+
+
+def test_intersect_deleted_file_matches_a_path_when_b_is_dev_null():
+    """GitHub deletion headers use b/dev/null; PR paths come from the old path."""
+    pr = """diff --git a/src/removed.py b/dev/null
+deleted file mode 100644
+--- a/src/removed.py
++++ /dev/null
+@@ -1 +0,0 @@
+-x
+"""
+    push = """diff --git a/src/removed.py b/dev/null
+deleted file mode 100644
+--- a/src/removed.py
++++ /dev/null
+@@ -1 +0,0 @@
+-y
+"""
+    scoped = intersect_push_diff_with_pr(pr, push)
+    assert "src/removed.py" in scoped


### PR DESCRIPTION
Intersect push deltas with the PR/MR file set so merge-from-base no longer re-reviews upstream changes. Fall back to full PR diff on rebase/force-push via is_ancestor checks on GitHub and GitLab.

<!--
Thanks for contributing to Mira!

Before opening this PR, please ensure:
- [ ] Tests pass locally (`uv run pytest tests/`)
- [ ] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [ ] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

Security fixes should be reported privately first — see SECURITY.md.
-->

## Summary

<!-- 1-3 bullets on what changed and why -->

## Test plan

<!-- How did you verify this works? -->

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
