### PR TITLE
fix(walkthrough): salvage leaked xml fragments in effort fields

### DIFF
--- a/src/mira/llm/response_parser.py
+++ b/src/mira/llm/response_parser.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from mira.core.context import extract_hunk_lines
 from mira.exceptions import ResponseParseError
@@ -317,8 +317,6 @@ def _try_load_json(text: str) -> object | None:
         return None
 
 
-_WALKTHROUGH_OBJECT_FIELDS = ("effort", "confidence_score")
-
 _ARG_KEY_VALUE_RE = re.compile(
     r"<arg_key>\s*([^<]+?)\s*</arg_key>\s*<arg_value>\s*(.*?)\s*</arg_value>",
     re.S,
@@ -424,14 +422,24 @@ def parse_walkthrough_response(raw_text: str) -> LLMWalkthroughResponse:
     # instead of objects (``"effort": "level</arg_key><arg_value>2"``). Rebuild
     # what we can; drop the field otherwise — both are optional with defaults,
     # so one bad field shouldn't skip the whole walkthrough (issue #162).
-    for key in _WALKTHROUGH_OBJECT_FIELDS:
+    _WALKTHROUGH_FIELD_MODELS = {
+        "effort": LLMWalkthroughEffort,
+        "confidence_score": LLMWalkthroughConfidenceScore,
+    }
+    for key, model in _WALKTHROUGH_FIELD_MODELS.items():
         value = data.get(key)
         if isinstance(value, dict):
             continue
         rebuilt = _salvage_arg_xml_fragment(value) if isinstance(value, str) else None
         if rebuilt is not None:
+            try:
+                model.model_validate(rebuilt)
+            except ValidationError as exc:
+                logger.warning("Dropping malformed walkthrough %s field: %s", key, exc)
+                data.pop(key, None)
+                continue
             data[key] = rebuilt
-        elif key in data:
+        elif value is not None:
             logger.warning("Dropping malformed walkthrough %s field: %r", key, value)
             data.pop(key)
 

--- a/src/mira/llm/response_parser.py
+++ b/src/mira/llm/response_parser.py
@@ -317,6 +317,58 @@ def _try_load_json(text: str) -> object | None:
         return None
 
 
+_WALKTHROUGH_OBJECT_FIELDS = ("effort", "confidence_score")
+
+_ARG_KEY_VALUE_RE = re.compile(
+    r"<arg_key>\s*([^<]+?)\s*</arg_key>\s*<arg_value>\s*(.*?)\s*</arg_value>",
+    re.S,
+)
+
+
+def _coerce_xml_value(raw: str) -> object:
+    """Coerce an XML-argument value string to a JSON-ish scalar."""
+    if raw == "null":
+        return None
+    if raw in ("true", "false"):
+        return raw == "true"
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    return raw
+
+
+def _salvage_arg_xml_fragment(text: str) -> dict | None:
+    """Rebuild a dict from leaked Anthropic-style tool-arg XML.
+
+    Some models emit nested-object fields as an ``<arg_key>k</arg_key>
+    <arg_value>v</arg_value>`` fragment *inside* a quoted JSON string
+    (observed on ``effort``/``confidence_score`` via OpenRouter), e.g.
+    ``"effort": "level</arg_key><arg_value>2"``. The transport may drop the
+    opening ``<arg_key>`` / trailing ``</arg_value>`` tags, so normalize before
+    matching. Returns ``None`` when the string isn't a key/value fragment.
+    """
+    fragment = text.strip()
+    if not fragment.startswith("<arg_key>"):
+        fragment = "<arg_key>" + fragment
+    if not fragment.endswith("</arg_value>"):
+        fragment = fragment + "</arg_value>"
+    pairs = _ARG_KEY_VALUE_RE.findall(fragment)
+    if not pairs:
+        return None
+    result: dict = {}
+    for key, raw in pairs:
+        key = key.strip()
+        if key in result:
+            return None
+        result[key] = _coerce_xml_value(raw.strip())
+    return result
+
+
 def _validate_change_groups(raw_groups: list) -> list[LLMWalkthroughChangeGroup]:
     """Validate change groups one at a time, skipping malformed entries.
 
@@ -356,21 +408,39 @@ def parse_walkthrough_response(raw_text: str) -> LLMWalkthroughResponse:
     cleaned = strip_think_blocks(raw_text)
     cleaned = strip_code_fences(cleaned)
 
-    try:
-        data = json.loads(cleaned)
-    except json.JSONDecodeError as e:
-        raise ResponseParseError(f"Walkthrough response is not valid JSON: {e}") from e
-
+    # Some models leak Anthropic-style tool-call XML around/inside the JSON
+    # arguments (e.g. a trailing ``</parameter></invoke>``). Use the lenient
+    # loader the review path uses so an external leak truncates cleanly instead
+    # of killing the walkthrough.
+    data = loads_lenient(cleaned)
+    if data is None:
+        raise ResponseParseError("Walkthrough response is not valid JSON")
     if not isinstance(data, dict):
         raise ResponseParseError(f"Expected JSON object, got {type(data).__name__}")
 
     data = _unstring_nested_json(data)
+
+    # Nested object fields occasionally arrive as leaked tool-arg XML fragments
+    # instead of objects (``"effort": "level</arg_key><arg_value>2"``). Rebuild
+    # what we can; drop the field otherwise — both are optional with defaults,
+    # so one bad field shouldn't skip the whole walkthrough (issue #162).
+    for key in _WALKTHROUGH_OBJECT_FIELDS:
+        value = data.get(key)
+        if isinstance(value, dict):
+            continue
+        rebuilt = _salvage_arg_xml_fragment(value) if isinstance(value, str) else None
+        if rebuilt is not None:
+            data[key] = rebuilt
+        elif key in data:
+            logger.warning("Dropping malformed walkthrough %s field: %r", key, value)
+            data.pop(key)
 
     raw_groups = data.pop("change_groups", None)
 
     try:
         response = LLMWalkthroughResponse.model_validate(data)
     except Exception as e:
+        logger.debug("Raw walkthrough response: %s", raw_text)
         raise ResponseParseError(f"Walkthrough response validation failed: {e}") from e
 
     if isinstance(raw_groups, list):

--- a/src/mira/llm/response_parser.py
+++ b/src/mira/llm/response_parser.py
@@ -322,6 +322,15 @@ _ARG_KEY_VALUE_RE = re.compile(
     re.S,
 )
 
+# Nested object fields occasionally arrive as leaked tool-arg XML fragments
+# instead of objects (``"effort": "level</arg_key><arg_value>2"``). Rebuild
+# what we can; drop the field otherwise — both are optional with defaults,
+# so one bad field shouldn't skip the whole walkthrough (issue #162).
+_WALKTHROUGH_FIELD_MODELS = {
+    "effort": LLMWalkthroughEffort,
+    "confidence_score": LLMWalkthroughConfidenceScore,
+}
+
 
 def _coerce_xml_value(raw: str) -> object:
     """Coerce an XML-argument value string to a JSON-ish scalar."""
@@ -418,22 +427,31 @@ def parse_walkthrough_response(raw_text: str) -> LLMWalkthroughResponse:
 
     data = _unstring_nested_json(data)
 
-    # Nested object fields occasionally arrive as leaked tool-arg XML fragments
-    # instead of objects (``"effort": "level</arg_key><arg_value>2"``). Rebuild
-    # what we can; drop the field otherwise — both are optional with defaults,
-    # so one bad field shouldn't skip the whole walkthrough (issue #162).
-    _WALKTHROUGH_FIELD_MODELS = {
-        "effort": LLMWalkthroughEffort,
-        "confidence_score": LLMWalkthroughConfidenceScore,
-    }
+    # Rebuild any fields that arrived as leaked XML fragments (issue #162)
     for key, model in _WALKTHROUGH_FIELD_MODELS.items():
         value = data.get(key)
         if isinstance(value, dict):
+            try:
+                if hasattr(model, "model_validate"):
+                    model.model_validate(value)
+                elif hasattr(model, "parse_obj"):
+                    model.parse_obj(value)
+                else:
+                    model(**value)
+            except ValidationError as exc:
+                logger.warning("Dropping malformed walkthrough %s field: %s", key, exc)
+                data.pop(key, None)
             continue
+
         rebuilt = _salvage_arg_xml_fragment(value) if isinstance(value, str) else None
         if rebuilt is not None:
             try:
-                model.model_validate(rebuilt)
+                if hasattr(model, "model_validate"):
+                    model.model_validate(rebuilt)
+                elif hasattr(model, "parse_obj"):
+                    model.parse_obj(rebuilt)
+                else:
+                    model(**rebuilt)
             except ValidationError as exc:
                 logger.warning("Dropping malformed walkthrough %s field: %s", key, exc)
                 data.pop(key, None)

--- a/tests/test_walkthrough.py
+++ b/tests/test_walkthrough.py
@@ -275,6 +275,32 @@ class TestParseWalkthroughResponse:
         assert len(result.change_groups) == 1
         assert result.change_groups[0].label == "Core"
 
+    def test_salvage_failure_defaults_effort(self):
+        """Leaked XML fragment that fails sub-model validation → effort drops to None (P3)."""
+        raw = json.dumps(
+            {
+                "summary": "Changes",
+                "change_groups": [],
+                "effort": ("level</arg_key><arg_value>high"),
+            }
+        )
+        result = parse_walkthrough_response(raw)
+        assert result.summary == "Changes"
+        assert result.effort is None
+
+    def test_salvage_failure_defaults_confidence_score(self):
+        """Leaked XML fragment that fails sub-model validation → confidence_score drops to None (P3)."""
+        raw = json.dumps(
+            {
+                "summary": "Changes",
+                "change_groups": [],
+                "confidence_score": ("score</arg_key><arg_value>uncertain"),
+            }
+        )
+        result = parse_walkthrough_response(raw)
+        assert result.summary == "Changes"
+        assert result.confidence_score is None
+
 
 class TestConvertToWalkthroughResult:
     def test_basic_conversion(self, sample_walkthrough_response_text: str):

--- a/tests/test_walkthrough.py
+++ b/tests/test_walkthrough.py
@@ -301,6 +301,19 @@ class TestParseWalkthroughResponse:
         assert result.summary == "Changes"
         assert result.confidence_score is None
 
+    def test_malformed_dict_field_dropped(self):
+        """Dict-form effort with invalid value fails LLMWalkthroughEffort validation → dropped to None."""
+        raw = json.dumps(
+            {
+                "summary": "Changes",
+                "change_groups": [],
+                "effort": {"level": 3, "label": "Moderate", "minutes": "not_an_int"},
+            }
+        )
+        result = parse_walkthrough_response(raw)
+        assert result.summary == "Changes"
+        assert result.effort is None
+
 
 class TestConvertToWalkthroughResult:
     def test_basic_conversion(self, sample_walkthrough_response_text: str):

--- a/tests/test_walkthrough.py
+++ b/tests/test_walkthrough.py
@@ -176,6 +176,58 @@ class TestParseWalkthroughResponse:
         result = parse_walkthrough_response(raw)
         assert result.effort is None
 
+    def test_leaked_arg_xml_in_object_fields(self):
+        raw = json.dumps(
+            {
+                "summary": "Changes",
+                "change_groups": [],
+                "effort": "level</arg_key><arg_value>2",
+                "confidence_score": "score</arg_key><arg_value>4",
+            }
+        )
+        result = parse_walkthrough_response(raw)
+        assert result.summary == "Changes"
+        assert result.effort is not None
+        assert result.effort.level == 2
+        assert result.confidence_score is not None
+        assert result.confidence_score.score == 4
+
+    def test_full_arg_xml_fragment_rebuilt(self):
+        raw = json.dumps(
+            {
+                "summary": "Changes",
+                "change_groups": [],
+                "effort": (
+                    "<arg_key>level</arg_key><arg_value>2</arg_value>"
+                    "<arg_key>label</arg_key><arg_value>Trivial</arg_value>"
+                ),
+            }
+        )
+        result = parse_walkthrough_response(raw)
+        assert result.effort is not None
+        assert result.effort.level == 2
+        assert result.effort.label == "Trivial"
+
+    def test_malformed_object_field_dropped(self):
+        raw = json.dumps(
+            {
+                "summary": "Changes",
+                "change_groups": [],
+                "effort": "some random garbage",
+                "confidence_score": {"score": 1, "label": "x", "reason": "y"},
+            }
+        )
+        result = parse_walkthrough_response(raw)
+        assert result.summary == "Changes"
+        assert result.effort is None
+        assert result.confidence_score is not None
+        assert result.confidence_score.score == 1
+
+    def test_trailing_tool_xml_truncated(self):
+        raw = '{"summary": "Changes", "change_groups": []}</parameter></invoke>'
+        result = parse_walkthrough_response(raw)
+        assert result.summary == "Changes"
+
     def test_skips_file_missing_path(self):
         raw = json.dumps(
             {


### PR DESCRIPTION
## Summary
Salvage walkthrough responses that contain leaked Anthropic-style tool-call XML inside JSON fields

## Motivation
Walkthrough responses from some models occasionally arrive with raw `<arg_key>`/`<arg_value>` XML fragments embedded in string fields like `effort` and `confidence_score` instead of proper objects. The strict JSON parse survived, but Pydantic validation failed, causing the entire walkthrough to be silently skipped. A single malformed sub-field would drop the whole walkthrough, including all valid inline review comments and the confidence score.

## Changes
- Switched walkthrough parsing to use the lenient JSON loader already used by the review path, which tolerates XML noise around/inside JSON strings
- Added a new `_salvage_object_field()` helper that rebuilds nested object fields from `<arg_key>`/`<arg_value>` fragment pairs by matching keys to a canonical field-to-model dictionary
- When a salvaged sub-field fails its own Pydantic validation, it now drops to the default value instead of raising — preserving the rest of the walkthrough
- Imported `ValidationError` from Pydantic to catch and Suppress these sub-field failures cleanly
- Added test coverage for both happy-path salvage and the validation-drop path

## Notes
- The lenient loader was already proven in the review pipeline; this PR simply reuses it for walkthroughs instead of maintaining two incompatible parse strategies
- `effort` and `confidence_score` are the only fields currently known to leak as XML fragments; the field-to-model dictionary is extensible if new ones appear
- Null values for these optional fields pass through silently without a warning
