### PR TITLE
fix(ui): truncate learned rule text to prevent horizontal overflow

### DIFF
--- a/ui/mira/src/pages/dashboard.tsx
+++ b/ui/mira/src/pages/dashboard.tsx
@@ -600,7 +600,7 @@ function PendingLearningsCard({ rules }: { rules: OrgLearnedRuleModel[] }) {
         </div>
       </CardHeader>
       <CardContent className="px-0 pb-0">
-        <Table>
+        <Table className="w-full">
           <TableBody>
             {top.map((r) => (
               <TableRow
@@ -614,8 +614,8 @@ function PendingLearningsCard({ rules }: { rules: OrgLearnedRuleModel[] }) {
                     {r.owner}/{r.repo}
                   </span>
                 </TableCell>
-                <TableCell className="text-sm text-muted-foreground">
-                  <span className="line-clamp-1">{r.rule_text}</span>
+                <TableCell className="max-w-0 text-sm text-muted-foreground">
+                  <span className="block truncate">{r.rule_text}</span>
                 </TableCell>
               </TableRow>
             ))}


### PR DESCRIPTION
## Summary
Truncate learned rule text in pending learnings card to prevent horizontal overflow on dashboard.

## Motivation
Long rule description text in the pending learnings table would not wrap, causing the entire dashboard page to become horizontally scrollable. The repo name column was more important to keep visible than the description text.

## Changes
- Constrained the pending learnings table to full width with `w-full`
- Added `max-w-0` on the description column to allow truncation
- Changed `line-clamp-1` to `block truncate` so long rule texts are properly ellipsized