### PR TITLE
feat(platforms): add PR author allowlist and denylist filter

### DIFF
--- a/.mira.yaml.example
+++ b/.mira.yaml.example
@@ -40,6 +40,13 @@ filter:
     - "*.png"
     - "*.jpg"
     - "*.gif"
+  # Auto-review only PRs from these authors (empty = review all)
+  # allowed_authors:
+  #   - alice
+  # Never auto-review PRs from these authors (takes precedence over allowed)
+  # blocked_authors:
+  #   - app/renovate
+  #   - app/dependabot
   # Skip deleted files
   exclude_deleted: true
   # Maximum number of files to review

--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -116,6 +116,15 @@ class FilterConfig(BaseModel):
     )
     exclude_deleted: bool = True
     max_files: int = 50
+    # Only auto-review PRs whose author (payload `sender.login` /
+    # `user.username`) is in this list. Empty list = review all (default).
+    # Bot-self events are always excluded regardless of this list.
+    allowed_authors: list[str] = Field(default_factory=list)
+    # Never auto-review PRs from these authors. Takes precedence over
+    # allowed_authors. A trailing `[bot]` suffix on the payload login is
+    # stripped by the dispatcher check so that `dependabot` here matches
+    # `dependabot[bot]` in a webhook payload.
+    blocked_authors: list[str] = Field(default_factory=list)
 
 
 class ReviewConfig(BaseModel):

--- a/src/mira/platforms/forgejo/webhook.py
+++ b/src/mira/platforms/forgejo/webhook.py
@@ -17,10 +17,17 @@ from typing import Any
 
 import httpx
 
+from mira.config import load_config
 from mira.platforms import profiles
 from mira.platforms.auth import PlatformAuth
 from mira.platforms.fetch import make_fetcher
-from mira.platforms.mentions import has_mention, mention_names, strip_mentions
+from mira.platforms.mentions import (
+    author_is_filtered,
+    command_after_mention,
+    has_mention,
+    mention_names,
+    strip_mentions,
+)
 from mira.providers import create_provider
 
 logger = logging.getLogger(__name__)
@@ -351,16 +358,36 @@ async def dispatch_forgejo_event(
     bot_identity = await auth.get_bot_identity()
     if actor and bot_identity and actor == bot_identity:
         return "ignored"
+    cfg = load_config()
 
     if event == "pull_request":
         action = payload.get("action", "")
         if action in ("opened", "synchronized", "reopened"):
+            full_name = payload.get("repository", {}).get("full_name", "")
+            number = payload.get("pull_request", {}).get("number", 0)
+            try:
+                owner, repo_name = _split_repo_path(full_name)
+            except ValueError:
+                owner, repo_name = "?", "?"
+
+            if author_is_filtered(actor, cfg.filter.allowed_authors, cfg.filter.blocked_authors):
+                logger.debug(
+                    "PR %s/%s#%s skipped — author %s filtered by author filter",
+                    owner,
+                    repo_name,
+                    number,
+                    actor,
+                )
+                return "ignored"
             background_tasks.add_task(handle_forgejo_pr, payload, auth, bot_name)
             return "processing"
         # Ignore other PR actions (closed, edited, labeled, merged, etc.)
         return "ignored"
 
     if event == "push":
+        if author_is_filtered(actor, cfg.filter.allowed_authors, cfg.filter.blocked_authors):
+            logger.debug("push ignored — author %s filtered", actor)
+            return "ignored"
         background_tasks.add_task(handle_forgejo_push, payload, auth, bot_name)
         return "processing"
 
@@ -370,6 +397,12 @@ async def dispatch_forgejo_event(
         names = mention_names(bot_name, bot_identity)
         comment_body = payload.get("comment", {}).get("body", "") or ""
         if has_mention(comment_body, names):
+            cmd_word = command_after_mention(comment_body, names)
+            if cmd_word == "review":
+                pass  # review command bypasses author filter
+            elif author_is_filtered(actor, cfg.filter.allowed_authors, cfg.filter.blocked_authors):
+                logger.debug("issue_comment skipped — author %s filtered", actor)
+                return "ignored"
             background_tasks.add_task(handle_forgejo_note, payload, auth, bot_name)
             return "processing"
         return "ignored"

--- a/src/mira/platforms/github/webhook.py
+++ b/src/mira/platforms/github/webhook.py
@@ -33,6 +33,7 @@ from mira.platforms.handlers import (
 )
 from mira.platforms.index_handlers import _get_app_db, run_incremental_index
 from mira.platforms.mentions import (
+    author_is_filtered,
     command_after_mention,
     has_mention,
     mention_names,
@@ -415,6 +416,7 @@ async def dispatch_github_event(
     avoid review loops.
     """
     action = payload.get("action", "")
+    cfg = load_config()
 
     # Track PR review lifecycle for every pull_request event (open/close/
     # ready/review_requested/...), independent of the review-trigger logic
@@ -444,6 +446,19 @@ async def dispatch_github_event(
         if sender == f"{bot_name}[bot]":
             logger.debug("Ignoring pull_request event from self (%s)", sender)
             return "ignored"
+
+        if author_is_filtered(sender, cfg.filter.allowed_authors, cfg.filter.blocked_authors):
+            owner = payload.get("repository", {}).get("owner", {}).get("login", "?")
+            repo = payload.get("repository", {}).get("name", "?")
+            number = payload.get("pull_request", {}).get("number", 0)
+            logger.debug(
+                "PR %s/%s#%s skipped — author %s filtered by author filter",
+                owner,
+                repo,
+                number,
+                sender,
+            )
+            return "ignored"
         names = mention_names(bot_name, await app_auth.get_bot_identity())
         pr_body = payload.get("pull_request", {}).get("body", "") or ""
         if any(re.search(rf"@{re.escape(n)}[ \t]+ignore\b", pr_body, re.IGNORECASE) for n in names):
@@ -466,6 +481,16 @@ async def dispatch_github_event(
         names = mention_names(bot_name, await app_auth.get_bot_identity())
         if "pull_request" in payload.get("issue", {}) and has_mention(comment_body, names):
             cmd_word = command_after_mention(comment_body, names)
+            if cmd_word == "review":
+                pass  # review command bypasses author filter
+            elif author_is_filtered(
+                comment_user, cfg.filter.allowed_authors, cfg.filter.blocked_authors
+            ):
+                logger.debug(
+                    "issue_comment skipped — author %s filtered by author filter",
+                    comment_user,
+                )
+                return "ignored"
             if cmd_word in _PAUSE_KEYWORDS | _RESUME_KEYWORDS:
                 background_tasks.add_task(
                     handle_pause_resume, payload, app_auth, bot_name, cmd_word
@@ -503,6 +528,10 @@ async def dispatch_github_event(
         ref = payload.get("ref", "")
         default_branch = payload.get("repository", {}).get("default_branch", "main")
         if ref == f"refs/heads/{default_branch}":
+            sender = payload.get("sender", {}).get("login", "")
+            if author_is_filtered(sender, cfg.filter.allowed_authors, cfg.filter.blocked_authors):
+                logger.debug("push to %s skipped — author %s filtered", ref, sender)
+                return "ignored"
             background_tasks.add_task(handle_push_index, payload, app_auth, bot_name)
             return "processing"
 

--- a/src/mira/platforms/gitlab/webhook.py
+++ b/src/mira/platforms/gitlab/webhook.py
@@ -15,10 +15,17 @@ from typing import Any
 
 import httpx
 
+from mira.config import load_config
 from mira.platforms import profiles
 from mira.platforms.auth import PlatformAuth
 from mira.platforms.fetch import _next_link, make_fetcher
-from mira.platforms.mentions import has_mention, mention_names, strip_mentions
+from mira.platforms.mentions import (
+    author_is_filtered,
+    command_after_mention,
+    has_mention,
+    mention_names,
+    strip_mentions,
+)
 from mira.providers import create_provider
 
 logger = logging.getLogger(__name__)
@@ -291,6 +298,10 @@ async def dispatch_gitlab_event(
         action = attrs.get("action", "")
         # 'update' fires for many reasons; only review when new commits landed.
         if action in ("open", "reopen") or (action == "update" and attrs.get("oldrev")):
+            cfg = load_config()
+            if author_is_filtered(actor, cfg.filter.allowed_authors, cfg.filter.blocked_authors):
+                logger.debug("MR skipped — author %s filtered by author filter", actor)
+                return "ignored"
             background_tasks.add_task(handle_merge_request, payload, auth, bot_name)
             return "processing"
         if action == "merge":
@@ -304,6 +315,14 @@ async def dispatch_gitlab_event(
         if attrs.get("noteable_type") == "MergeRequest" and has_mention(
             attrs.get("note") or "", names
         ):
+            cmd_word = command_after_mention(attrs.get("note") or "", names)
+            if cmd_word != "review":
+                cfg = load_config()
+                if author_is_filtered(
+                    actor, cfg.filter.allowed_authors, cfg.filter.blocked_authors
+                ):
+                    logger.debug("MR note skipped — author %s filtered", actor)
+                    return "ignored"
             background_tasks.add_task(handle_gitlab_note, payload, auth, bot_name)
             return "processing"
         return "ignored"
@@ -312,6 +331,10 @@ async def dispatch_gitlab_event(
         ref = payload.get("ref", "")
         default_branch = payload.get("project", {}).get("default_branch", "main")
         if ref == f"refs/heads/{default_branch}":
+            cfg = load_config()
+            if author_is_filtered(actor, cfg.filter.allowed_authors, cfg.filter.blocked_authors):
+                logger.debug("push skipped — author %s filtered", actor)
+                return "ignored"
             background_tasks.add_task(handle_gitlab_push, payload, auth, bot_name)
             return "processing"
 

--- a/src/mira/platforms/mentions.py
+++ b/src/mira/platforms/mentions.py
@@ -40,3 +40,23 @@ def command_after_mention(text: str, names: list[str]) -> str:
         if m:
             return m.group(1).lower()
     return ""
+
+
+def author_is_filtered(login: str, allowed: list[str], blocked: list[str]) -> bool:
+    """True if `login` should be skipped for auto-review.
+
+    Precedence (matches GitHub issue #180):
+      - empty `login` → never filtered (no sender info → let the
+        dispatcher's existing bot-self check do its job);
+      - `blocked` wins: matches against the raw login OR the login
+        with a trailing `[bot]` stripped (so `dependabot` in `blocked`
+        matches `dependabot[bot]` from the webhook);
+      - then if `allowed` is non-empty and `login` (raw or stripped)
+        is not in it → filtered.
+    """
+    if not login:
+        return False
+    variants = {login, login.removesuffix("[bot]")}
+    if any(v in blocked for v in variants):
+        return True
+    return bool(allowed and not any(v in allowed for v in variants))

--- a/tests/test_forgejo_webhooks.py
+++ b/tests/test_forgejo_webhooks.py
@@ -1,0 +1,190 @@
+"""Tests for the Forgejo webhook route + author filter dispatch."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from mira.config import FilterConfig, MiraConfig
+from mira.platforms.forgejo.auth import ForgejoTokenAuth
+from mira.platforms.server import create_app
+
+FJ_SECRET = "fj-secret"
+BOT = "mira-bot"
+
+
+@pytest.fixture
+def forgejo_auth():  # noqa: ANN201
+    auth = ForgejoTokenAuth("tok")
+    auth.get_bot_identity = AsyncMock(return_value="mira-bot")  # type: ignore[method-assign]
+    return auth
+
+
+@pytest.fixture
+def app(forgejo_auth):  # noqa: ANN001, ANN201
+    return create_app(
+        app_auth=None,
+        webhook_secret=None,
+        bot_name=BOT,
+        forgejo_auth=forgejo_auth,
+        forgejo_webhook_secret=FJ_SECRET,
+    )
+
+
+@pytest.fixture
+async def client(app) -> AsyncClient:  # noqa: ANN001
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _sign(payload_bytes: bytes) -> str:
+    return hmac.new(FJ_SECRET.encode(), payload_bytes, hashlib.sha256).hexdigest()
+
+
+def _pr_payload(action: str, login: str):
+    return {
+        "action": action,
+        "pull_request": {"number": 7},
+        "repository": {"full_name": "o/r", "private": False},
+        "sender": {"login": login},
+    }
+
+
+def _comment_payload(body: str, login: str):
+    return {
+        "action": "created",
+        "is_pull": True,
+        "comment": {"body": body},
+        "sender": {"login": login},
+    }
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_blocked_author_filtered(client):
+    """Blocked author with [bot] suffix is filtered for PR opened."""
+    with (
+        patch("mira.platforms.forgejo.webhook.handle_forgejo_pr", new=AsyncMock()) as h,
+        patch(
+            "mira.platforms.forgejo.webhook.load_config",
+            return_value=MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"])),
+        ),
+    ):
+        payload = _pr_payload("opened", "dependabot[bot]")
+        body = json.dumps(payload).encode()
+        resp = await client.post(
+            "/forgejo/webhook",
+            content=body,
+            headers={
+                "X-Forgejo-Event": "pull_request",
+                "X-Forgejo-Signature": _sign(body),
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ignored"
+    h.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_allowed_author_not_filtered(client):
+    """Non-blocked author passes through the filter."""
+    with (
+        patch("mira.platforms.forgejo.webhook.handle_forgejo_pr", new=AsyncMock()) as h,
+        patch(
+            "mira.platforms.forgejo.webhook.load_config",
+            return_value=MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"])),
+        ),
+    ):
+        payload = _pr_payload("opened", "alice")
+        body = json.dumps(payload).encode()
+        resp = await client.post(
+            "/forgejo/webhook",
+            content=body,
+            headers={
+                "X-Forgejo-Event": "pull_request",
+                "X-Forgejo-Signature": _sign(body),
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "processing"
+    h.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pr_opened_allowlist_filters_off_list(client):
+    """Allowlist set but author not on it → filtered."""
+    with (
+        patch("mira.platforms.forgejo.webhook.handle_forgejo_pr", new=AsyncMock()) as h,
+        patch(
+            "mira.platforms.forgejo.webhook.load_config",
+            return_value=MiraConfig(filter=FilterConfig(allowed_authors=["alice"])),
+        ),
+    ):
+        payload = _pr_payload("opened", "bob")
+        body = json.dumps(payload).encode()
+        resp = await client.post(
+            "/forgejo/webhook",
+            content=body,
+            headers={
+                "X-Forgejo-Event": "pull_request",
+                "X-Forgejo-Signature": _sign(body),
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ignored"
+    h.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_comment_review_bypass(client):
+    """Manual @mira-bot review comment bypasses the author filter."""
+    with (
+        patch("mira.platforms.forgejo.webhook.handle_forgejo_note", new=AsyncMock()) as h,
+        patch(
+            "mira.platforms.forgejo.webhook.load_config",
+            return_value=MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"])),
+        ),
+    ):
+        payload = _comment_payload("@mira-bot review", "dependabot[bot]")
+        body = json.dumps(payload).encode()
+        resp = await client.post(
+            "/forgejo/webhook",
+            content=body,
+            headers={
+                "X-Forgejo-Event": "issue_comment",
+                "X-Forgejo-Signature": _sign(body),
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "processing"
+    h.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_comment_non_review_no_bypass(client):
+    """Non-review command (pause) by blocked author does NOT bypass filter."""
+    with (
+        patch("mira.platforms.forgejo.webhook.handle_forgejo_note", new=AsyncMock()) as h,
+        patch(
+            "mira.platforms.forgejo.webhook.load_config",
+            return_value=MiraConfig(filter=FilterConfig(blocked_authors=["alice"])),
+        ),
+    ):
+        payload = _comment_payload("@mira-bot pause", "alice")
+        body = json.dumps(payload).encode()
+        resp = await client.post(
+            "/forgejo/webhook",
+            content=body,
+            headers={
+                "X-Forgejo-Event": "issue_comment",
+                "X-Forgejo-Signature": _sign(body),
+            },
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ignored"
+    h.assert_not_called()

--- a/tests/test_gitlab_webhooks.py
+++ b/tests/test_gitlab_webhooks.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from mira.config import FilterConfig, MiraConfig
 from mira.platforms.gitlab.auth import GitLabTokenAuth
 from mira.platforms.server import create_app
 
@@ -226,3 +227,93 @@ async def test_github_route_404_when_not_configured(client):
     # GitLab-only deployment: the GitHub webhook route is disabled.
     resp = await client.post("/github/webhook", content="{}", headers={"X-GitHub-Event": "ping"})
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_mr_open_blocked_author_filtered(client):
+    payload = _mr_payload(action="open")
+    payload["user"]["username"] = "dependabot"
+    cfg = MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"]))
+    with (
+        patch("mira.platforms.gitlab.webhook.load_config", return_value=cfg),
+        patch("mira.platforms.gitlab.webhook.handle_merge_request", new=AsyncMock()) as h,
+    ):
+        resp = await client.post(
+            "/gitlab/webhook",
+            content=json.dumps(payload),
+            headers={"X-Gitlab-Token": GL_SECRET, "X-Gitlab-Event": "Merge Request Hook"},
+        )
+    assert resp.json()["status"] == "ignored"
+    h.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mr_open_allowed_author_not_filtered(client):
+    payload = _mr_payload(action="open")
+    payload["user"]["username"] = "alice"
+    cfg = MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"]))
+    with (
+        patch("mira.platforms.gitlab.webhook.load_config", return_value=cfg),
+        patch("mira.platforms.gitlab.webhook.handle_merge_request", new=AsyncMock()) as h,
+    ):
+        resp = await client.post(
+            "/gitlab/webhook",
+            content=json.dumps(payload),
+            headers={"X-Gitlab-Token": GL_SECRET, "X-Gitlab-Event": "Merge Request Hook"},
+        )
+    assert resp.json()["status"] == "processing"
+    h.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_mr_open_allowlist_filters_off_list(client):
+    payload = _mr_payload(action="open")
+    payload["user"]["username"] = "bob"
+    cfg = MiraConfig(filter=FilterConfig(allowed_authors=["alice"]))
+    with (
+        patch("mira.platforms.gitlab.webhook.load_config", return_value=cfg),
+        patch("mira.platforms.gitlab.webhook.handle_merge_request", new=AsyncMock()) as h,
+    ):
+        resp = await client.post(
+            "/gitlab/webhook",
+            content=json.dumps(payload),
+            headers={"X-Gitlab-Token": GL_SECRET, "X-Gitlab-Event": "Merge Request Hook"},
+        )
+    assert resp.json()["status"] == "ignored"
+    h.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_note_review_bypass_for_blocked_author(client):
+    payload = _note_payload(note="@mira-bot review")
+    payload["user"]["username"] = "dependabot"
+    cfg = MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"]))
+    with (
+        patch("mira.platforms.gitlab.webhook.load_config", return_value=cfg),
+        patch("mira.platforms.gitlab.webhook.handle_gitlab_note", new=AsyncMock()) as h,
+    ):
+        resp = await client.post(
+            "/gitlab/webhook",
+            content=json.dumps(payload),
+            headers={"X-Gitlab-Token": GL_SECRET, "X-Gitlab-Event": "Note Hook"},
+        )
+    assert resp.json()["status"] == "processing"
+    h.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_note_non_review_no_bypass(client):
+    payload = _note_payload(note="@mira-bot pause")
+    payload["user"]["username"] = "alice"
+    cfg = MiraConfig(filter=FilterConfig(blocked_authors=["alice"]))
+    with (
+        patch("mira.platforms.gitlab.webhook.load_config", return_value=cfg),
+        patch("mira.platforms.gitlab.webhook.handle_gitlab_note", new=AsyncMock()) as h,
+    ):
+        resp = await client.post(
+            "/gitlab/webhook",
+            content=json.dumps(payload),
+            headers={"X-Gitlab-Token": GL_SECRET, "X-Gitlab-Event": "Note Hook"},
+        )
+    assert resp.json()["status"] == "ignored"
+    h.assert_not_called()

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from mira.platforms.mentions import (
+    author_is_filtered,
     command_after_mention,
     has_mention,
     mention_names,
@@ -36,3 +37,31 @@ def test_command_after_mention():
     assert command_after_mention("@project_1_bot_x Reject", names) == "reject"
     assert command_after_mention("@mira", names) == ""  # no command word
     assert command_after_mention("nothing", names) == ""
+
+
+def test_author_is_filtered_blocked_by_raw_login():
+    assert author_is_filtered("alice", [], ["alice"]) is True
+
+
+def test_author_is_filtered_blocked_by_stripped_bot_suffix():
+    assert author_is_filtered("dependabot[bot]", [], ["dependabot"]) is True
+
+
+def test_author_is_filtered_allowlist_empty_not_filtered():
+    assert author_is_filtered("alice", [], []) is False
+
+
+def test_author_is_filtered_allowlist_set_and_on_list_not_filtered():
+    assert author_is_filtered("alice", ["alice"], []) is False
+
+
+def test_author_is_filtered_allowlist_set_and_off_list_filtered():
+    assert author_is_filtered("bob", ["alice"], []) is True
+
+
+def test_author_is_filtered_blocked_preempts_allowlist():
+    assert author_is_filtered("alice", ["alice"], ["alice"]) is True
+
+
+def test_author_is_filtered_empty_login_not_filtered():
+    assert author_is_filtered("", ["alice"], []) is False

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -11,6 +11,7 @@ import psycopg
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from mira.config import FilterConfig, MiraConfig
 from mira.platforms.github.auth import GitHubAppAuth
 from mira.platforms.server import create_app
 
@@ -419,4 +420,115 @@ async def test_review_comment_still_dispatches_handle_comment(
     assert resp.status_code == 200
     assert resp.json()["status"] == "processing"
     mock_comment.assert_awaited_once()
-    mock_pause.assert_not_awaited()
+
+
+async def _post(client: AsyncClient, event: str, payload: dict) -> dict:
+    """Helper to POST a webhook payload and return the JSON body."""
+    payload_bytes = json.dumps(payload).encode()
+    resp = await client.post(
+        "/webhook",
+        content=payload_bytes,
+        headers={
+            "X-Hub-Signature-256": _sign(payload_bytes),
+            "X-GitHub-Event": event,
+            "Content-Type": "application/json",
+        },
+    )
+    return resp.json()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_pull_request", new_callable=AsyncMock)
+async def test_pr_opened_blocked_author_filtered(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    mock_load_config.return_value = MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"]))
+    payload = _make_pr_payload()
+    payload["sender"] = {"login": "dependabot[bot]"}
+    result = await _post(client, "pull_request", payload)
+    assert result["status"] == "ignored"
+    mock_handler.assert_not_awaited()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_pull_request", new_callable=AsyncMock)
+async def test_pr_opened_allowed_author_not_filtered(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    mock_load_config.return_value = MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"]))
+    payload = _make_pr_payload()
+    payload["sender"] = {"login": "alice"}
+    result = await _post(client, "pull_request", payload)
+    assert result["status"] == "processing"
+    mock_handler.assert_awaited_once()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_pull_request", new_callable=AsyncMock)
+async def test_pr_opened_allowlist_filters_off_list(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    mock_load_config.return_value = MiraConfig(filter=FilterConfig(allowed_authors=["alice"]))
+    payload = _make_pr_payload()
+    payload["sender"] = {"login": "bob"}
+    result = await _post(client, "pull_request", payload)
+    assert result["status"] == "ignored"
+    mock_handler.assert_not_awaited()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_push_index", new_callable=AsyncMock)
+async def test_push_blocked_author_filtered(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    mock_load_config.return_value = MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"]))
+    payload = {
+        "ref": "refs/heads/main",
+        "sender": {"login": "dependabot[bot]"},
+        "repository": {"default_branch": "main"},
+        "installation": {"id": 1},
+    }
+    result = await _post(client, "push", payload)
+    assert result["status"] == "ignored"
+    mock_handler.assert_not_awaited()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_comment", new_callable=AsyncMock)
+async def test_comment_review_bypass_for_blocked_author(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    """Manual @mira-bot review bypasses the author filter."""
+    mock_load_config.return_value = MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"]))
+    payload = _comment_payload(f"@{BOT_NAME} review")
+    payload["comment"]["user"]["login"] = "dependabot[bot]"
+    result = await _post(client, "issue_comment", payload)
+    assert result["status"] == "processing"
+    mock_handler.assert_awaited_once()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_comment", new_callable=AsyncMock)
+async def test_comment_non_review_no_bypass(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    """Non-review commands do NOT bypass the author filter."""
+    mock_load_config.return_value = MiraConfig(filter=FilterConfig(blocked_authors=["alice"]))
+    payload = _comment_payload(f"@{BOT_NAME} pause")
+    result = await _post(client, "issue_comment", payload)
+    assert result["status"] == "ignored"
+    mock_handler.assert_not_awaited()
+
+
+@patch("mira.platforms.github.webhook.load_config")
+@patch("mira.platforms.github.webhook.handle_comment", new_callable=AsyncMock)
+async def test_comment_case_insensitive_review_bypass(
+    mock_handler: AsyncMock, mock_load_config, client: AsyncClient
+) -> None:
+    """Case-insensitive @mira-bot Review bypasses the author filter."""
+    mock_load_config.return_value = MiraConfig(filter=FilterConfig(blocked_authors=["dependabot"]))
+    payload = _comment_payload(f"@{BOT_NAME} Review")
+    payload["comment"]["user"]["login"] = "dependabot[bot]"
+    result = await _post(client, "issue_comment", payload)
+    assert result["status"] == "processing"
+    mock_handler.assert_awaited_once()


### PR DESCRIPTION
## Summary
Add configurable author allowlist and denylist to filter PR auto-review across all platforms

## Motivation
Deployments auto-review every incoming PR, including those from bots, dependents, or trusted/internal authors who don't need reviews. This wastes compute and creates noise in the review queue.

## Changes
- New `FilterConfig.allowed_authors` and `FilterConfig.blocked_authors` settings (denylist takes precedence)
- Shared `author_is_filtered()` helper in `platforms/mentions.py` with GitHub self-bot detection (suffix `[bot]`)
- Filter check wired into GitHub, GitLab, and Forgejo webhooks for PR/MR opens, push events, and comment events
- Manual `@mira review` comments bypass the filter so any user can trigger on demand
- Full test coverage: unit tests for filter logic, integration tests per platform with blocked/allowed author scenarios

## Notes
- Empty lists mean "no filtering" (backwards compatible default)
- Bot self-events are already excluded upstream; this filter targets external actors
- `uv.lock` diff is a lockfile revision bump, unrelated to feature changes

## Resolves
Closes #180