### PR TITLE
Fix session cookies

### DIFF
--- a/src/mira/dashboard/auth.py
+++ b/src/mira/dashboard/auth.py
@@ -58,7 +58,7 @@ def create_auth_router(db: AppDatabase) -> APIRouter:
     router = APIRouter(prefix="/api/auth", tags=["auth"])
 
     @router.post("/login")
-    def login(body: LoginRequest, response: Response) -> dict:
+    def login(body: LoginRequest, request: Request, response: Response) -> dict:
         user = db.authenticate(body.username, body.password)
         if not user:
             return JSONResponse(status_code=401, content={"error": "Invalid credentials"})
@@ -69,6 +69,8 @@ def create_auth_router(db: AppDatabase) -> APIRouter:
             token,
             httponly=True,
             samesite="lax",
+            # Secure when served over HTTPS (directly or via X-Forwarded-Proto)
+            secure=request.url.scheme == "https",
             max_age=86400 * 7,
         )
         return {

--- a/src/mira/dashboard/auth.py
+++ b/src/mira/dashboard/auth.py
@@ -69,7 +69,9 @@ def create_auth_router(db: AppDatabase) -> APIRouter:
             token,
             httponly=True,
             samesite="lax",
-            # Secure when served over HTTPS (directly or via X-Forwarded-Proto)
+            # Secure when served over HTTPS. Behind a TLS-terminating proxy this
+            # relies on uvicorn honoring X-Forwarded-Proto (trusted from
+            # 127.0.0.1 by default; see the deployment docs for other setups).
             secure=request.url.scheme == "https",
             max_age=86400 * 7,
         )

--- a/tests/test_session_cookie_secure.py
+++ b/tests/test_session_cookie_secure.py
@@ -1,0 +1,40 @@
+"""The session cookie gets the Secure flag when served over HTTPS."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mira.dashboard.auth import create_auth_router
+from mira.dashboard.db import AppDatabase
+
+
+@pytest.fixture
+def app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+    app = FastAPI()
+    app.include_router(create_auth_router(AppDatabase(url="", admin_password="admin")))
+    return app
+
+
+def _login_cookie_header(app: FastAPI, base_url: str) -> str:
+    client = TestClient(app, base_url=base_url)
+    resp = client.post("/api/auth/login", json={"username": "admin", "password": "admin"})
+    assert resp.status_code == 200
+    header = resp.headers.get("set-cookie", "")
+    assert "mira_session=" in header
+    return header
+
+
+def test_cookie_not_secure_over_http(app: FastAPI) -> None:
+    header = _login_cookie_header(app, "http://testserver")
+    assert "Secure" not in header
+
+
+def test_cookie_secure_over_https(app: FastAPI) -> None:
+    header = _login_cookie_header(app, "https://testserver")
+    assert "Secure" in header
+    assert "HttpOnly" in header


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`


## Summary
- Fixes session cookies bug
## Test plan
Locally & CI
## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
