### PR TITLE
Fix default admin account password, svg API bug

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,7 @@ export OPENROUTER_API_KEY=sk-or-v1-your-key-here
 export MIRA_MODEL=anthropic/claude-sonnet-4-6
 
 # Dashboard
-export ADMIN_PASSWORD=changeme
+# Initial admin password. If unset, a random password is generated on first
+# start and printed in the server logs. Never use a guessable value here.
+# export ADMIN_PASSWORD=
 export MIRA_INDEX_DIR=./data/indexes

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ export MIRA_MODEL=anthropic/claude-sonnet-4-6
 
 # Dashboard
 # Initial admin password. If unset, a random password is generated on first
-# start and printed in the server logs. Never use a guessable value here.
+# start and written to <MIRA_INDEX_DIR>/initial_admin_password (mode 0600).
+# Never use a guessable value here.
 # export ADMIN_PASSWORD=
 export MIRA_INDEX_DIR=./data/indexes

--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -241,7 +241,9 @@ class ProviderConfig(BaseModel):
 
 class DatabaseConfig(BaseModel):
     url: str = ""  # empty = SQLite fallback. "postgresql://user:pass@host:5432/mira"
-    admin_password: str = "admin"  # default admin password, change in production
+    admin_password: str = (
+        ""  # initial admin password; empty = random generated + logged on first start
+    )
 
 
 class MiraConfig(BaseModel):

--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -242,7 +242,7 @@ class ProviderConfig(BaseModel):
 class DatabaseConfig(BaseModel):
     url: str = ""  # empty = SQLite fallback. "postgresql://user:pass@host:5432/mira"
     admin_password: str = (
-        ""  # initial admin password; empty = random generated + logged on first start
+        ""  # initial admin password; empty = generated on first start, written to a 0600 file
     )
 
 

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 # Database + auth
 _db_url = os.environ.get("DATABASE_URL", "")
-_admin_password = os.environ.get("ADMIN_PASSWORD", "admin")
+_admin_password = os.environ.get("ADMIN_PASSWORD", "")
 _app_db = AppDatabase(_db_url, admin_password=_admin_password)
 
 # All dashboard routes register on this router. `register_dashboard()` wires

--- a/src/mira/dashboard/auth.py
+++ b/src/mira/dashboard/auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
@@ -17,7 +18,8 @@ SESSION_COOKIE = "mira_session"
 
 # Routes that don't require auth
 _PUBLIC_PATHS = {"/api/auth/login", "/docs", "/openapi.json", "/redoc"}
-_PUBLIC_PREFIXES = ("/api/repos/",)  # SVG endpoints need to be public for GitHub image embedding
+# The badge SVG must be public so GitHub can embed it as an image
+_PUBLIC_SVG = re.compile(r"/api/repos/[^/]+/[^/]+/blast-radius\.svg")
 
 
 class LoginRequest(BaseModel):
@@ -186,8 +188,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         if request.url.path in _PUBLIC_PATHS:
             return await call_next(request)
-        # Allow SVG endpoints for GitHub image embedding
-        if request.url.path.endswith(".svg"):
+        # Allow the badge SVG for GitHub image embedding
+        if _PUBLIC_SVG.fullmatch(request.url.path):
             return await call_next(request)
         # Non-API paths (frontend assets) don't need auth
         if not request.url.path.startswith("/api/"):

--- a/src/mira/dashboard/db.py
+++ b/src/mira/dashboard/db.py
@@ -679,7 +679,8 @@ class AppDatabase:
 
     def _ensure_default_admin(self) -> None:
         """Create the initial admin user if none exists. Never uses a fixed default
-        password: takes the configured one, or generates a random one and logs it."""
+        password: takes the configured one, or generates a random one and writes it
+        to a 0600 file (never to logs, which may be shipped to long-lived stores)."""
         if self._backend == "sqlite":
             assert self._sqlite_conn is not None
             row = self._sqlite_conn.execute(
@@ -699,11 +700,19 @@ class AppDatabase:
             logger.info("Created admin user (password from ADMIN_PASSWORD)")
         else:
             password = secrets.token_urlsafe(16)
+            # Written before create_user: if the write fails, startup fails and
+            # no admin exists, so the next start retries cleanly.
+            secrets_dir = os.environ.get("MIRA_INDEX_DIR", "./data/indexes")
+            os.makedirs(secrets_dir, exist_ok=True)
+            path = os.path.join(secrets_dir, "initial_admin_password")
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
+                f.write(password + "\n")
             self.create_user("admin", password, is_admin=True)
             logger.warning(
-                "No ADMIN_PASSWORD set — created admin user with generated password: %s "
-                "(set ADMIN_PASSWORD or change it after first login)",
-                password,
+                "No ADMIN_PASSWORD set — created admin user with a generated password, "
+                "written to %s (log in, change it, then delete the file)",
+                path,
             )
 
     def _warn_if_default_password(self) -> None:

--- a/src/mira/dashboard/db.py
+++ b/src/mira/dashboard/db.py
@@ -6,6 +6,7 @@ Supports PostgreSQL via DATABASE_URL or SQLite fallback for local dev.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 import logging
 import os
@@ -462,16 +463,30 @@ def _epoch_to_day(event_at: float) -> str:
     return datetime.fromtimestamp(event_at, tz=UTC).strftime("%Y-%m-%d")
 
 
+_PBKDF2_ITERATIONS = 600_000
+
+
 def _hash_password(password: str) -> str:
-    """Hash password with salt using SHA-256. Simple and dependency-free."""
-    salt = "mira_salt_v1"
-    return hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
+    """PBKDF2-HMAC-SHA256 with a per-user random salt: 'pbkdf2$iterations$salt$hash'."""
+    salt = secrets.token_hex(16)
+    dk = hashlib.pbkdf2_hmac("sha256", password.encode(), bytes.fromhex(salt), _PBKDF2_ITERATIONS)
+    return f"pbkdf2${_PBKDF2_ITERATIONS}${salt}${dk.hex()}"
+
+
+def _verify_password(password: str, stored: str) -> bool:
+    if stored.startswith("pbkdf2$"):
+        _, iterations, salt, expected = stored.split("$")
+        dk = hashlib.pbkdf2_hmac("sha256", password.encode(), bytes.fromhex(salt), int(iterations))
+        return hmac.compare_digest(dk.hex(), expected)
+    # Legacy static-salt SHA-256 (pre-0.7.1); upgraded on next successful login.
+    legacy = hashlib.sha256(f"mira_salt_v1:{password}".encode()).hexdigest()
+    return hmac.compare_digest(legacy, stored)
 
 
 class AppDatabase:
     """Application database for users and sessions."""
 
-    def __init__(self, url: str = "", admin_password: str = "admin") -> None:
+    def __init__(self, url: str = "", admin_password: str = "") -> None:
         self._url = url
         self._admin_password = admin_password
         self._pg_conn = None
@@ -663,22 +678,49 @@ class AppDatabase:
                 self._pg_conn.commit()
 
     def _ensure_default_admin(self) -> None:
-        """Create default admin user if none exists. Uses configured admin_password."""
+        """Create the initial admin user if none exists. Never uses a fixed default
+        password: takes the configured one, or generates a random one and logs it."""
         if self._backend == "sqlite":
             assert self._sqlite_conn is not None
             row = self._sqlite_conn.execute(
                 "SELECT COUNT(*) FROM users WHERE is_admin = 1"
             ).fetchone()
-            if row[0] == 0:
-                self.create_user("admin", self._admin_password, is_admin=True)
-                logger.info("Created default admin user (password from config)")
+            has_admin = row[0] > 0
         else:
             with self._pg_cursor() as cur:
                 cur.execute("SELECT COUNT(*) FROM users WHERE is_admin = TRUE")
                 row = cur.fetchone()
-                if row and row[0] == 0:
-                    self.create_user("admin", self._admin_password, is_admin=True)
-                    logger.info("Created default admin user (password from config)")
+                has_admin = bool(row and row[0])
+        if has_admin:
+            self._warn_if_default_password()
+            return
+        if self._admin_password:
+            self.create_user("admin", self._admin_password, is_admin=True)
+            logger.info("Created admin user (password from ADMIN_PASSWORD)")
+        else:
+            password = secrets.token_urlsafe(16)
+            self.create_user("admin", password, is_admin=True)
+            logger.warning(
+                "No ADMIN_PASSWORD set — created admin user with generated password: %s "
+                "(set ADMIN_PASSWORD or change it after first login)",
+                password,
+            )
+
+    def _warn_if_default_password(self) -> None:
+        """Flag deployments still carrying admin/admin (or the old .env.example value)."""
+        if self._backend == "sqlite":
+            assert self._sqlite_conn is not None
+            row = self._sqlite_conn.execute(
+                "SELECT password_hash FROM users WHERE username = 'admin'"
+            ).fetchone()
+        else:
+            with self._pg_cursor() as cur:
+                cur.execute("SELECT password_hash FROM users WHERE username = 'admin'")
+                row = cur.fetchone()
+        if row and any(_verify_password(p, row[0]) for p in ("admin", "changeme")):
+            logger.warning(
+                "The 'admin' user has a well-known default password — change it immediately"
+            )
 
     def create_user(self, username: str, password: str, is_admin: bool = False) -> User:
         pw_hash = _hash_password(password)
@@ -701,31 +743,39 @@ class AppDatabase:
             return User(id=row[0], username=username, is_admin=is_admin, created_at=now)
 
     def authenticate(self, username: str, password: str) -> User | None:
-        pw_hash = _hash_password(password)
         if self._backend == "sqlite":
             assert self._sqlite_conn is not None
             row = self._sqlite_conn.execute(
-                "SELECT id, username, is_admin, theme, created_at FROM users WHERE username = ? AND password_hash = ?",
-                (username, pw_hash),
+                "SELECT id, username, is_admin, theme, created_at, password_hash "
+                "FROM users WHERE username = ?",
+                (username,),
             ).fetchone()
-            if row:
-                return User(
-                    id=row[0],
-                    username=row[1],
-                    is_admin=bool(row[2]),
-                    theme=row[3],
-                    created_at=row[4],
-                )
-            return None
-        with self._pg_cursor() as cur:
-            cur.execute(
-                "SELECT id, username, is_admin, theme FROM users WHERE username = %s AND password_hash = %s",
-                (username, pw_hash),
+            if not row or not _verify_password(password, row[5]):
+                return None
+            user = User(
+                id=row[0],
+                username=row[1],
+                is_admin=bool(row[2]),
+                theme=row[3],
+                created_at=row[4],
             )
-            row = cur.fetchone()
-            if row:
-                return User(id=row[0], username=row[1], is_admin=bool(row[2]), theme=row[3])
-            return None
+            stored = row[5]
+        else:
+            with self._pg_cursor() as cur:
+                cur.execute(
+                    "SELECT id, username, is_admin, theme, password_hash "
+                    "FROM users WHERE username = %s",
+                    (username,),
+                )
+                row = cur.fetchone()
+            if not row or not _verify_password(password, row[4]):
+                return None
+            user = User(id=row[0], username=row[1], is_admin=bool(row[2]), theme=row[3])
+            stored = row[4]
+        if not stored.startswith("pbkdf2$"):
+            # Transparent upgrade of legacy SHA-256 hashes.
+            self.update_password(user.id, password)
+        return user
 
     def create_session(self, user_id: int) -> str:
         token = secrets.token_urlsafe(32)

--- a/tests/test_auth_middleware_public_paths.py
+++ b/tests/test_auth_middleware_public_paths.py
@@ -1,0 +1,47 @@
+"""AuthMiddleware public-path rules: only the badge SVG bypasses auth, not any *.svg."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mira.dashboard.auth import AuthMiddleware
+from mira.dashboard.db import AppDatabase
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware, db=AppDatabase(url="", admin_password="pw"))
+
+    @app.get("/{full_path:path}")
+    def catch_all(full_path: str) -> dict:
+        return {"ok": True}
+
+    return TestClient(app)
+
+
+def test_badge_svg_is_public(client: TestClient) -> None:
+    assert client.get("/api/repos/owner/repo/blast-radius.svg").status_code == 200
+
+
+def test_other_svg_paths_require_auth(client: TestClient) -> None:
+    for path in (
+        "/api/users.svg",
+        "/api/admin/settings.svg",
+        "/api/repos/owner/blast-radius.svg",
+        "/api/repos/owner/repo/extra/blast-radius.svg",
+    ):
+        assert client.get(path).status_code == 401, path
+
+
+def test_api_requires_auth_without_cookie(client: TestClient) -> None:
+    assert client.get("/api/events").status_code == 401
+
+
+def test_non_api_paths_are_public(client: TestClient) -> None:
+    assert client.get("/login").status_code == 200

--- a/tests/test_default_admin.py
+++ b/tests/test_default_admin.py
@@ -1,0 +1,61 @@
+"""Tests for initial admin creation — no hard-coded default password (CWE-1188)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mira.dashboard.db import AppDatabase
+
+
+@pytest.fixture(autouse=True)
+def _index_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+
+
+def test_no_password_generates_random_admin(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING"):
+        db = AppDatabase(url="")
+
+    # admin/admin must not work.
+    assert db.authenticate("admin", "admin") is None
+
+    # The generated password is logged once and does work.
+    msg = next(r.getMessage() for r in caplog.records if "generated password" in r.getMessage())
+    password = msg.split("generated password: ")[1].split(" ")[0]
+    assert db.authenticate("admin", password) is not None
+
+
+def test_configured_password_is_used(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING"):
+        db = AppDatabase(url="", admin_password="s3cret-value")
+
+    assert db.authenticate("admin", "s3cret-value") is not None
+    assert db.authenticate("admin", "admin") is None
+    assert not any("generated password" in r.getMessage() for r in caplog.records)
+
+
+def test_existing_default_password_warns_on_startup(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Simulate an old deployment that shipped with admin/admin.
+    AppDatabase(url="", admin_password="admin")
+
+    with caplog.at_level("WARNING"):
+        db = AppDatabase(url="")
+
+    assert any("well-known default password" in r.getMessage() for r in caplog.records)
+    # No second admin was created; the old one is untouched.
+    assert db.authenticate("admin", "admin") is not None
+
+
+def test_no_warning_for_strong_existing_password(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    AppDatabase(url="", admin_password="a-strong-password")
+
+    with caplog.at_level("WARNING"):
+        AppDatabase(url="")
+
+    assert not any("well-known default" in r.getMessage() for r in caplog.records)

--- a/tests/test_default_admin.py
+++ b/tests/test_default_admin.py
@@ -14,17 +14,22 @@ def _index_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
 
 
-def test_no_password_generates_random_admin(caplog: pytest.LogCaptureFixture) -> None:
+def test_no_password_generates_random_admin(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
     with caplog.at_level("WARNING"):
         db = AppDatabase(url="")
 
     # admin/admin must not work.
     assert db.authenticate("admin", "admin") is None
 
-    # The generated password is logged once and does work.
-    msg = next(r.getMessage() for r in caplog.records if "generated password" in r.getMessage())
-    password = msg.split("generated password: ")[1].split(" ")[0]
+    # The generated password lands in a 0600 file, not in the logs.
+    pw_file = tmp_path / "initial_admin_password"
+    password = pw_file.read_text().strip()
     assert db.authenticate("admin", password) is not None
+    assert pw_file.stat().st_mode & 0o777 == 0o600
+    assert password not in caplog.text
+    assert str(pw_file) in caplog.text
 
 
 def test_configured_password_is_used(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_password_hashing.py
+++ b/tests/test_password_hashing.py
@@ -1,0 +1,72 @@
+"""Tests for PBKDF2 password hashing and legacy SHA-256 migration."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from mira.dashboard.db import AppDatabase, _hash_password, _verify_password
+
+
+@pytest.fixture
+def db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppDatabase:
+    monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+    return AppDatabase(url="", admin_password="adminpw")
+
+
+def _legacy_hash(password: str) -> str:
+    return hashlib.sha256(f"mira_salt_v1:{password}".encode()).hexdigest()
+
+
+def test_hashes_are_salted_per_user() -> None:
+    a, b = _hash_password("same-password"), _hash_password("same-password")
+    assert a != b
+    assert a.startswith("pbkdf2$")
+    assert _verify_password("same-password", a)
+    assert _verify_password("same-password", b)
+    assert not _verify_password("wrong", a)
+
+
+def test_verify_accepts_legacy_hash() -> None:
+    stored = _legacy_hash("oldpw")
+    assert _verify_password("oldpw", stored)
+    assert not _verify_password("wrong", stored)
+
+
+def test_login_upgrades_legacy_hash(db: AppDatabase) -> None:
+    bob = db.create_user("bob", "irrelevant", is_admin=False)
+    db._sqlite_conn.execute(
+        "UPDATE users SET password_hash = ? WHERE id = ?", (_legacy_hash("oldpw"), bob.id)
+    )
+    db._sqlite_conn.commit()
+
+    assert db.authenticate("bob", "wrong") is None
+    assert db.authenticate("bob", "oldpw") is not None
+
+    stored = db._sqlite_conn.execute(
+        "SELECT password_hash FROM users WHERE id = ?", (bob.id,)
+    ).fetchone()[0]
+    assert stored.startswith("pbkdf2$")
+    # Still logs in after the upgrade.
+    assert db.authenticate("bob", "oldpw") is not None
+
+
+def test_default_password_warning_covers_legacy_hashes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+    db = AppDatabase(url="", admin_password="x")
+    db._sqlite_conn.execute(
+        "UPDATE users SET password_hash = ? WHERE username = 'admin'",
+        (_legacy_hash("admin"),),
+    )
+    db._sqlite_conn.commit()
+
+    with caplog.at_level("WARNING"):
+        AppDatabase(url="")
+
+    assert any("well-known default password" in r.getMessage() for r in caplog.records)

--- a/tests/test_postgres_reconnect.py
+++ b/tests/test_postgres_reconnect.py
@@ -13,8 +13,10 @@ from unittest.mock import patch
 
 import psycopg
 
-from mira.dashboard.db import AppDatabase
+from mira.dashboard.db import AppDatabase, _hash_password
 from mira.index import pg_store
+
+_ADMIN_HASH = _hash_password("admin")
 
 
 class _FakeCursor:
@@ -31,7 +33,7 @@ class _FakeCursor:
         if self._conn.dead:
             raise psycopg.OperationalError("the connection is closed")
         if "FROM users" in sql and "password_hash" in sql:
-            self._conn.last_row = (1, "admin", True, "dark")
+            self._conn.last_row = (1, "admin", True, "dark", _ADMIN_HASH)
         elif "FROM files" in sql and "path" in sql:
             self._conn.last_row = ("warmup.py", "py", "summary", "hash", 1, 0.0)
         elif "COUNT(*)" in sql and "is_admin" in sql:


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary

- Fixes bug where admin password is not randomly generated
- Fixes bug with .svg API access
- Fixes bug with password hashing

## Test plan

- Locally & CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
