### PR TITLE
fix(index): use store total for files_indexed after incremental index

### DIFF
--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -530,12 +530,15 @@ async def _run_initial_indexing(default_mode: str) -> None:
                 llm=llm,
                 full=(repo_record.index_mode == "full"),
             )
+            # `count` is files re-indexed this run, not the store total.
+            # Read the true total before closing to keep the DB in sync.
+            total_files = len(store.all_paths())
             store.close()
             _app_db.set_repo_status(
                 owner,
                 repo,
                 "ready",
-                files_indexed=count,
+                files_indexed=total_files,
                 bump_last_indexed=True,
                 platform=platform,
             )

--- a/src/mira/dashboard/routers/admin.py
+++ b/src/mira/dashboard/routers/admin.py
@@ -61,13 +61,18 @@ async def _register_and_index_repo(platform: str, env_token: str, body: BaseMode
         store = None
         try:
             store = IndexStore.open(owner, repo, platform=platform)
-            count = await index_repo(
+            await index_repo(
                 owner=owner, repo=repo, store=store, fetcher=make_fetcher(platform, token)
             )
-            # `count` is files re-indexed this run, not the store total.
+            # index_repo returns files re-indexed this run, not the store total.
             total_files = len(store.all_paths())
             _api._app_db.set_repo_status(
-                owner, repo, "ready", files_indexed=total_files, bump_last_indexed=True, platform=platform
+                owner,
+                repo,
+                "ready",
+                files_indexed=total_files,
+                bump_last_indexed=True,
+                platform=platform,
             )
         except EmptyRepoError as empty:
             _api._app_db.set_repo_status(owner, repo, "empty", error=str(empty), platform=platform)

--- a/src/mira/dashboard/routers/admin.py
+++ b/src/mira/dashboard/routers/admin.py
@@ -64,8 +64,10 @@ async def _register_and_index_repo(platform: str, env_token: str, body: BaseMode
             count = await index_repo(
                 owner=owner, repo=repo, store=store, fetcher=make_fetcher(platform, token)
             )
+            # `count` is files re-indexed this run, not the store total.
+            total_files = len(store.all_paths())
             _api._app_db.set_repo_status(
-                owner, repo, "ready", files_indexed=count, bump_last_indexed=True, platform=platform
+                owner, repo, "ready", files_indexed=total_files, bump_last_indexed=True, platform=platform
             )
         except EmptyRepoError as empty:
             _api._app_db.set_repo_status(owner, repo, "empty", error=str(empty), platform=platform)

--- a/src/mira/dashboard/routers/repos.py
+++ b/src/mira/dashboard/routers/repos.py
@@ -531,11 +531,14 @@ async def trigger_index(owner: str, repo: str, request: Request, full: bool = Fa
             )
             # Real indexing run finished — bump last_indexed_at so the
             # dashboard's "Indexed N ago" reflects this completion.
+            # `count` is files re-indexed *this run* (not the store total), so
+            # read the store for the true total to keep the repos list in sync.
+            total_files = len(store.all_paths())
             _api._app_db.set_repo_status(
                 owner,
                 repo,
                 "ready",
-                files_indexed=count,
+                files_indexed=total_files,
                 bump_last_indexed=True,
                 platform=platform,
             )

--- a/src/mira/platforms/index_handlers.py
+++ b/src/mira/platforms/index_handlers.py
@@ -74,6 +74,11 @@ async def run_incremental_index(
             fetcher=fetcher,
         )
 
+    # ``count`` is the number of files re-indexed *this run*, not the total
+    # in the store. For incremental runs that's a small subset (e.g. 3 of 120),
+    # so reading the store's actual path count keeps the repos-list file count
+    # in sync with the detail page.
+    total_files = len(store.all_paths())
     store.close()
 
     if count > 0:
@@ -82,7 +87,7 @@ async def run_incremental_index(
                 owner,
                 repo,
                 "ready",
-                files_indexed=count,
+                files_indexed=total_files,
                 bump_last_indexed=True,
                 platform=platform,
             )


### PR DESCRIPTION
## What Changed

`run_incremental_index` was setting `files_indexed=count`, where `count` is the number of files re-indexed during that run (e.g. 3). It should be the total number of files in the store (e.g. 120) so the repos list file count stays in sync with the detail page.

## How It's Fixed

Reads `len(store.all_paths())` before closing the store and passes that total to `files_indexed` instead of the incremental count.

## Impact

- **Files changed**: 1 (`src/mira/platforms/index_handlers.py`)
- **Lines changed**: +6 / −1

## Resolves

No open issue tracked.
