### PR TITLE
Fixed some dashboard endpoints not having auth

### DIFF
--- a/src/mira/dashboard/routers/admin.py
+++ b/src/mira/dashboard/routers/admin.py
@@ -81,10 +81,11 @@ async def _register_and_index_repo(platform: str, env_token: str, body: BaseMode
 
 
 @router.post("/api/gitlab/sync")
-async def sync_gitlab_projects() -> dict:
+async def sync_gitlab_projects(request: Request) -> dict:
     """Discover every GitLab project the configured token can access and
     register them (status pending), so they appear ready-to-index without
     waiting for a webhook. Idempotent."""
+    _require_admin(request)
     from mira.platforms.gitlab.auth import GitLabTokenAuth
     from mira.platforms.gitlab.webhook import backfill_gitlab_projects
 
@@ -99,21 +100,23 @@ async def sync_gitlab_projects() -> dict:
 
 
 @router.post("/api/gitlab/repos")
-async def register_gitlab_repo(body: GitLabRepoRegister) -> dict:
+async def register_gitlab_repo(body: GitLabRepoRegister, request: Request) -> dict:
     """Register a GitLab project and index it in the background.
 
     GitLab has no installation webhook, so repos are added explicitly. The
     access token comes from MIRA_GITLAB_TOKEN; add a project webhook pointing
     at ``/gitlab/webhook`` to get auto-review on new MRs.
     """
+    _require_admin(request)
     return await _register_and_index_repo("gitlab", "MIRA_GITLAB_TOKEN", body)
 
 
 @router.post("/api/forgejo/sync")
-async def sync_forgejo_repos() -> dict:
+async def sync_forgejo_repos(request: Request) -> dict:
     """Discover every Forgejo repo the configured token can access and
     register them (status pending), so they appear ready-to-index without
     waiting for a webhook. Idempotent."""
+    _require_admin(request)
     from mira.platforms.forgejo.auth import ForgejoTokenAuth
     from mira.platforms.forgejo.webhook import backfill_forgejo_repos
 
@@ -128,13 +131,14 @@ async def sync_forgejo_repos() -> dict:
 
 
 @router.post("/api/forgejo/repos")
-async def register_forgejo_repo(body: ForgejoRepoRegister) -> dict:
+async def register_forgejo_repo(body: ForgejoRepoRegister, request: Request) -> dict:
     """Register a Forgejo repo and index it in the background.
 
     Forgejo has no installation webhook, so repos are added explicitly. The
     access token comes from MIRA_FORGEJO_TOKEN; add a repo webhook pointing
     at ``/forgejo/webhook`` to get auto-review on new PRs.
     """
+    _require_admin(request)
     return await _register_and_index_repo("forgejo", "MIRA_FORGEJO_TOKEN", body)
 
 
@@ -237,7 +241,8 @@ def set_global_settings(body: GlobalSettingsUpdate, request: Request) -> dict:
 
 
 @router.put("/api/settings/models")
-def set_models(body: ModelsUpdate) -> dict:
+def set_models(body: ModelsUpdate, request: Request) -> dict:
+    _require_admin(request)
     from mira.dashboard.models_config import THINKING_MODE_VALUES
 
     if body.review_thinking_mode not in THINKING_MODE_VALUES:
@@ -386,15 +391,17 @@ def list_pending_uninstalls() -> list[PendingUninstallModel]:
 
 
 @router.post("/api/uninstalls/{installation_id}/keep")
-def keep_uninstall_data(installation_id: int) -> dict:
+def keep_uninstall_data(installation_id: int, request: Request) -> dict:
     """User chose to keep data after uninstall — just dismiss the popup."""
+    _require_admin(request)
     _api._app_db.remove_pending_uninstall(installation_id)
     return {"ok": True}
 
 
 @router.post("/api/uninstalls/{installation_id}/delete")
-def delete_uninstall_data(installation_id: int) -> dict:
+def delete_uninstall_data(installation_id: int, request: Request) -> dict:
     """User chose to delete all data for this installation."""
+    _require_admin(request)
     removed = _api._app_db.delete_repos_by_installation(installation_id)
     _api._app_db.remove_pending_uninstall(installation_id)
     return {"ok": True, "removed": removed}
@@ -442,8 +449,9 @@ async def get_setup_status() -> dict:
 
 
 @router.post("/api/setup/complete")
-async def complete_setup(body: SetupRequest) -> dict:
+async def complete_setup(body: SetupRequest, request: Request) -> dict:
     """Save setup choices and start indexing selected repos."""
+    _require_admin(request)
     enabled_count = 0
     for r in body.repos:
         owner, repo = r["owner"], r["repo"]

--- a/src/mira/dashboard/routers/repos.py
+++ b/src/mira/dashboard/routers/repos.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 from datetime import UTC, datetime
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from fastapi import Response as FastAPIResponse
 
 from mira.dashboard import api as _api
@@ -27,6 +27,7 @@ from mira.dashboard.api import (
     _open_relationships,
     _open_store,
     _pick_platform_record,
+    _require_admin,
     logger,
     router,
 )
@@ -57,11 +58,12 @@ def list_repos() -> list[RepoListItem]:
 
 
 @router.post("/api/repos/sync")
-async def sync_repos() -> dict:
+async def sync_repos(request: Request) -> dict:
     """Reconcile the repos table with actual GitHub App installations.
 
     Removes repos that are no longer accessible and adds any new ones.
     """
+    _require_admin(request)
     app_id = os.environ.get("MIRA_GITHUB_APP_ID", "")
     private_key = os.environ.get("MIRA_GITHUB_PRIVATE_KEY", "")
     if not app_id or not private_key:
@@ -437,8 +439,9 @@ def get_packages(owner: str, repo: str) -> list[PackageModel]:
 
 
 @router.post("/api/repos/{owner}/{repo}/index")
-async def trigger_index(owner: str, repo: str, full: bool = False) -> dict:
+async def trigger_index(owner: str, repo: str, request: Request, full: bool = False) -> dict:
     """Trigger indexing for a repo. full=true wipes and re-indexes everything."""
+    _require_admin(request)
     from mira.index.status import tracker
 
     full_name = f"{owner}/{repo}"
@@ -564,7 +567,7 @@ async def trigger_index(owner: str, repo: str, full: bool = False) -> dict:
 
 
 @router.delete("/api/repos/{owner}/{repo}/index")
-async def cancel_index(owner: str, repo: str) -> dict:
+async def cancel_index(owner: str, repo: str, request: Request) -> dict:
     """Request cancellation of an in-progress indexing job.
 
     Returns ``{"status": "cancelling"}`` if a job was active,
@@ -572,6 +575,7 @@ async def cancel_index(owner: str, repo: str) -> dict:
     ``cancelled`` once the indexer notices the flag (at the next batch
     boundary).
     """
+    _require_admin(request)
     from mira.index.status import tracker
 
     full_name = f"{owner}/{repo}"

--- a/tests/test_admin_authz.py
+++ b/tests/test_admin_authz.py
@@ -1,0 +1,59 @@
+"""Every state-changing admin endpoint must reject non-admin users (CWE-862)."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from mira.dashboard.api import router
+
+# (path, method, extra kwargs). Bodies are None: _require_admin fires first.
+PROTECTED = [
+    ("/api/gitlab/sync", "POST", {}),
+    ("/api/gitlab/repos", "POST", {"body": None}),
+    ("/api/forgejo/sync", "POST", {}),
+    ("/api/forgejo/repos", "POST", {"body": None}),
+    ("/api/settings/models", "PUT", {"body": None}),
+    ("/api/uninstalls/{installation_id}/keep", "POST", {"installation_id": 1}),
+    ("/api/uninstalls/{installation_id}/delete", "POST", {"installation_id": 1}),
+    ("/api/setup/complete", "POST", {"body": None}),
+    ("/api/repos/sync", "POST", {}),
+    ("/api/repos/{owner}/{repo}/index", "POST", {"owner": "o", "repo": "r"}),
+    ("/api/repos/{owner}/{repo}/index", "DELETE", {"owner": "o", "repo": "r"}),
+]
+
+
+def _endpoint(path: str, method: str):
+    for route in router.routes:
+        if route.path == path and method in route.methods:
+            return route.endpoint
+    raise AssertionError(f"route {method} {path} not found")
+
+
+def _non_admin_request() -> SimpleNamespace:
+    user = SimpleNamespace(id=2, username="bob", is_admin=False)
+    return SimpleNamespace(state=SimpleNamespace(user=user))
+
+
+@pytest.mark.parametrize("path,method,kwargs", PROTECTED)
+async def test_rejects_non_admin(path: str, method: str, kwargs: dict) -> None:
+    endpoint = _endpoint(path, method)
+    with pytest.raises(HTTPException) as exc:
+        result = endpoint(request=_non_admin_request(), **kwargs)
+        if inspect.iscoroutine(result):
+            await result
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.parametrize("path,method,kwargs", PROTECTED)
+async def test_rejects_missing_user(path: str, method: str, kwargs: dict) -> None:
+    endpoint = _endpoint(path, method)
+    request = SimpleNamespace(state=SimpleNamespace())
+    with pytest.raises(HTTPException) as exc:
+        result = endpoint(request=request, **kwargs)
+        if inspect.iscoroutine(result):
+            await result
+    assert exc.value.status_code == 403

--- a/tests/test_models_config_thinking.py
+++ b/tests/test_models_config_thinking.py
@@ -23,6 +23,13 @@ from mira.dashboard.models_config import (
 from mira.dashboard.routers.admin import set_models
 
 
+def _admin_req():
+    from types import SimpleNamespace
+
+    user = SimpleNamespace(is_admin=True)
+    return SimpleNamespace(state=SimpleNamespace(user=user))
+
+
 @pytest.fixture
 def in_memory_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppDatabase:
     """Fresh per-test SQLite DB swapped in for the module-level `_app_db`."""
@@ -80,7 +87,7 @@ class TestSetModelsThinkingValidation:
             review_thinking_mode="ultra",
         )
         with pytest.raises(HTTPException) as exc:
-            set_models(body)
+            set_models(body, _admin_req())
         assert exc.value.status_code == 400
 
     def test_persists_valid_thinking_mode(self, in_memory_db: AppDatabase):
@@ -89,7 +96,7 @@ class TestSetModelsThinkingValidation:
             review_model="anthropic/claude-sonnet-4-6",
             review_thinking_mode="medium",
         )
-        assert set_models(body) == {"ok": True}
+        assert set_models(body, _admin_req()) == {"ok": True}
         assert in_memory_db.get_setting("review_thinking_mode") == "medium"
 
     def test_off_clears_setting_so_config_can_win(self, in_memory_db: AppDatabase):
@@ -100,7 +107,7 @@ class TestSetModelsThinkingValidation:
             review_model="anthropic/claude-sonnet-4-6",
             review_thinking_mode="off",
         )
-        assert set_models(body) == {"ok": True}
+        assert set_models(body, _admin_req()) == {"ok": True}
         assert in_memory_db.get_setting("review_thinking_mode") == ""
         cfg = LLMConfig(review_reasoning_effort="high")
         assert (

--- a/tests/test_models_settings.py
+++ b/tests/test_models_settings.py
@@ -20,6 +20,13 @@ from mira.dashboard.models_config import llm_config_for
 from mira.dashboard.routers.admin import get_models, set_models
 
 
+def _admin_req():
+    from types import SimpleNamespace
+
+    user = SimpleNamespace(is_admin=True)
+    return SimpleNamespace(state=SimpleNamespace(user=user))
+
+
 @pytest.fixture
 def in_memory_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppDatabase:
     """Fresh per-test SQLite DB swapped in for the module-level `_app_db`."""
@@ -59,7 +66,7 @@ class TestSetModelsInheritAndCustom:
     def test_empty_value_clears_override(self, in_memory_db: AppDatabase):
         in_memory_db.set_setting("review_model", "anthropic/claude-sonnet-4-6")
         body = ModelsUpdate(indexing_model="", review_model="")
-        assert set_models(body) == {"ok": True}
+        assert set_models(body, _admin_req()) == {"ok": True}
         assert in_memory_db.get_setting("review_model") == ""
         # Cleared override → config is authoritative again.
         cfg = LLMConfig(review_model="openai/gpt-5.1")
@@ -70,7 +77,7 @@ class TestSetModelsInheritAndCustom:
             indexing_model="local/llama-3.3-70b",
             review_model="openai/gpt-5.1-codex-mini",
         )
-        assert set_models(body) == {"ok": True}
+        assert set_models(body, _admin_req()) == {"ok": True}
         assert in_memory_db.get_setting("review_model") == "openai/gpt-5.1-codex-mini"
         assert llm_config_for("review", LLMConfig()).model == "openai/gpt-5.1-codex-mini"
 

--- a/tests/test_repos_sync.py
+++ b/tests/test_repos_sync.py
@@ -15,6 +15,13 @@ from mira.dashboard.routers.admin import complete_setup
 from mira.dashboard.routers.repos import sync_repos
 
 
+def _admin_req():
+    from types import SimpleNamespace
+
+    user = SimpleNamespace(is_admin=True)
+    return SimpleNamespace(state=SimpleNamespace(user=user))
+
+
 @pytest.fixture
 def db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppDatabase:
     monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
@@ -39,7 +46,7 @@ async def test_sync_prunes_stale_github_but_leaves_gitlab(db: AppDatabase) -> No
         patch("mira.platforms.github.auth.GitHubAppAuth", return_value=auth),
         patch("mira.platforms.github.webhook._count_files_for_repos", new=AsyncMock()),
     ):
-        result = await sync_repos()
+        result = await sync_repos(_admin_req())
 
     assert result["removed"] == 1
     remaining = {(r.platform, r.owner, r.repo) for r in db.list_repos()}
@@ -59,7 +66,8 @@ async def test_complete_setup_writes_to_platform_rows(db: AppDatabase) -> None:
                     {"owner": "grp", "repo": "proj", "platform": "gitlab", "enabled": False},
                 ],
                 index_mode="full",
-            )
+            ),
+            _admin_req(),
         )
 
     gh = db.get_repo("acme", "web")


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary
- Fixes some dashboard endpoints not having full authentication methods

## Test plan

Locally & CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
