### PR TITLE
fix(index): pass platform to IndexStore.open in review and dashboard paths

### DIFF
--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -1181,7 +1181,9 @@ class ReviewEngine:
         try:
             pr_info = getattr(self, "_pr_info", None)
             if pr_info is not None:
-                _rules_store = IndexStore.open(pr_info.owner, pr_info.repo, platform=pr_info.platform)
+                _rules_store = IndexStore.open(
+                    pr_info.owner, pr_info.repo, platform=pr_info.platform
+                )
 
                 learned_rules = _rules_store.get_learned_rules_text()
 
@@ -1351,7 +1353,9 @@ class ReviewEngine:
             pr_info = getattr(self, "_pr_info", None)
             if pr_info is not None:
                 try:
-                    _pkg_store = IndexStore.open(pr_info.owner, pr_info.repo, platform=pr_info.platform)
+                    _pkg_store = IndexStore.open(
+                        pr_info.owner, pr_info.repo, platform=pr_info.platform
+                    )
                     try:
                         existing_packages = sorted(
                             {p.name for p in _pkg_store.list_manifest_packages()}

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -442,7 +442,7 @@ class ReviewEngine:
             if not current_paths:
                 return []
 
-            store = IndexStore.open(pr_info.owner, pr_info.repo)
+            store = IndexStore.open(pr_info.owner, pr_info.repo, platform=pr_info.platform)
             try:
                 symbols: set[str] = set()
                 for path in current_paths:
@@ -832,7 +832,7 @@ class ReviewEngine:
 
             from mira.models import Severity
 
-            store = IndexStore.open(pr_info.owner, pr_info.repo)
+            store = IndexStore.open(pr_info.owner, pr_info.repo, platform=pr_info.platform)
             blocker_count = sum(1 for c in result.comments if c.severity == Severity.BLOCKER)
             warning_count = sum(1 for c in result.comments if c.severity == Severity.WARNING)
             suggestion_count = sum(
@@ -1041,7 +1041,7 @@ class ReviewEngine:
             try:
                 pr_info = getattr(self, "_pr_info", None)
                 if pr_info is not None:
-                    store = IndexStore.open(pr_info.owner, pr_info.repo)
+                    store = IndexStore.open(pr_info.owner, pr_info.repo, platform=pr_info.platform)
                     source_fetcher = None
                     if self.provider and pr_info:
                         from mira.index.context import ProviderSourceFetcher
@@ -1181,7 +1181,7 @@ class ReviewEngine:
         try:
             pr_info = getattr(self, "_pr_info", None)
             if pr_info is not None:
-                _rules_store = IndexStore.open(pr_info.owner, pr_info.repo)
+                _rules_store = IndexStore.open(pr_info.owner, pr_info.repo, platform=pr_info.platform)
 
                 learned_rules = _rules_store.get_learned_rules_text()
 
@@ -1351,7 +1351,7 @@ class ReviewEngine:
             pr_info = getattr(self, "_pr_info", None)
             if pr_info is not None:
                 try:
-                    _pkg_store = IndexStore.open(pr_info.owner, pr_info.repo)
+                    _pkg_store = IndexStore.open(pr_info.owner, pr_info.repo, platform=pr_info.platform)
                     try:
                         existing_packages = sorted(
                             {p.name for p in _pkg_store.list_manifest_packages()}

--- a/src/mira/dashboard/routers/core.py
+++ b/src/mira/dashboard/routers/core.py
@@ -205,7 +205,7 @@ def get_org_stats(period: str = "") -> OrgStatsModel:
 
     for repo_record in repos:
         try:
-            store = IndexStore.open(repo_record.owner, repo_record.repo)
+            store = IndexStore.open(repo_record.owner, repo_record.repo, platform=repo_record.platform)
             total_files += len(store.all_paths())
             stats = store.get_review_stats(since=since)
             agg_stats["total_reviews"] += stats["total_reviews"]
@@ -258,7 +258,7 @@ def get_timeseries(period: str = "day") -> list[TimeSeriesPoint]:
 
     for repo_record in _api._app_db.list_repos():
         try:
-            store = IndexStore.open(repo_record.owner, repo_record.repo)
+            store = IndexStore.open(repo_record.owner, repo_record.repo, platform=repo_record.platform)
             for e in store.list_review_events(limit=500):
                 all_events.append(
                     {

--- a/src/mira/dashboard/routers/core.py
+++ b/src/mira/dashboard/routers/core.py
@@ -205,7 +205,9 @@ def get_org_stats(period: str = "") -> OrgStatsModel:
 
     for repo_record in repos:
         try:
-            store = IndexStore.open(repo_record.owner, repo_record.repo, platform=repo_record.platform)
+            store = IndexStore.open(
+                repo_record.owner, repo_record.repo, platform=repo_record.platform
+            )
             total_files += len(store.all_paths())
             stats = store.get_review_stats(since=since)
             agg_stats["total_reviews"] += stats["total_reviews"]
@@ -258,7 +260,9 @@ def get_timeseries(period: str = "day") -> list[TimeSeriesPoint]:
 
     for repo_record in _api._app_db.list_repos():
         try:
-            store = IndexStore.open(repo_record.owner, repo_record.repo, platform=repo_record.platform)
+            store = IndexStore.open(
+                repo_record.owner, repo_record.repo, platform=repo_record.platform
+            )
             for e in store.list_review_events(limit=500):
                 all_events.append(
                     {

--- a/src/mira/index/relationships.py
+++ b/src/mira/index/relationships.py
@@ -228,7 +228,8 @@ class RelationshipStore:
                         full_name = f"{repo_record.owner}/{repo_record.repo}"
                         try:
                             self._stores[full_name] = IndexStore.open(
-                                repo_record.owner, repo_record.repo
+                                repo_record.owner, repo_record.repo,
+                                platform=repo_record.platform
                             )
                         except Exception as exc:
                             logger.warning("Failed to open index for %s: %s", full_name, exc)

--- a/src/mira/index/relationships.py
+++ b/src/mira/index/relationships.py
@@ -228,8 +228,7 @@ class RelationshipStore:
                         full_name = f"{repo_record.owner}/{repo_record.repo}"
                         try:
                             self._stores[full_name] = IndexStore.open(
-                                repo_record.owner, repo_record.repo,
-                                platform=repo_record.platform
+                                repo_record.owner, repo_record.repo, platform=repo_record.platform
                             )
                         except Exception as exc:
                             logger.warning("Failed to open index for %s: %s", full_name, exc)


### PR DESCRIPTION
## Summary

`IndexStore.open()` calls in the review engine, dashboard stats, and relationship resolver were missing the `platform` argument. The method defaults to `platform='github'`, so for non-GitHub repos (Forgejo, GitLab) the reader was hitting the wrong namespace — e.g. reading from `_github/owner` instead of `_forgejo/owner`.

## Problem

The indexer writes to a platform-namespaced key (e.g. `_forgejo/owner`), but downstream consumers opened the store without specifying `platform`, so they read from the default `github` namespace — an empty store. This caused:

- "repo not indexed" on Forgejo/GitLab PRs despite successful indexing
- Missing cross-file context in code reviews
- Empty dashboard stats for non-GitHub orgs

## Changes

Added `platform=` to every `IndexStore.open()` call that was missing it:

| File | Callsites |
|------|-----------|
| `src/mira/core/engine.py` | 5 (`ReviewEngine`) |
| `src/mira/dashboard/routers/core.py` | 2 (`get_org_stats`, `get_timeseries`) |
| `src/mira/index/relationships.py` | 1 (`RelationshipStore`) |

## Testing

- Diff verified: all 8 affected callsites now pass `platform=pr_info.platform` or `platform=repo_record.platform`
- No new dependencies or behavioral changes for GitHub repos (the default)
