### PR TITLE
Fix Webhook SSRF guard

### DIFF
--- a/src/mira/outbound_webhooks.py
+++ b/src/mira/outbound_webhooks.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import ipaddress
 import logging
+import os
+import socket
 import time
 from typing import Any
 from urllib.parse import urlparse
@@ -190,24 +192,8 @@ def render(event: str, data: dict[str, Any], fmt: str) -> dict[str, Any]:
 # ── Delivery ─────────────────────────────────────────────────────────────────
 
 
-def is_safe_webhook_url(url: str) -> bool:
-    """Best-effort SSRF guard run before delivery.
-
-    Rejects ``localhost`` and any private / loopback / link-local / reserved IP
-    *literal* so an admin can't point a webhook at internal services or a cloud
-    metadata endpoint (e.g. ``169.254.169.254``). Hostnames are intentionally
-    not resolved — named internal services (e.g. a docker-compose ``mattermost``
-    host) stay usable on self-hosted deployments; this only blocks the obvious
-    raw-IP probe vectors.
-    """
-    host = (urlparse(url).hostname or "").lower()
-    if not host or host == "localhost":
-        return False
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        return True  # not an IP literal — a hostname; allow without resolving
-    return not (
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
         ip.is_private
         or ip.is_loopback
         or ip.is_link_local
@@ -215,6 +201,53 @@ def is_safe_webhook_url(url: str) -> bool:
         or ip.is_multicast
         or ip.is_unspecified
     )
+
+
+def _allowed_hosts() -> set[str]:
+    """Opt-in hostnames trusted without DNS resolution (comma-separated env)."""
+    raw = os.getenv("MIRA_WEBHOOK_ALLOWED_HOSTS", "")
+    return {h.strip().lower() for h in raw.split(",") if h.strip()}
+
+
+def is_safe_webhook_url(url: str) -> bool:
+    """Best-effort SSRF guard run before delivery.
+
+    Rejects ``localhost``, any private / loopback / link-local / reserved IP
+    literal, and any *hostname that resolves* into one of those ranges — so an
+    admin can't reach internal services or a cloud metadata endpoint (e.g.
+    ``169.254.169.254``) either directly or via a DNS name pointing there.
+
+    Named internal services (a docker-compose ``mattermost`` host, etc.) no
+    longer pass implicitly; list them in ``MIRA_WEBHOOK_ALLOWED_HOSTS`` to keep
+    them usable on self-hosted deployments.
+
+    Still best-effort: the check resolves the name but the eventual request
+    re-resolves it, leaving a narrow DNS-rebinding window for an admin who also
+    controls a fast-flipping DNS record.
+    """
+    host = (urlparse(url).hostname or "").lower()
+    if not host or host == "localhost":
+        return False
+
+    try:
+        return not _is_blocked_ip(ipaddress.ip_address(host))
+    except ValueError:
+        pass  # not an IP literal — resolve it below
+
+    if host in _allowed_hosts():
+        return True
+
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except socket.gaierror:
+        return False  # unresolvable — treat as unsafe rather than send blind
+    for info in infos:
+        try:
+            if _is_blocked_ip(ipaddress.ip_address(info[4][0])):
+                return False
+        except ValueError:
+            return False
+    return True
 
 
 async def deliver_one(

--- a/tests/test_outbound_webhooks.py
+++ b/tests/test_outbound_webhooks.py
@@ -7,6 +7,7 @@ endpoints (mirroring the fixture pattern in test_admin_settings.py).
 
 from __future__ import annotations
 
+import socket
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -26,6 +27,19 @@ from mira.dashboard.routers.admin import (
     update_webhook,
 )
 from mira.dashboard.routers.admin import test_webhook as run_webhook_test
+
+
+def _resolves_to(ip: str):
+    """A getaddrinfo stub that maps any host to a single address."""
+    fam = socket.AF_INET6 if ":" in ip else socket.AF_INET
+    return lambda host, *a, **k: [(fam, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+
+@pytest.fixture(autouse=True)
+def _public_dns(monkeypatch: pytest.MonkeyPatch):
+    """Named hosts resolve to a public IP by default so delivery tests never hit
+    the network. SSRF-resolution tests override this."""
+    monkeypatch.setattr(nf.socket, "getaddrinfo", _resolves_to("93.184.216.34"))
 
 
 @pytest.fixture
@@ -164,9 +178,9 @@ class TestDeliverOne:
         assert client.post.call_count == 0  # never even attempted
 
     def test_safe_url_helper(self):
+        # A public name (stubbed to a public IP) is allowed; literals to internal
+        # ranges are rejected without resolving.
         assert nf.is_safe_webhook_url("https://hooks.slack.com/x") is True
-        # Named internal hosts are allowed (not resolved); only IP literals blocked.
-        assert nf.is_safe_webhook_url("http://mattermost:8065/hooks/x") is True
         assert nf.is_safe_webhook_url("http://localhost/x") is False
         assert nf.is_safe_webhook_url("http://169.254.169.254/") is False
 
@@ -178,6 +192,42 @@ class TestDeliverOne:
             )
         assert ok is False
         assert "ConnectError" in detail
+
+
+class TestSsrfResolution:
+    def test_name_resolving_to_metadata_ip_blocked(self, monkeypatch: pytest.MonkeyPatch):
+        # The core bypass: a DNS name whose record points at the metadata IP.
+        monkeypatch.setattr(nf.socket, "getaddrinfo", _resolves_to("169.254.169.254"))
+        assert nf.is_safe_webhook_url("http://metadata.evil.test/latest") is False
+
+    def test_name_resolving_to_private_ip_blocked(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(nf.socket, "getaddrinfo", _resolves_to("10.0.0.5"))
+        assert nf.is_safe_webhook_url("http://internal.corp.test/") is False
+
+    def test_unresolvable_host_blocked(self, monkeypatch: pytest.MonkeyPatch):
+        def boom(*a, **k):
+            raise socket.gaierror("nxdomain")
+
+        monkeypatch.setattr(nf.socket, "getaddrinfo", boom)
+        assert nf.is_safe_webhook_url("http://does-not-exist.test/") is False
+
+    def test_allowlist_skips_resolution(self, monkeypatch: pytest.MonkeyPatch):
+        # A named internal host is only usable when explicitly trusted.
+        monkeypatch.setattr(nf.socket, "getaddrinfo", _resolves_to("10.1.2.3"))
+        assert nf.is_safe_webhook_url("http://mattermost:8065/hooks/x") is False
+        monkeypatch.setenv("MIRA_WEBHOOK_ALLOWED_HOSTS", "mattermost, teams.internal")
+        assert nf.is_safe_webhook_url("http://mattermost:8065/hooks/x") is True
+
+    async def test_delivery_blocked_for_rebinding_name(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(nf.socket, "getaddrinfo", _resolves_to("169.254.169.254"))
+        factory, client = _mock_httpx(status=200)
+        with patch("mira.outbound_webhooks.httpx.AsyncClient", factory):
+            ok, detail = await nf.deliver_one(
+                {"url": "http://metadata.evil.test/"}, nf.REVIEW_COMPLETED, {}
+            )
+        assert ok is False
+        assert "private or internal" in detail
+        assert client.post.call_count == 0
 
 
 class TestDispatch:


### PR DESCRIPTION
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

## Summary

- Fixes webhook SSRF guard

## Test plan
Locally & CI

## Notes for reviewers

<!-- Optional: anything subtle, anything still in flight, anything you punted -->
