### PR TITLE
fix(forgejo): add missing GET method arg to get_pr_info

### DIFF
--- a/src/mira/providers/forgejo.py
+++ b/src/mira/providers/forgejo.py
@@ -114,6 +114,7 @@ class ForgejoProvider(BaseProvider):
         owner, repo, number = parse_pr_url(pr_url)
         try:
             resp = await self._request(
+                "GET",
                 f"{self._api}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/{number}",
             )
             pr = resp.json()


### PR DESCRIPTION
## Summary

Add missing `"GET"` method argument to `ForgejoProvider.get_pr_info` `_request` call.

## Motivation

The `_request` method signature is `(self, method: str, url: str, ...)`. The call in `get_pr_info` passed only the URL, causing:

```
TypeError: ForgejoProvider._request() missing 1 required positional argument: 'url'
```

This blocked all Forgejo PR reviews (e.g., milmus#152). The bug was introduced in commit `6bf3c0f` (July 11, 2026) when `"GET"` was accidentally dropped while refactoring to add URL quoting — just hours after the Forgejo provider was initially merged.

## Changes

- `src/mira/providers/forgejo.py`: Added `"GET"` as the first positional argument to the `_request` call in `get_pr_info`.
