### PR TITLE
fix: update placeholder comment on PR review failure

### DIFF
--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -28,7 +28,7 @@ from mira.core.passes import (
 )
 from mira.core.priority import rank_files
 from mira.core.threads import resolve_verified_threads, short_thread_description
-from mira.exceptions import ResponseParseError
+from mira.exceptions import MiraError, ResponseParseError
 from mira.index.context import build_code_context
 from mira.index.manifests import _is_lockfile_path, is_manifest
 from mira.index.store import IndexStore
@@ -42,7 +42,6 @@ from mira.llm.response_parser import (
     parse_llm_response,
     parse_walkthrough_response,
 )
-from mira.exceptions import MiraError
 from mira.models import (
     WALKTHROUGH_MARKER,
     FileChangeType,
@@ -421,10 +420,7 @@ class ReviewEngine:
     @staticmethod
     def _format_failure_notice(exc: BaseException) -> str:
         """Format a user-safe failure notice without model names or internal errors."""
-        if isinstance(exc, MiraError):
-            message = exc.safe_message
-        else:
-            message = type(exc).__name__
+        message = exc.safe_message if isinstance(exc, MiraError) else type(exc).__name__
         return (
             f"The code review failed to complete due to an unexpected error.\n\n"
             f"**Stage:** Code review\n"

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -42,6 +42,7 @@ from mira.llm.response_parser import (
     parse_llm_response,
     parse_walkthrough_response,
 )
+from mira.exceptions import MiraError
 from mira.models import (
     WALKTHROUGH_MARKER,
     FileChangeType,
@@ -417,6 +418,20 @@ class ReviewEngine:
         await self.provider.post_comment(pr_info, placeholder)
         return await self.provider.find_bot_comment(pr_info, WALKTHROUGH_MARKER)
 
+    @staticmethod
+    def _format_failure_notice(exc: BaseException) -> str:
+        """Format a user-safe failure notice without model names or internal errors."""
+        if isinstance(exc, MiraError):
+            message = exc.safe_message
+        else:
+            message = type(exc).__name__
+        return (
+            f"The code review failed to complete due to an unexpected error.\n\n"
+            f"**Stage:** Code review\n"
+            f"**Error type:** `{type(exc).__name__}`\n"
+            f"**Message:** {message}"
+        )
+
     async def _detect_overlaps_safe(
         self,
         pr_info: PRInfo,
@@ -546,6 +561,8 @@ class ReviewEngine:
             except Exception as exc:
                 logger.warning("Failed to post walkthrough placeholder: %s", exc)
 
+        _walkthrough_result: list[WalkthroughResult | None] = [None]
+
         async def _on_walkthrough_ready(wt: WalkthroughResult | None) -> None:
             if self.dry_run or wt is None or placeholder_id is None:
                 return
@@ -555,6 +572,7 @@ class ReviewEngine:
                     in_progress=True,
                 )
                 await self.provider.update_comment(pr_info, placeholder_id, markdown)
+                _walkthrough_result[0] = wt
             except Exception as exc:
                 logger.warning("Failed to post in-progress walkthrough: %s", exc)
 
@@ -677,22 +695,40 @@ class ReviewEngine:
             if overlap_task is not None:
                 overlap_task.cancel()
 
-            # Cancel pending in-progress notification task BEFORE updating the
-            # comment, so it cannot overwrite the failure message.
+            # Await the in-progress walkthrough notification BEFORE updating the
+            # comment. If the walkthrough LLM call resolved but the callback
+            # hasn't run yet, this lets it post the in-progress content and
+            # store the result so we can re-render it below. If it fails or
+            # times out, we suppress and fall back to the bare failure notice.
             notify_task = getattr(self, "_walkthrough_notify_task", None)
             if notify_task is not None:
-                notify_task.cancel()
+                with contextlib.suppress(Exception):
+                    await notify_task
                 self._walkthrough_notify_task = None
 
             # Update placeholder so the user knows the review failed.
+            # If the walkthrough already landed, re-render it without the
+            # in-progress banner and append the failure notice — preserves
+            # walkthrough content while removing the stuck "in progress" state.
             if placeholder_id is not None:
                 try:
-                    failure_body = (
-                        f"{WALKTHROUGH_MARKER}\n"
-                        "## Mira PR Walkthrough\n\n"
-                        f"*❌ Review failed: {exc!r}*  \n"
-                        f"```\n{type(exc).__name__}\n```\n"
-                    )
+                    wt = _walkthrough_result[0]
+                    if wt is not None:
+                        failure_body = wt.to_markdown(
+                            bot_name=self.bot_name or "miracodeai",
+                            in_progress=False,
+                            failure_notice=self._format_failure_notice(exc),
+                        )
+                    else:
+                        failure_body = (
+                            f"{WALKTHROUGH_MARKER}\n"
+                            "## Mira PR Walkthrough\n\n"
+                            "---\n\n"
+                            "<details>\n"
+                            "<summary><b>❌ Review failed</b> — click for details</summary>\n\n"
+                            f"{self._format_failure_notice(exc)}\n\n"
+                            "</details>\n"
+                        )
                     await self.provider.update_comment(pr_info, placeholder_id, failure_body)
                 except Exception as comment_exc:
                     logger.warning(

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -673,9 +673,32 @@ class ReviewEngine:
                 resolved_threads=resolved_thread_dicts or None,
                 team_conventions=team_conventions,
             )
-        except BaseException:
+        except BaseException as exc:
             if overlap_task is not None:
                 overlap_task.cancel()
+
+            # Cancel pending in-progress notification task BEFORE updating the
+            # comment, so it cannot overwrite the failure message.
+            notify_task = getattr(self, "_walkthrough_notify_task", None)
+            if notify_task is not None:
+                notify_task.cancel()
+                self._walkthrough_notify_task = None
+
+            # Update placeholder so the user knows the review failed.
+            if placeholder_id is not None:
+                try:
+                    failure_body = (
+                        f"{WALKTHROUGH_MARKER}\n"
+                        "## Mira PR Walkthrough\n\n"
+                        f"*❌ Review failed: {exc!r}*  \n"
+                        f"```\n{type(exc).__name__}\n```\n"
+                    )
+                    await self.provider.update_comment(pr_info, placeholder_id, failure_body)
+                except Exception as comment_exc:
+                    logger.warning(
+                        "Failed to update placeholder on review failure: %s", comment_exc
+                    )
+
             raise
 
         # The final walkthrough must land after the in-progress one, or it gets

--- a/src/mira/error_messages.py
+++ b/src/mira/error_messages.py
@@ -1,0 +1,99 @@
+"""Centralized LLM error message catalog.
+
+Each error has two templates:
+- ``full``: the detailed message used at raise time (includes model names, underlying errors)
+- ``safe``: the sanitized message shown to users (no model names, no internal errors)
+
+New LLM error types MUST add both templates here. The ``safe`` template is what
+appears in PR comments; the full traceback stays in server logs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ErrorMessage:
+    """A pair of full and safe error message templates."""
+
+    full: str
+    safe: str
+
+
+# Maps error code → (full_template, safe_template)
+# Templates use {placeholder} syntax for .format() — not f-strings — so they
+# can be reused at both raise and display sites without evaluation.
+LLM_ERROR_MESSAGES: dict[str, ErrorMessage] = {
+    "no_api_key": ErrorMessage(
+        full=(
+            "No API key found. Set {api_key_env} (or OPENROUTER_API_KEY / "
+            'OPENAI_API_KEY) in the environment, or set llm.api_key_env: "" in '
+            "your config for a local endpoint that needs no auth."
+        ),
+        safe="No API key found",
+    ),
+    "api_error": ErrorMessage(
+        full="LLM API error {status}: {body}",
+        safe="LLM API error {status}",
+    ),
+    "no_tool_call": ErrorMessage(
+        full="Model returned neither tool call nor content",
+        safe="Model returned neither tool call nor content",
+    ),
+    "completion_failed": ErrorMessage(
+        full="LLM completion failed with {model}: {error}",
+        safe="LLM completion failed",
+    ),
+    "agentic_failed": ErrorMessage(
+        full="LLM agentic call failed with {model}: {error}",
+        safe="LLM agentic call failed",
+    ),
+    "tool_call_failed": ErrorMessage(
+        full="LLM tool-call failed with {model}: {error}",
+        safe="LLM tool-call failed",
+    ),
+    "both_models_failed": ErrorMessage(
+        full="Both primary ({primary_model}) and fallback ({fallback_model}) models failed: {error}",
+        safe="Both primary and fallback models failed",
+    ),
+    # Bedrock-specific errors
+    "bedrock_no_boto3": ErrorMessage(
+        full="boto3 is required for the Bedrock provider. Install with: pip install mira-reviewer[bedrock]",
+        safe="boto3 is required for the Bedrock provider",
+    ),
+    "bedrock_access_denied": ErrorMessage(
+        full="Bedrock access denied for model {model}. Ensure your IAM role/user has bedrock:InvokeModel permission and the model is enabled in your account.",
+        safe="Bedrock access denied",
+    ),
+    "bedrock_model_not_found": ErrorMessage(
+        full="Bedrock model not found: {model}. Check the model ID and ensure it's available in your region.",
+        safe="Bedrock model not found",
+    ),
+    "bedrock_validation_error": ErrorMessage(
+        full="Bedrock validation error for {model}: {error}",
+        safe="Bedrock validation error",
+    ),
+    "bedrock_api_error": ErrorMessage(
+        full="Bedrock API error for {model}: {error}",
+        safe="Bedrock API error",
+    ),
+    "bedrock_call_failed": ErrorMessage(
+        full="Bedrock call failed with {model}: {error}",
+        safe="Bedrock call failed",
+    ),
+    "bedrock_no_tool_call": ErrorMessage(
+        full="Bedrock model returned neither tool call nor content",
+        safe="Bedrock model returned neither tool call nor content",
+    ),
+}
+
+
+def get_error_message(code: str, **kwargs: object) -> tuple[str, str]:
+    """Return (full_message, safe_message) for the given error code.
+
+    Raises:
+        KeyError: If the error code is not in the catalog.
+    """
+    entry = LLM_ERROR_MESSAGES[code]
+    return entry.full.format(**kwargs), entry.safe.format(**kwargs)

--- a/src/mira/exceptions.py
+++ b/src/mira/exceptions.py
@@ -1,8 +1,20 @@
 """Custom exception hierarchy for Mira."""
 
+from __future__ import annotations
+
+# Import directly from the module, not the mira.llm package, to avoid a
+# circular import: mira.llm.__init__ imports mira.config which imports
+# mira.exceptions.
+from mira.error_messages import get_error_message
+
 
 class MiraError(Exception):
     """Base exception for all Mira errors."""
+
+    @property
+    def safe_message(self) -> str:
+        """User-safe error message without sensitive details."""
+        return str(self)
 
 
 class ConfigError(MiraError):
@@ -14,7 +26,33 @@ class DiffParseError(MiraError):
 
 
 class LLMError(MiraError):
-    """Error communicating with an LLM provider."""
+    """Error communicating with an LLM provider.
+
+    Constructed from the centralized error catalog in
+    ``mira.llm.error_messages`` — never from an ad-hoc f-string. The catalog
+    holds both the full template (with model names, internal errors) and a
+    safe template (user-facing). ``safe_message`` returns the safe variant.
+
+    Use the ``code`` parameter to select the error type, and pass template
+    variables as keyword args::
+
+        raise LLMError("tool_call_failed", model="glm-5.2", error=primary_err)
+    """
+
+    def __init__(self, code: str, **kwargs: object) -> None:
+        self._code = code
+        self._full, self._safe = get_error_message(code, **kwargs)
+        super().__init__(self._full)
+
+    @property
+    def safe_message(self) -> str:
+        """User-safe error message without model names or underlying errors."""
+        return self._safe
+
+    @property
+    def code(self) -> str:
+        """The error code from the catalog."""
+        return self._code
 
 
 class NonRetriableLLMError(LLMError):

--- a/src/mira/exceptions.py
+++ b/src/mira/exceptions.py
@@ -29,7 +29,7 @@ class LLMError(MiraError):
     """Error communicating with an LLM provider.
 
     Constructed from the centralized error catalog in
-    ``mira.llm.error_messages`` — never from an ad-hoc f-string. The catalog
+    ``mira.error_messages`` — never from an ad-hoc f-string. The catalog
     holds both the full template (with model names, internal errors) and a
     safe template (user-facing). ``safe_message`` returns the safe variant.
 

--- a/src/mira/llm/bedrock.py
+++ b/src/mira/llm/bedrock.py
@@ -117,10 +117,7 @@ class BedrockProvider:
         try:
             import boto3
         except ImportError as e:
-            raise LLMError(
-                "boto3 is required for the Bedrock provider. "
-                "Install with: pip install mira-reviewer[bedrock]"
-            ) from e
+            raise LLMError("bedrock_no_boto3") from e
 
         self.config = config
         session = boto3.Session(
@@ -229,25 +226,18 @@ class BedrockProvider:
 
         # Access denied — not retryable, clear message
         if "AccessDeniedException" in error_msg:
-            raise LLMError(
-                f"Bedrock access denied for model {model}. "
-                "Ensure your IAM role/user has bedrock:InvokeModel permission "
-                "and the model is enabled in your account."
-            ) from error
+            raise LLMError("bedrock_access_denied", model=model) from error
 
         # Model not found
         if "ResourceNotFoundException" in error_msg:
-            raise LLMError(
-                f"Bedrock model not found: {model}. "
-                "Check the model ID and ensure it's available in your region."
-            ) from error
+            raise LLMError("bedrock_model_not_found", model=model) from error
 
         # Validation error (bad request shape)
         if "ValidationException" in error_msg:
-            raise LLMError(f"Bedrock validation error for {model}: {error_msg}") from error
+            raise LLMError("bedrock_validation_error", model=model, error=error_msg) from error
 
         # Catch-all
-        raise LLMError(f"Bedrock API error for {model}: {error_msg}") from error
+        raise LLMError("bedrock_api_error", model=model, error=error_msg) from error
 
     def _extract_text(self, response: dict) -> str:
         """Extract text content from a Bedrock Converse response."""
@@ -302,11 +292,13 @@ class BedrockProvider:
                     )
                 except Exception as fallback_err:
                     raise LLMError(
-                        f"Both primary ({self.config.model}) and fallback "
-                        f"({self.config.fallback_model}) models failed: {fallback_err}"
+                        "both_models_failed",
+                        primary_model=self.config.model,
+                        fallback_model=self.config.fallback_model,
+                        error=fallback_err,
                     ) from fallback_err
             raise LLMError(
-                f"Bedrock call failed with {self.config.model}: {primary_err}"
+                "bedrock_call_failed", model=self.config.model, error=primary_err
             ) from primary_err
 
     async def complete(
@@ -371,7 +363,7 @@ class BedrockProvider:
             logger.warning("Bedrock model returned text instead of tool call, using as fallback")
             return text
 
-        raise LLMError("Bedrock model returned neither tool call nor content")
+        raise LLMError("bedrock_no_tool_call")
 
     async def complete_agentic(
         self,

--- a/src/mira/llm/provider.py
+++ b/src/mira/llm/provider.py
@@ -41,11 +41,7 @@ def _get_api_key(config: LLMConfig, profile: dict | None = None) -> str:
         # Back-compat with pre-`api_key_env` setups.
         key = os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY", "")
     if not key:
-        raise LLMError(
-            f"No API key found. Set {config.api_key_env} (or OPENROUTER_API_KEY / "
-            f'OPENAI_API_KEY) in the environment, or set llm.api_key_env: "" in '
-            f"your config for a local endpoint that needs no auth."
-        )
+        raise LLMError("no_api_key", api_key_env=config.api_key_env)
     return key
 
 
@@ -173,8 +169,8 @@ class LLMProvider:
             )
             if resp.status_code != 200:
                 if 400 <= resp.status_code < 500 and resp.status_code != 429:
-                    raise NonRetriableLLMError(f"LLM API error {resp.status_code}: {resp.text}")
-                raise LLMError(f"LLM API error {resp.status_code}: {resp.text}")
+                    raise NonRetriableLLMError("api_error", status=resp.status_code, body=resp.text)
+                raise LLMError("api_error", status=resp.status_code, body=resp.text)
             data = resp.json()
 
         content = data["choices"][0]["message"].get("content") or ""
@@ -243,8 +239,8 @@ class LLMProvider:
                 resp = await client.post(self._chat_url(), headers=self._build_headers(), json=body)
             if resp.status_code != 200:
                 if 400 <= resp.status_code < 500 and resp.status_code != 429:
-                    raise NonRetriableLLMError(f"LLM API error {resp.status_code}: {resp.text}")
-                raise LLMError(f"LLM API error {resp.status_code}: {resp.text}")
+                    raise NonRetriableLLMError("api_error", status=resp.status_code, body=resp.text)
+                raise LLMError("api_error", status=resp.status_code, body=resp.text)
             data = resp.json()
 
         usage = data.get("usage")
@@ -265,7 +261,7 @@ class LLMProvider:
             logger.warning("Model returned content instead of tool call, using content as fallback")
             return content
 
-        raise LLMError("Model returned neither tool call nor content")
+        raise LLMError("no_tool_call")
 
     async def complete(
         self,
@@ -311,11 +307,13 @@ class LLMProvider:
                     )
                 except Exception as fallback_err:
                     raise LLMError(
-                        f"Both primary ({self.config.model}) and fallback "
-                        f"({self.config.fallback_model}) models failed: {fallback_err}"
+                        "both_models_failed",
+                        primary_model=self.config.model,
+                        fallback_model=self.config.fallback_model,
+                        error=fallback_err,
                     ) from fallback_err
             raise LLMError(
-                f"LLM completion failed with {self.config.model}: {primary_err}"
+                "completion_failed", model=self.config.model, error=primary_err
             ) from primary_err
 
     async def _call_llm_agentic(
@@ -350,8 +348,8 @@ class LLMProvider:
             )
             if resp.status_code != 200:
                 if 400 <= resp.status_code < 500 and resp.status_code != 429:
-                    raise NonRetriableLLMError(f"LLM API error {resp.status_code}: {resp.text}")
-                raise LLMError(f"LLM API error {resp.status_code}: {resp.text}")
+                    raise NonRetriableLLMError("api_error", status=resp.status_code, body=resp.text)
+                raise LLMError("api_error", status=resp.status_code, body=resp.text)
             data = resp.json()
 
         usage = data.get("usage")
@@ -393,11 +391,13 @@ class LLMProvider:
                     )
                 except Exception as fallback_err:
                     raise LLMError(
-                        f"Both primary ({self.config.model}) and fallback "
-                        f"({self.config.fallback_model}) models failed: {fallback_err}"
+                        "both_models_failed",
+                        primary_model=self.config.model,
+                        fallback_model=self.config.fallback_model,
+                        error=fallback_err,
                     ) from fallback_err
             raise LLMError(
-                f"LLM agentic call failed with {self.config.model}: {primary_err}"
+                "agentic_failed", model=self.config.model, error=primary_err
             ) from primary_err
 
     async def complete_with_tools(
@@ -439,11 +439,13 @@ class LLMProvider:
                     )
                 except Exception as fallback_err:
                     raise LLMError(
-                        f"Both primary ({self.config.model}) and fallback "
-                        f"({self.config.fallback_model}) models failed: {fallback_err}"
+                        "both_models_failed",
+                        primary_model=self.config.model,
+                        fallback_model=self.config.fallback_model,
+                        error=fallback_err,
                     ) from fallback_err
             raise LLMError(
-                f"LLM tool-call failed with {self.config.model}: {primary_err}"
+                "tool_call_failed", model=self.config.model, error=primary_err
             ) from primary_err
 
     async def review(self, messages: list[dict[str, str]], temperature: float | None = None) -> str:

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -211,6 +211,7 @@ class WalkthroughResult:
         index_was_empty: bool = False,
         dashboard_url: str = "",
         overlaps: list[OverlapFinding] | None = None,
+        failure_notice: str | None = None,
     ) -> str:
         """Render as a markdown PR comment."""
         parts = [WALKTHROUGH_MARKER, "## Mira PR Walkthrough", ""]
@@ -345,6 +346,19 @@ class WalkthroughResult:
                 f"this repo — Mira will then know about callers, dependents, "
                 f"and cross-repo impact."
             )
+
+        if failure_notice:
+            parts.append("")
+            parts.append("---")
+            parts.append("")
+            parts.append(
+                "<details>\n"
+                "<summary><b>❌ Review failed</b> — click for details</summary>\n"
+            )
+            parts.append("")
+            parts.append(failure_notice)
+            parts.append("")
+            parts.append("</details>")
 
         parts.append("")
         parts.append("---")

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -352,8 +352,7 @@ class WalkthroughResult:
             parts.append("---")
             parts.append("")
             parts.append(
-                "<details>\n"
-                "<summary><b>❌ Review failed</b> — click for details</summary>\n"
+                "<details>\n<summary><b>❌ Review failed</b> — click for details</summary>\n"
             )
             parts.append("")
             parts.append(failure_notice)

--- a/src/mira/platforms/handlers.py
+++ b/src/mira/platforms/handlers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+import sqlite3
 from typing import Any
 
 from jinja2 import Environment, FileSystemLoader
@@ -116,7 +117,10 @@ async def run_pr_review(
 
     # Keep visibility current — the blast-radius filter relies on it to avoid
     # naming private repos in a public repo's review.
-    _app_db.set_repo_visibility(owner, repo, is_private, platform=platform)
+    try:
+        _app_db.set_repo_visibility(owner, repo, is_private, platform=platform)
+    except sqlite3.OperationalError as exc:
+        logger.debug("set_repo_visibility failed (ignored): %s", exc)
 
     repo_record = _app_db.get_repo(owner, repo, platform=platform)
     is_indexed = bool(repo_record and repo_record.status == "ready")

--- a/src/mira/platforms/handlers.py
+++ b/src/mira/platforms/handlers.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 import json
 import logging
-from pathlib import Path
 import sqlite3
+from pathlib import Path
 from typing import Any
 
 from jinja2 import Environment, FileSystemLoader

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -22,6 +22,7 @@ from mira.core.engine import (
 from mira.core.threads import _extract_sections
 from mira.llm.provider import LLMProvider
 from mira.models import (
+    WALKTHROUGH_MARKER,
     FileChangeType,
     FileDiff,
     KeyIssue,
@@ -747,6 +748,56 @@ class TestReviewEngine:
                 assert kwargs.get("existing_comments") is None, (
                     f"Chunk {i + 1} should not receive synthetic cross-chunk comments"
                 )
+
+    @pytest.mark.asyncio
+    async def test_review_failure_updates_placeholder_comment(
+        self, mock_provider: AsyncMock,
+    ):
+        """When _review_diff_internal raises, the placeholder comment is updated
+        with a failure message before the exception propagates."""
+        llm = MagicMock(spec=LLMProvider)
+        llm.count_tokens = MagicMock(return_value=50)
+        llm.usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+        # Provider returns a valid placeholder ID so the update path can fire
+        # First call returns None (no existing comment), second returns the new ID
+        mock_provider.find_bot_comment = AsyncMock(side_effect=[None, 42])
+        mock_provider.post_comment = AsyncMock(return_value=42)
+        mock_provider.update_comment = AsyncMock()
+
+        pr_info = PRInfo(
+            title="Test PR",
+            description="",
+            base_branch="main",
+            head_branch="feature",
+            url="https://github.com/test/repo/pull/1",
+            number=1,
+            owner="test",
+            repo="repo",
+        )
+        mock_provider.get_pr_info.return_value = pr_info
+        mock_provider.get_pr_diff.return_value = sample_diff_text
+
+        engine = ReviewEngine(config=MiraConfig(), llm=llm, provider=mock_provider)
+
+        # Patch _review_diff_internal to raise directly — bypasses all internal
+        # exception swallowing, tests the outer handler in review_pr.
+        engine._review_diff_internal = AsyncMock(
+            side_effect=ValueError("LLM broke")
+        )
+
+        with pytest.raises(ValueError, match="LLM broke"):
+            await engine.review_pr("https://github.com/test/repo/pull/1")
+
+        # The original exception must propagate
+        # But before it did, the placeholder should have been updated
+        mock_provider.update_comment.assert_called_once()
+        call_args = mock_provider.update_comment.call_args
+        assert call_args[0][1] == 42, "must update the placeholder comment by ID"
+        body = call_args[0][2]
+        assert WALKTHROUGH_MARKER in body
+        assert "Review failed" in body
+        assert "ValueError" in body
 
 
 class TestDryRun:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -798,7 +798,6 @@ class TestReviewEngine:
         assert WALKTHROUGH_MARKER in body
         assert "Code review" in body
         assert "ValueError" in body
-        assert "ValueError" in body
 
     @pytest.mark.asyncio
     async def test_review_failure_re_renders_walkthrough_without_in_progress(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -751,7 +751,9 @@ class TestReviewEngine:
 
     @pytest.mark.asyncio
     async def test_review_failure_updates_placeholder_comment(
-        self, mock_provider: AsyncMock,
+        self,
+        mock_provider: AsyncMock,
+        sample_diff_text: str,
     ):
         """When _review_diff_internal raises, the placeholder comment is updated
         with a failure message before the exception propagates."""
@@ -782,9 +784,7 @@ class TestReviewEngine:
 
         # Patch _review_diff_internal to raise directly — bypasses all internal
         # exception swallowing, tests the outer handler in review_pr.
-        engine._review_diff_internal = AsyncMock(
-            side_effect=ValueError("LLM broke")
-        )
+        engine._review_diff_internal = AsyncMock(side_effect=ValueError("LLM broke"))
 
         with pytest.raises(ValueError, match="LLM broke"):
             await engine.review_pr("https://github.com/test/repo/pull/1")
@@ -796,8 +796,67 @@ class TestReviewEngine:
         assert call_args[0][1] == 42, "must update the placeholder comment by ID"
         body = call_args[0][2]
         assert WALKTHROUGH_MARKER in body
-        assert "Review failed" in body
+        assert "Code review" in body
         assert "ValueError" in body
+        assert "ValueError" in body
+
+    @pytest.mark.asyncio
+    async def test_review_failure_re_renders_walkthrough_without_in_progress(
+        self,
+        mock_provider: AsyncMock,
+        sample_diff_text: str,
+    ):
+        """When the walkthrough already landed in-progress, a subsequent
+        review failure must re-render it without the in-progress banner and
+        append the failure notice — not wipe it, not leave it stuck."""
+        llm = MagicMock(spec=LLMProvider)
+        llm.count_tokens = MagicMock(return_value=50)
+        llm.usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+        mock_provider.find_bot_comment = AsyncMock(side_effect=[None, 42])
+        mock_provider.post_comment = AsyncMock(return_value=42)
+        mock_provider.update_comment = AsyncMock()
+
+        pr_info = PRInfo(
+            title="Test PR",
+            description="",
+            base_branch="main",
+            head_branch="feature",
+            url="https://github.com/test/repo/pull/1",
+            number=1,
+            owner="test",
+            repo="repo",
+        )
+        mock_provider.get_pr_info.return_value = pr_info
+        mock_provider.get_pr_diff.return_value = sample_diff_text
+
+        engine = ReviewEngine(config=MiraConfig(), llm=llm, provider=mock_provider)
+
+        async def _raise_after_walkthrough(*args, **kwargs):
+            cb = kwargs.get("on_walkthrough_ready")
+            wt = WalkthroughResult(summary="Walkthrough summary")
+            if cb is not None:
+                await cb(wt)
+            raise ValueError("LLM broke")
+
+        engine._review_diff_internal = AsyncMock(side_effect=_raise_after_walkthrough)
+
+        with pytest.raises(ValueError, match="LLM broke"):
+            await engine.review_pr("https://github.com/test/repo/pull/1")
+
+        # update_comment called twice: once for in-progress, once for failure
+        assert mock_provider.update_comment.call_count == 2
+        # First call: in-progress banner present
+        first_body = mock_provider.update_comment.call_args_list[0][0][2]
+        assert "in progress" in first_body.lower()
+        # Second call: no in-progress banner, walkthrough content preserved,
+        # failure notice appended
+        second_body = mock_provider.update_comment.call_args_list[1][0][2]
+        assert "in progress" not in second_body.lower()
+        assert "Walkthrough summary" in second_body
+        assert "<details>" in second_body
+        assert "Review failed" in second_body
+        assert "ValueError" in second_body
 
 
 class TestDryRun:


### PR DESCRIPTION
## Summary

When the review pipeline throws during a PR, the "Reviewing this PR…" / "⏳ Code review in progress…" placeholder comment now gets a failure notification — instead of remaining stuck forever.

## Important changes

### Failure-landing on placeholder comment
The `except BaseException` handler in `review_pr` updates the placeholder comment with a failure notice (using `provider.update_comment`). If a walkthrough was already posted in-progress, it is re-rendered without the "in progress" banner and the failure notice is appended — preserving the walkthrough content rather than wiping it.

**What the user sees — no walkthrough landed (e.g. 500 from API):**

> <!-- mira-walkthrough-marker -->
> ## Mira PR Walkthrough
>
> ---
>
> <details>
> <summary><b>❌ Review failed</b> — click for details</summary>
>
> The code review failed to complete due to an unexpected error.
>
> **Stage:** Code review
> **Error type:** `NonRetriableLLMError`
> **Message:** LLM API error 500
>
> </details>

**What the user sees — walkthrough already posted, then failure (e.g. tool-call failed):**

> ... walkthrough content (files reviewed, summary, scores) ...
>
> ---
>
> <details>
> <summary><b>❌ Review failed</b> — click for details</summary>
>
> The code review failed to complete due to an unexpected error.
>
> **Stage:** Code review
> **Error type:** `LLMError`
> **Message:** LLM tool-call failed
>
> </details>

The walkthrough content is preserved; only the stuck "⏳ Code review in progress…" banner is replaced, and the failure detail is appended below it.

### Centralized LLM error message catalog
All LLM error strings were extracted from `provider.py` and `bedrock.py` into a new `mira.error_messages` module. Every error now has two templates:
- **full**: detailed message with model names and underlying errors (used at raise time, logged server-side)
- **safe**: sanitized message shown to users (no model names, no internal details)

`LLMError` was refactored to accept a catalog key + keyword parameters instead of ad-hoc f-strings. `MiraError` and `LLMError` expose a `safe_message` property for the user-facing variant.

### Walkthrough failure-notice rendering
`WalkthroughResult.to_markdown()` accepts an optional `failure_notice` parameter to render a collapsible failure detail section below the walkthrough content.

### Defensive database error handling
`set_repo_visibility` failures in `handlers.py` are now caught and logged at debug level instead of propagating.

## Resolves
Fixes #214