### PR TITLE
feat: add OpenAI Responses API support

### DIFF
--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -52,6 +52,11 @@ class LLMConfig(BaseModel):
     # Provider selection. "openai" uses any OpenAI-compatible endpoint (default).
     # "bedrock" uses AWS Bedrock Converse API directly (requires boto3).
     provider: str = "openai"
+    # Protocol dialect for the OpenAI-compatible endpoint: "chat"
+    # (Chat Completions, default) or "responses" (OpenAI Responses API).
+    # Only meaningful when `provider` is "openai" — bedrock ignores it
+    # (create_llm checks provider first).
+    api_style: str = "chat"
     # Endpoint configuration. Defaults to OpenRouter but any OpenAI-compatible
     # chat-completions endpoint works — vLLM, Ollama, LiteLLM proxy, LocalAI,
     # llama.cpp server, Together, Fireworks, Groq, etc. Set api_key_env to ""

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -368,12 +368,17 @@ class ModelsResponse(BaseModel):
     # Extended-thinking effort for reviews ("off"/"low"/"medium"/"high").
     review_thinking_mode: str
     thinking_options: list[ModelOption]
+    # Protocol dialect for the OpenAI-compatible endpoint ("chat"/"responses"),
+    # resolved DB → config → default. Mirrors review_thinking_mode.
+    api_style: str
+    api_style_options: list[ModelOption]
 
 
 class ModelsUpdate(BaseModel):
     indexing_model: str
     review_model: str
     review_thinking_mode: str = "off"
+    api_style: str = "chat"
 
 
 class GlobalSettingsResponse(BaseModel):

--- a/src/mira/dashboard/model_catalog.py
+++ b/src/mira/dashboard/model_catalog.py
@@ -19,7 +19,7 @@ import httpx
 from mira.config import LLMConfig
 from mira.llm import provider_profiles as profiles
 from mira.llm import registry
-from mira.llm.provider import _get_api_key
+from mira.llm.base import _get_api_key
 
 logger = logging.getLogger(__name__)
 

--- a/src/mira/dashboard/models_config.py
+++ b/src/mira/dashboard/models_config.py
@@ -32,6 +32,21 @@ THINKING_MODES: list[dict[str, str]] = [
 ]
 THINKING_MODE_VALUES = {m["value"] for m in THINKING_MODES}
 
+# API-protocol options for the Models page. Single source for the dropdown
+# and validation, mirroring THINKING_MODES.
+API_STYLES: list[dict[str, str]] = [
+    {"value": "chat", "label": "Chat Completions"},
+    {"value": "responses", "label": "Responses API"},
+]
+API_STYLE_VALUES = {m["value"] for m in API_STYLES}
+
+
+def resolve_api_style(config: LLMConfig, db_value: str | None = None) -> str:
+    """Resolve the API protocol: DB → config.api_style → "chat"."""
+    if db_value and db_value in API_STYLE_VALUES:
+        return db_value
+    return config.api_style if config.api_style in API_STYLE_VALUES else "chat"
+
 
 def estimate_indexing_cost(file_count: int, model: str) -> dict:
     """Estimate cost of indexing N files with the given model.
@@ -108,6 +123,7 @@ def llm_config_for(purpose: str, base: LLMConfig) -> LLMConfig:
     """
     db_model: str | None = None
     db_thinking: str | None = None
+    db_style: str | None = None
     try:
         from mira.dashboard.api import _app_db
 
@@ -117,11 +133,13 @@ def llm_config_for(purpose: str, base: LLMConfig) -> LLMConfig:
             elif purpose == "review":
                 db_model = _app_db.get_setting("review_model")
                 db_thinking = _app_db.get_setting("review_thinking_mode")
+            db_style = _app_db.get_setting("api_style")
     except Exception:
         pass  # DB not available — resolve from config fields alone
 
     # Thinking mode only applies to reviews; other purposes leave it off.
     thinking_mode: str | None = None
+    resolved_style = resolve_api_style(base, db_style)
     if purpose == "indexing":
         resolved = get_indexing_model(base, db_model)
         config_model = base.indexing_model
@@ -130,8 +148,10 @@ def llm_config_for(purpose: str, base: LLMConfig) -> LLMConfig:
         config_model = base.review_model
         thinking_mode = get_review_thinking_mode(base, db_thinking)
     else:
-        return base.model_copy(update={"reasoning_effort": None})
+        return base.model_copy(update={"reasoning_effort": None, "api_style": resolved_style})
 
     source = "dashboard setting" if db_model else ("mira.yaml" if config_model else "default")
     logger.info("%s model: %s (source: %s)", purpose.capitalize(), resolved, source)
-    return base.model_copy(update={"model": resolved, "reasoning_effort": thinking_mode})
+    return base.model_copy(
+        update={"model": resolved, "reasoning_effort": thinking_mode, "api_style": resolved_style}
+    )

--- a/src/mira/dashboard/routers/admin.py
+++ b/src/mira/dashboard/routers/admin.py
@@ -154,10 +154,12 @@ async def get_models() -> ModelsResponse:
     from mira.config import load_config
     from mira.dashboard.model_catalog import active_backend, build_options, fetch_catalog
     from mira.dashboard.models_config import (
+        API_STYLES,
         THINKING_MODES,
         get_indexing_model,
         get_review_model,
         get_review_thinking_mode,
+        resolve_api_style,
     )
 
     config = load_config()
@@ -168,6 +170,7 @@ async def get_models() -> ModelsResponse:
     thinking = get_review_thinking_mode(
         config.llm, _api._app_db.get_setting("review_thinking_mode")
     )
+    api_style = resolve_api_style(config.llm, _api._app_db.get_setting("api_style"))
 
     backend = active_backend(config.llm)
     catalog = await fetch_catalog(config.llm)
@@ -184,6 +187,8 @@ async def get_models() -> ModelsResponse:
         review_options=[ModelOption(**m) for m in build_options(backend, catalog, "review")],
         review_thinking_mode=thinking or "off",
         thinking_options=[ModelOption(**m) for m in THINKING_MODES],
+        api_style=api_style,
+        api_style_options=[ModelOption(**m) for m in API_STYLES],
     )
 
 
@@ -250,12 +255,17 @@ def set_global_settings(body: GlobalSettingsUpdate, request: Request) -> dict:
 @router.put("/api/settings/models")
 def set_models(body: ModelsUpdate, request: Request) -> dict:
     _require_admin(request)
-    from mira.dashboard.models_config import THINKING_MODE_VALUES
+    from mira.dashboard.models_config import API_STYLE_VALUES, THINKING_MODE_VALUES
 
     if body.review_thinking_mode not in THINKING_MODE_VALUES:
         raise HTTPException(
             status_code=400,
             detail=f"{body.review_thinking_mode!r} is not a valid thinking mode.",
+        )
+    if body.api_style not in API_STYLE_VALUES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{body.api_style!r} is not a valid API style.",
         )
     # "" clears the override so mira.yaml is authoritative again. Any other id
     # is stored as-is — the dashboard accepts the same free-form model ids as
@@ -271,6 +281,13 @@ def set_models(body: ModelsUpdate, request: Request) -> dict:
         _api._app_db.set_setting("review_thinking_mode", body.review_thinking_mode)
     else:
         _api._app_db.set_setting("review_thinking_mode", "")
+
+    # Clear "chat" (default) to "" so a stored value never shadows mira.yaml config overrides.
+    if body.api_style and body.api_style != "chat":
+        _api._app_db.set_setting("api_style", body.api_style)
+    else:
+        _api._app_db.set_setting("api_style", "")
+
     _api._app_db.mark_setup_complete()
     return {"ok": True}
 

--- a/src/mira/error_messages.py
+++ b/src/mira/error_messages.py
@@ -41,6 +41,10 @@ LLM_ERROR_MESSAGES: dict[str, ErrorMessage] = {
         full="Model returned neither tool call nor content",
         safe="Model returned neither tool call nor content",
     ),
+    "no_tools": ErrorMessage(
+        full="tools list must not be empty",
+        safe="tools list must not be empty",
+    ),
     "completion_failed": ErrorMessage(
         full="LLM completion failed with {model}: {error}",
         safe="LLM completion failed",

--- a/src/mira/llm/__init__.py
+++ b/src/mira/llm/__init__.py
@@ -16,6 +16,11 @@ def create_llm(config: LLMConfig) -> LLMProviderProtocol:
 
         return BedrockProvider(config)
 
+    if config.api_style == "responses":
+        from mira.llm.responses import ResponsesProvider
+
+        return ResponsesProvider(config)
+
     # Default: OpenAI-compatible endpoint (OpenRouter, vLLM, Ollama, etc.)
     from mira.llm.provider import LLMProvider
 

--- a/src/mira/llm/base.py
+++ b/src/mira/llm/base.py
@@ -2,7 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+import logging
+import os
+from typing import ClassVar, Protocol, runtime_checkable
+
+import httpx
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from mira.config import LLMConfig
+from mira.exceptions import LLMError, NonRetriableLLMError
+from mira.llm import provider_profiles as profiles
+from mira.llm.tool_schemas import SUBMIT_REVIEW_TOOL, SUBMIT_WALKTHROUGH_TOOL
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -55,3 +67,321 @@ class LLMProviderProtocol(Protocol):
 
     @property
     def usage(self) -> dict[str, int]: ...
+
+
+# ── Module-level helpers (shared by both providers) ─────────────────
+
+
+def _get_api_key(config: LLMConfig, profile: dict | None = None) -> str:
+    """Resolve the API key for the configured endpoint.
+
+    Reads `config.api_key_env` first, then the matched provider profile's
+    `api_key_env`, then the legacy `OPENROUTER_API_KEY` / `OPENAI_API_KEY`
+    lookup for backward compatibility. If `api_key_env` is explicitly "" the
+    empty string is returned without error — useful for local endpoints
+    (Ollama, llama.cpp server) that don't require auth.
+    """
+    if config.api_key_env == "":
+        return ""
+    key = os.environ.get(config.api_key_env, "")
+    if not key and profile and profile.get("api_key_env"):
+        key = os.environ.get(profile["api_key_env"], "")
+    if not key:
+        # Back-compat with pre-`api_key_env` setups.
+        key = os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY", "")
+    if not key:
+        raise LLMError("no_api_key", api_key_env=config.api_key_env)
+    return key
+
+
+def _strip_model_prefix(model: str, base_url: str) -> str:
+    """Apply the endpoint's model-prefix policy from its provider profile.
+
+    'keep' (OpenRouter) routes on the full `vendor/model` string and only sheds
+    a redundant self-prefix (`openrouter/…`). 'strip' (the default for other
+    endpoints) sends the bare model name (e.g. 'minimax/MiniMax-M2.7' →
+    'MiniMax-M2.7').
+    """
+    profile = profiles.resolve(base_url)
+    if profile.get("model_prefix") == "keep":
+        self_prefix = f"{profile['name']}/"
+        return model[len(self_prefix) :] if model.startswith(self_prefix) else model
+    return model.split("/", 1)[1] if "/" in model else model
+
+
+def _retriable(exception: BaseException) -> bool:
+    """Return True for transient errors; False for 4xx non-retriable errors."""
+    if isinstance(exception, NonRetriableLLMError):
+        return False
+    return isinstance(
+        exception,
+        (httpx.TimeoutException, httpx.NetworkError, LLMError),
+    )
+
+
+# ── Shared base for OpenAI-compatible providers ─────────────────────
+
+
+class OpenAICompatibleProvider:
+    """Protocol-agnostic base for OpenAI-compatible API providers.
+
+    Captures the code shared by ``LLMProvider`` (chat/completions) and
+    ``ResponsesProvider`` (/responses protocol): retry setup, header
+    building, reasoning, fallback model logic, token accounting, and the
+    public API surface.  Protocol-specific paths (URL, input/output
+    format, tool transformation) remain in each subclass.
+    """
+
+    supports_json_mode: ClassVar[bool] = True
+    supports_tool_calling: ClassVar[bool] = True
+
+    def __init__(self, config: LLMConfig) -> None:
+        self.config = config
+        self.profile = profiles.resolve(config.base_url)
+        self.total_prompt_tokens = 0
+        self.total_completion_tokens = 0
+        self._no_forced_tool_choice: set[str] = set()
+        self._no_reasoning: set[str] = set()
+
+        # Apply retry decorator imperatively so it reads config values
+        # (max_retries, retry_min_wait, retry_max_wait) at instance time.
+        self._retry = retry(
+            stop=stop_after_attempt(config.max_retries),
+            wait=wait_exponential(
+                multiplier=1,
+                min=config.retry_min_wait,
+                max=config.retry_max_wait,
+            ),
+            retry=retry_if_exception(_retriable),
+            reraise=True,
+        )
+        # Decorate the concrete subclass methods with retry logic.
+        self._call_llm = self._retry(self._call_llm)
+        self._call_llm_with_tools = self._retry(self._call_llm_with_tools)
+        self._call_llm_agentic = self._retry(self._call_llm_agentic)
+
+    # ── Shared helpers ─────────────────────────────────────────────
+
+    def _build_headers(self) -> dict[str, str]:
+        """Build request headers: Content-Type, optional Bearer auth, and any
+        provider-specific extras from the profile. Authorization is omitted
+        entirely if the endpoint needs no key (Ollama, llama.cpp, etc.)."""
+        if hasattr(self, "_cached_headers"):
+            return dict(self._cached_headers)
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        key = _get_api_key(self.config, self.profile)
+        if key:
+            headers["Authorization"] = f"Bearer {key}"
+        headers.update(self.profile.get("extra_headers", {}))
+        self._cached_headers = headers
+        return dict(headers)
+
+    def _apply_reasoning(self, body: dict) -> None:
+        """Enable extended thinking when a reasoning effort is configured.
+
+        The effort is passed via the unified ``reasoning.effort`` knob, after
+        any per-provider remap from the profile. Anthropic models reject a
+        custom ``temperature`` while thinking is on, so we drop it.
+        No-op when reasoning is off, keeping the request unchanged.
+        """
+        effort = self.config.reasoning_effort
+        if not effort or effort == "off":
+            return
+        if body.get("model") in self._no_reasoning:
+            return
+        effort = self.profile.get("reasoning_effort_map", {}).get(effort, effort)
+        body["reasoning"] = {"effort": effort}
+        body.pop("temperature", None)
+
+    def _account_usage(self, data: dict) -> None:
+        """Accumulate token counts. Default: chat/completions key names.
+
+        Subclasses override when the API uses different keys
+        (e.g. Responses API uses ``input_tokens`` / ``output_tokens``).
+        """
+        usage = data.get("usage")
+        if usage:
+            self.total_prompt_tokens += usage.get("prompt_tokens", 0)
+            self.total_completion_tokens += usage.get("completion_tokens", 0)
+
+    @staticmethod
+    def _handle_error(resp: httpx.Response) -> None:
+        """Raise LLMError or NonRetriableLLMError on non-200 responses."""
+        if resp.status_code != 200:
+            if 400 <= resp.status_code < 500 and resp.status_code != 429:
+                raise NonRetriableLLMError("api_error", status=resp.status_code, body=resp.text)
+            raise LLMError("api_error", status=resp.status_code, body=resp.text)
+
+    # ── Subclass hooks (abstract) ──────────────────────────────────
+
+    async def _call_llm(
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        json_mode: bool,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    async def _call_llm_with_tools(
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> str:
+        raise NotImplementedError
+
+    async def _call_llm_agentic(
+        self,
+        model: str,
+        messages: list,
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> dict:
+        raise NotImplementedError
+
+    # ── Public API (shared across chat and responses providers) ─────
+
+    async def complete(
+        self,
+        messages: list[dict[str, str]],
+        json_mode: bool = True,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        """Complete a prompt using JSON mode, with fallback model support."""
+        try:
+            return await self._call_llm(
+                self.config.model,
+                messages,
+                json_mode,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except NonRetriableLLMError:
+            raise
+        except Exception as primary_err:
+            if self.config.fallback_model:
+                logger.warning(
+                    "Primary model %s failed (%s), trying fallback %s",
+                    self.config.model,
+                    primary_err,
+                    self.config.fallback_model,
+                )
+                try:
+                    return await self._call_llm(
+                        self.config.fallback_model,
+                        messages,
+                        json_mode,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                    )
+                except Exception as fallback_err:
+                    raise LLMError(
+                        "both_models_failed",
+                        primary_model=self.config.model,
+                        fallback_model=self.config.fallback_model,
+                        error=fallback_err,
+                    ) from fallback_err
+            raise LLMError(
+                "completion_failed", model=self.config.model, error=primary_err
+            ) from primary_err
+
+    async def complete_with_tools(
+        self,
+        messages: list[dict[str, str]],
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> str:
+        """Complete a prompt using tool calling for structured output."""
+        try:
+            return await self._call_llm_with_tools(
+                self.config.model, messages, tools, temperature=temperature
+            )
+        except NonRetriableLLMError:
+            raise
+        except Exception as primary_err:
+            if self.config.fallback_model:
+                logger.warning(
+                    "Primary model %s failed (%s), trying fallback %s",
+                    self.config.model,
+                    primary_err,
+                    self.config.fallback_model,
+                )
+                try:
+                    return await self._call_llm_with_tools(
+                        self.config.fallback_model,
+                        messages,
+                        tools,
+                        temperature=temperature,
+                    )
+                except Exception as fallback_err:
+                    raise LLMError(
+                        "both_models_failed",
+                        primary_model=self.config.model,
+                        fallback_model=self.config.fallback_model,
+                        error=fallback_err,
+                    ) from fallback_err
+            raise LLMError(
+                "tool_call_failed", model=self.config.model, error=primary_err
+            ) from primary_err
+
+    async def complete_agentic(
+        self,
+        messages: list,
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> dict:
+        """Single hop of an agentic loop. Returns the assistant message dict."""
+        try:
+            return await self._call_llm_agentic(
+                self.config.model, messages, tools, temperature=temperature
+            )
+        except NonRetriableLLMError:
+            raise
+        except Exception as primary_err:
+            if self.config.fallback_model:
+                logger.warning(
+                    "Primary model %s failed (%s), trying fallback %s",
+                    self.config.model,
+                    primary_err,
+                    self.config.fallback_model,
+                )
+                try:
+                    return await self._call_llm_agentic(
+                        self.config.fallback_model, messages, tools, temperature=temperature
+                    )
+                except Exception as fallback_err:
+                    raise LLMError(
+                        "both_models_failed",
+                        primary_model=self.config.model,
+                        fallback_model=self.config.fallback_model,
+                        error=fallback_err,
+                    ) from fallback_err
+            raise LLMError(
+                "agentic_failed", model=self.config.model, error=primary_err
+            ) from primary_err
+
+    async def review(self, messages: list[dict[str, str]], temperature: float | None = None) -> str:
+        """Submit a review using tool calling."""
+        return await self.complete_with_tools(
+            messages, tools=[SUBMIT_REVIEW_TOOL], temperature=temperature
+        )
+
+    async def walkthrough(self, messages: list[dict[str, str]]) -> str:
+        """Submit a walkthrough using tool calling."""
+        return await self.complete_with_tools(messages, tools=[SUBMIT_WALKTHROUGH_TOOL])
+
+    def count_tokens(self, text: str) -> int:
+        """Estimate token count. Uses ~4 chars per token heuristic."""
+        return len(text) // 4
+
+    @property
+    def usage(self) -> dict[str, int]:
+        return {
+            "prompt_tokens": self.total_prompt_tokens,
+            "completion_tokens": self.total_completion_tokens,
+            "total_tokens": self.total_prompt_tokens + self.total_completion_tokens,
+        }

--- a/src/mira/llm/provider.py
+++ b/src/mira/llm/provider.py
@@ -9,138 +9,31 @@ other OpenAI-compatible endpoint works off the portable default, no entry needed
 from __future__ import annotations
 
 import logging
-import os
 from typing import ClassVar
 
 import httpx
-from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
-from mira.config import LLMConfig
-from mira.exceptions import LLMError, NonRetriableLLMError
-from mira.llm import provider_profiles as profiles
-from mira.llm.tool_schemas import SUBMIT_REVIEW_TOOL, SUBMIT_WALKTHROUGH_TOOL
+from mira.exceptions import LLMError
+from mira.llm.base import (
+    OpenAICompatibleProvider,
+    _strip_model_prefix,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _get_api_key(config: LLMConfig, profile: dict | None = None) -> str:
-    """Resolve the API key for the configured endpoint.
+class LLMProvider(OpenAICompatibleProvider):
+    """OpenAI-compatible API client for LLM completions (/chat/completions).
 
-    Reads `config.api_key_env` first, then the matched provider profile's
-    `api_key_env`, then the legacy `OPENROUTER_API_KEY` / `OPENAI_API_KEY`
-    lookup for backward compatibility. If `api_key_env` is explicitly "" the
-    empty string is returned without error — useful for local endpoints
-    (Ollama, llama.cpp server) that don't require auth.
+    Inherits protocol-agnostic infrastructure (retry setup, headers, reasoning,
+    fallback model logic, public API) from :class:`OpenAICompatibleProvider`.
     """
-    if config.api_key_env == "":
-        return ""
-    key = os.environ.get(config.api_key_env, "")
-    if not key and profile and profile.get("api_key_env"):
-        key = os.environ.get(profile["api_key_env"], "")
-    if not key:
-        # Back-compat with pre-`api_key_env` setups.
-        key = os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY", "")
-    if not key:
-        raise LLMError("no_api_key", api_key_env=config.api_key_env)
-    return key
-
-
-def _strip_model_prefix(model: str, base_url: str) -> str:
-    """Apply the endpoint's model-prefix policy from its provider profile.
-
-    'keep' (OpenRouter) routes on the full `vendor/model` string and only sheds
-    a redundant self-prefix (`openrouter/…`). 'strip' (the default for other
-    endpoints) sends the bare model name (e.g. 'minimax/MiniMax-M2.7' →
-    'MiniMax-M2.7').
-    """
-    profile = profiles.resolve(base_url)
-    if profile.get("model_prefix") == "keep":
-        self_prefix = f"{profile['name']}/"
-        return model[len(self_prefix) :] if model.startswith(self_prefix) else model
-    return model.split("/", 1)[1] if "/" in model else model
-
-
-def _retriable(exception: BaseException) -> bool:
-    """Return True for transient errors; False for 4xx non-retriable errors."""
-    if isinstance(exception, NonRetriableLLMError):
-        return False
-    return isinstance(
-        exception,
-        (httpx.TimeoutException, httpx.NetworkError, LLMError),
-    )
-
-
-class LLMProvider:
-    """OpenAI-compatible API client for LLM completions."""
 
     supports_json_mode: ClassVar[bool] = True
     supports_tool_calling: ClassVar[bool] = True
 
-    def __init__(self, config: LLMConfig) -> None:
-        self.config = config
-        # Per-provider quirks (headers, model-prefix, reasoning remap), matched
-        # to the endpoint by base_url. Unknown endpoints get the portable default.
-        self.profile = profiles.resolve(config.base_url)
-        self.total_prompt_tokens = 0
-        self.total_completion_tokens = 0
-        # Models that 400 on a forced tool_choice (deepseek thinking mode);
-        # remembered so we send tool_choice="auto" instead.
-        self._no_forced_tool_choice: set[str] = set()
-        # Models that 400 on a reasoning effort (it's opt-in and applied to
-        # whatever model is selected); remembered so we drop it and review
-        # without thinking rather than failing.
-        self._no_reasoning: set[str] = set()
-        # Apply retry decorator imperatively so it reads config values
-        # (max_retries, retry_min_wait, retry_max_wait) at instance time.
-        self._retry = retry(
-            stop=stop_after_attempt(self.config.max_retries),
-            wait=wait_exponential(
-                multiplier=1,
-                min=self.config.retry_min_wait,
-                max=self.config.retry_max_wait,
-            ),
-            retry=retry_if_exception(_retriable),
-            reraise=True,
-        )
-        self._call_llm = self._retry(self._call_llm)
-        self._call_llm_with_tools = self._retry(self._call_llm_with_tools)
-        self._call_llm_agentic = self._retry(self._call_llm_agentic)
-
     def _chat_url(self) -> str:
         return f"{self.config.base_url.rstrip('/')}/chat/completions"
-
-    def _build_headers(self) -> dict[str, str]:
-        """Build request headers: Content-Type, optional Bearer auth, and any
-        provider-specific extras from the profile (e.g. OpenRouter's ranking
-        headers). Authorization is omitted entirely if the endpoint needs no
-        key (Ollama, llama.cpp, etc.)."""
-        if hasattr(self, "_cached_headers"):
-            return dict(self._cached_headers)
-        headers: dict[str, str] = {"Content-Type": "application/json"}
-        key = _get_api_key(self.config, self.profile)
-        if key:
-            headers["Authorization"] = f"Bearer {key}"
-        headers.update(self.profile.get("extra_headers", {}))
-        self._cached_headers = headers
-        return dict(headers)
-
-    def _apply_reasoning(self, body: dict) -> None:
-        """Enable extended thinking when a reasoning effort is configured.
-
-        The effort is passed via the unified ``reasoning.effort`` knob, after
-        any per-provider remap from the profile (e.g. OpenRouter wants
-        ``xhigh`` where DeepSeek's native top level is ``max``). Anthropic
-        models reject a custom ``temperature`` while thinking is on, so we drop
-        it. No-op when reasoning is off, keeping the request unchanged.
-        """
-        effort = self.config.reasoning_effort
-        if not effort or effort == "off":
-            return
-        if body.get("model") in self._no_reasoning:
-            return
-        effort = self.profile.get("reasoning_effort_map", {}).get(effort, effort)
-        body["reasoning"] = {"effort": effort}
-        body.pop("temperature", None)
 
     async def _call_llm(
         self,
@@ -150,7 +43,7 @@ class LLMProvider:
         temperature: float | None = None,
         max_tokens: int | None = None,
     ) -> str:
-        """Make a single LLM call with retries against the configured endpoint."""
+        """Make a single LLM call with retries against the /chat/completions endpoint."""
         body: dict = {
             "model": _strip_model_prefix(model, self.config.base_url),
             "messages": messages,
@@ -167,20 +60,11 @@ class LLMProvider:
                 headers=self._build_headers(),
                 json=body,
             )
-            if resp.status_code != 200:
-                if 400 <= resp.status_code < 500 and resp.status_code != 429:
-                    raise NonRetriableLLMError("api_error", status=resp.status_code, body=resp.text)
-                raise LLMError("api_error", status=resp.status_code, body=resp.text)
+            self._handle_error(resp)
             data = resp.json()
 
-        content = data["choices"][0]["message"].get("content") or ""
-
-        usage = data.get("usage")
-        if usage:
-            self.total_prompt_tokens += usage.get("prompt_tokens", 0)
-            self.total_completion_tokens += usage.get("completion_tokens", 0)
-
-        return content
+        self._account_usage(data)
+        return data["choices"][0]["message"].get("content") or ""
 
     async def _call_llm_with_tools(
         self,
@@ -195,6 +79,8 @@ class LLMProvider:
         tool arguments as the JSON response.
         """
         api_model = _strip_model_prefix(model, self.config.base_url)
+        if not tools:
+            raise LLMError("no_tools")
         forced_choice: dict | str = {
             "type": "function",
             "function": {"name": tools[0]["function"]["name"]},
@@ -237,16 +123,10 @@ class LLMProvider:
                     temperature if temperature is not None else self.config.temperature
                 )
                 resp = await client.post(self._chat_url(), headers=self._build_headers(), json=body)
-            if resp.status_code != 200:
-                if 400 <= resp.status_code < 500 and resp.status_code != 429:
-                    raise NonRetriableLLMError("api_error", status=resp.status_code, body=resp.text)
-                raise LLMError("api_error", status=resp.status_code, body=resp.text)
+            self._handle_error(resp)
             data = resp.json()
 
-        usage = data.get("usage")
-        if usage:
-            self.total_prompt_tokens += usage.get("prompt_tokens", 0)
-            self.total_completion_tokens += usage.get("completion_tokens", 0)
+        self._account_usage(data)
 
         message = data["choices"][0]["message"]
         tool_calls = message.get("tool_calls")
@@ -263,59 +143,6 @@ class LLMProvider:
 
         raise LLMError("no_tool_call")
 
-    async def complete(
-        self,
-        messages: list[dict[str, str]],
-        json_mode: bool = True,
-        temperature: float | None = None,
-        max_tokens: int | None = None,
-    ) -> str:
-        """Complete a prompt using JSON mode, with fallback model support.
-
-        Args:
-            temperature: Override the default temperature for this call.
-                         Use ``0.0`` for deterministic tasks like verification.
-            max_tokens: Override the default output token cap for this call.
-                        Indexing summarization needs ~16k to avoid truncation
-                        on large batches; the default 4096 cuts JSON off.
-        """
-        try:
-            return await self._call_llm(
-                self.config.model,
-                messages,
-                json_mode,
-                temperature=temperature,
-                max_tokens=max_tokens,
-            )
-        except NonRetriableLLMError:
-            raise
-        except Exception as primary_err:
-            if self.config.fallback_model:
-                logger.warning(
-                    "Primary model %s failed (%s), trying fallback %s",
-                    self.config.model,
-                    primary_err,
-                    self.config.fallback_model,
-                )
-                try:
-                    return await self._call_llm(
-                        self.config.fallback_model,
-                        messages,
-                        json_mode,
-                        temperature=temperature,
-                        max_tokens=max_tokens,
-                    )
-                except Exception as fallback_err:
-                    raise LLMError(
-                        "both_models_failed",
-                        primary_model=self.config.model,
-                        fallback_model=self.config.fallback_model,
-                        error=fallback_err,
-                    ) from fallback_err
-            raise LLMError(
-                "completion_failed", model=self.config.model, error=primary_err
-            ) from primary_err
-
     async def _call_llm_agentic(
         self,
         model: str,
@@ -325,11 +152,11 @@ class LLMProvider:
     ) -> dict:
         """Make a tool-using LLM call without forcing a specific tool.
 
-        Unlike `_call_llm_with_tools`, this returns the *full* assistant
-        message (with `tool_calls` and `content`) so the caller can
-        dispatch the calls and continue the conversation. This is what
-        the agentic loop needs.
+        Returns the full assistant message (with ``tool_calls`` and ``content``)
+        so the caller can dispatch the calls and continue the conversation.
         """
+        if not tools:
+            raise LLMError("no_tools")
         body: dict = {
             "model": _strip_model_prefix(model, self.config.base_url),
             "messages": messages,
@@ -346,132 +173,8 @@ class LLMProvider:
                 headers=self._build_headers(),
                 json=body,
             )
-            if resp.status_code != 200:
-                if 400 <= resp.status_code < 500 and resp.status_code != 429:
-                    raise NonRetriableLLMError("api_error", status=resp.status_code, body=resp.text)
-                raise LLMError("api_error", status=resp.status_code, body=resp.text)
+            self._handle_error(resp)
             data = resp.json()
 
-        usage = data.get("usage")
-        if usage:
-            self.total_prompt_tokens += usage.get("prompt_tokens", 0)
-            self.total_completion_tokens += usage.get("completion_tokens", 0)
-
+        self._account_usage(data)
         return data["choices"][0]["message"]
-
-    async def complete_agentic(
-        self,
-        messages: list,
-        tools: list[dict],
-        temperature: float | None = None,
-    ) -> dict:
-        """Single hop of an agentic loop. Returns the assistant message dict.
-
-        The caller is responsible for the loop: append the message,
-        dispatch any `tool_calls`, append the tool results as `tool`-role
-        messages, and call again until the terminal tool fires.
-        """
-        try:
-            return await self._call_llm_agentic(
-                self.config.model, messages, tools, temperature=temperature
-            )
-        except NonRetriableLLMError:
-            raise
-        except Exception as primary_err:
-            if self.config.fallback_model:
-                logger.warning(
-                    "Primary model %s failed (%s), trying fallback %s",
-                    self.config.model,
-                    primary_err,
-                    self.config.fallback_model,
-                )
-                try:
-                    return await self._call_llm_agentic(
-                        self.config.fallback_model, messages, tools, temperature=temperature
-                    )
-                except Exception as fallback_err:
-                    raise LLMError(
-                        "both_models_failed",
-                        primary_model=self.config.model,
-                        fallback_model=self.config.fallback_model,
-                        error=fallback_err,
-                    ) from fallback_err
-            raise LLMError(
-                "agentic_failed", model=self.config.model, error=primary_err
-            ) from primary_err
-
-    async def complete_with_tools(
-        self,
-        messages: list[dict[str, str]],
-        tools: list[dict],
-        temperature: float | None = None,
-    ) -> str:
-        """Complete a prompt using tool calling for structured output.
-
-        The LLM 'calls' a tool to return structured JSON data. Works reliably
-        across all models available on OpenRouter.
-
-        Args:
-            messages: The prompt messages.
-            tools: Tool schemas in OpenAI function-calling format.
-            temperature: Override the default temperature.
-
-        Returns:
-            The JSON string from the tool call arguments.
-        """
-        try:
-            return await self._call_llm_with_tools(
-                self.config.model, messages, tools, temperature=temperature
-            )
-        except NonRetriableLLMError:
-            raise
-        except Exception as primary_err:
-            if self.config.fallback_model:
-                logger.warning(
-                    "Primary model %s failed (%s), trying fallback %s",
-                    self.config.model,
-                    primary_err,
-                    self.config.fallback_model,
-                )
-                try:
-                    return await self._call_llm_with_tools(
-                        self.config.fallback_model, messages, tools, temperature=temperature
-                    )
-                except Exception as fallback_err:
-                    raise LLMError(
-                        "both_models_failed",
-                        primary_model=self.config.model,
-                        fallback_model=self.config.fallback_model,
-                        error=fallback_err,
-                    ) from fallback_err
-            raise LLMError(
-                "tool_call_failed", model=self.config.model, error=primary_err
-            ) from primary_err
-
-    async def review(self, messages: list[dict[str, str]], temperature: float | None = None) -> str:
-        """Submit a review using tool calling.
-
-        Returns the JSON string containing review comments, key issues, and summary.
-        """
-        return await self.complete_with_tools(
-            messages, tools=[SUBMIT_REVIEW_TOOL], temperature=temperature
-        )
-
-    async def walkthrough(self, messages: list[dict[str, str]]) -> str:
-        """Submit a walkthrough using tool calling.
-
-        Returns the JSON string containing walkthrough summary and file changes.
-        """
-        return await self.complete_with_tools(messages, tools=[SUBMIT_WALKTHROUGH_TOOL])
-
-    def count_tokens(self, text: str) -> int:
-        """Estimate token count. Uses ~4 chars per token heuristic."""
-        return len(text) // 4
-
-    @property
-    def usage(self) -> dict[str, int]:
-        return {
-            "prompt_tokens": self.total_prompt_tokens,
-            "completion_tokens": self.total_completion_tokens,
-            "total_tokens": self.total_prompt_tokens + self.total_completion_tokens,
-        }

--- a/src/mira/llm/responses.py
+++ b/src/mira/llm/responses.py
@@ -1,0 +1,330 @@
+"""OpenAI Responses API provider ({base_url}/responses).
+
+Speaks the Responses protocol: ``input`` items, ``text.format`` for JSON
+mode, ``max_output_tokens``, and ``output`` items (``function_call`` /
+``output_text``). Presents the same chat-shaped conversation contract to
+callers, converting to/from Responses input/output items internally.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import ClassVar
+
+import httpx
+
+from mira.config import LLMConfig
+from mira.exceptions import LLMError
+from mira.llm.base import OpenAICompatibleProvider, _strip_model_prefix
+
+logger = logging.getLogger(__name__)
+
+
+# ── Message conversion helpers ──────────────────────────────────────
+
+
+def _responses_input(messages: list[dict]) -> list[dict]:
+    """Convert chat-shaped messages to Responses API input items.
+
+    system/user -> {"role": role, "content": <str>} (simple form).
+    assistant   -> output-text message item, PLUS one {"type": "function_call",
+                  "id"/"call_id" = call id, "name", "arguments"} item per tool call.
+    tool        -> {"type": "function_call_output", "call_id": msg["tool_call_id"]
+                  or "call_0", "output": <str>}.
+    Assistant items with empty content AND no tool_calls are skipped.
+    ``arguments`` may arrive as a dict or JSON string: json.dumps dicts.
+    """
+    items: list[dict] = []
+    for msg in messages:
+        role = msg.get("role", "user")
+
+        if role == "system":
+            items.append({"role": "system", "content": msg.get("content", "")})
+            continue
+
+        if role == "user":
+            items.append({"role": "user", "content": msg.get("content", "")})
+            continue
+
+        if role == "assistant":
+            content = msg.get("content")
+            tool_calls = msg.get("tool_calls") or []
+            if not content and not tool_calls:
+                continue  # skip empty assistant
+            if content:
+                items.append({"type": "message", "role": "assistant", "content": content})
+            for tc in tool_calls:
+                args = tc.get("function", {}).get("arguments", "{}")
+                if isinstance(args, dict):
+                    args = json.dumps(args)
+                items.append(
+                    {
+                        "type": "function_call",
+                        "id": tc.get("id", ""),
+                        "call_id": tc.get("id", ""),
+                        "name": tc.get("function", {}).get("name", ""),
+                        "arguments": args,
+                    }
+                )
+            continue
+
+        if role == "tool":
+            call_id = msg.get("tool_call_id", "call_0")
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": msg.get("content", ""),
+                }
+            )
+            continue
+
+    return items
+
+
+def _responses_tool(chat_tool: dict) -> dict:
+    """Flatten {"type":"function","function":{...}} to the Responses shape
+    {"type":"function","name","description","parameters"}."""
+    f = chat_tool.get("function", {})
+    out: dict = {"type": "function", "name": f.get("name", "")}
+    if f.get("description"):
+        out["description"] = f["description"]
+    if f.get("parameters"):
+        out["parameters"] = f["parameters"]
+    return out
+
+
+def _output_text(data: dict) -> str:
+    """Concatenated assistant text: scan data["output"] for message items whose
+    content parts are type "output_text" or "text" (accept both for compat),
+    falling back to data.get("output_text", "") when no message item exists."""
+    output = data.get("output", [])
+    for item in output:
+        if item.get("type") == "message" and item.get("role") == "assistant":
+            content = item.get("content", [])
+            parts = []
+            if isinstance(content, list):
+                for part in content:
+                    if part.get("type") in ("output_text", "text"):
+                        parts.append(part.get("text", ""))
+            if parts:
+                return "".join(parts)
+    # Fallback: some implementations put output_text at the top level
+    return data.get("output_text", "")
+
+
+def _response_message(data: dict) -> dict:
+    """Normalize a Responses response to the chat-shaped assistant dict the
+    agentic loop reads: {"role":"assistant","content": <str or None>,
+    "tool_calls": [{"id","type":"function","function":{"name","arguments"}}]}.
+    content None when only tool calls are present (match chat shape).
+    tool_calls empty list when none."""
+    output = data.get("output", [])
+    text_parts: list[str] = []
+    tool_calls: list[dict] = []
+
+    for item in output:
+        itype = item.get("type", "")
+        if itype == "message" and item.get("role") == "assistant":
+            content = item.get("content", [])
+            if isinstance(content, list):
+                for part in content:
+                    if part.get("type") in ("output_text", "text"):
+                        text_parts.append(part.get("text", ""))
+        elif itype == "function_call":
+            # In Responses API, name/arguments are direct on the item
+            name = item.get("name", "")
+            arguments = item.get("arguments", "{}")
+            call_id = item.get("call_id") or item.get("id", "")
+            tool_calls.append(
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": name, "arguments": arguments},
+                }
+            )
+
+    content = "".join(text_parts) if text_parts else (None if tool_calls else "")
+    return {"role": "assistant", "content": content, "tool_calls": tool_calls}
+
+
+# ── Provider class ──────────────────────────────────────────────────
+
+
+class ResponsesProvider(OpenAICompatibleProvider):
+    """OpenAI Responses API provider ({base_url}/responses).
+
+    Same OpenAI-compatible endpoint/auth/model ids as the chat provider, but
+    speaks the /responses protocol. Inherits protocol-agnostic infrastructure
+    from :class:`OpenAICompatibleProvider`.
+    """
+
+    supports_json_mode: ClassVar[bool] = True
+    supports_tool_calling: ClassVar[bool] = True
+
+    def __init__(self, config: LLMConfig) -> None:
+        super().__init__(config)
+        self._url = f"{config.base_url.rstrip('/')}/responses"
+
+    # ── Overrides ────────────────────────────────────────────────────
+
+    def _account_usage(self, data: dict) -> None:
+        """Accumulate token counts from Responses API usage.
+
+        The Responses API uses ``input_tokens`` / ``output_tokens`` keys,
+        mapping to our ``total_prompt_tokens`` / ``total_completion_tokens``.
+        """
+        usage = data.get("usage")
+        if usage:
+            self.total_prompt_tokens += usage.get("input_tokens", 0)
+            self.total_completion_tokens += usage.get("output_tokens", 0)
+
+    # ── Internal LLM calls (retry-decorated by base class) ──────────
+
+    async def _call_llm(
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        json_mode: bool,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str:
+        """Make a single LLM call with retries against the /responses endpoint."""
+        body: dict = {
+            "model": _strip_model_prefix(model, self.config.base_url),
+            "input": _responses_input(messages),
+            "temperature": temperature if temperature is not None else self.config.temperature,
+            "max_output_tokens": max_tokens if max_tokens is not None else self.config.max_tokens,
+        }
+        if json_mode:
+            body["text"] = {"format": {"type": "json_object"}}
+        self._apply_reasoning(body)
+
+        async with httpx.AsyncClient(timeout=self.config.request_timeout) as client:
+            resp = await client.post(
+                self._url,
+                headers=self._build_headers(),
+                json=body,
+            )
+            self._handle_error(resp)
+            data = resp.json()
+
+        self._account_usage(data)
+        return _output_text(data)
+
+    async def _call_llm_with_tools(
+        self,
+        model: str,
+        messages: list[dict[str, str]],
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> str:
+        """Make an LLM call with tool/function calling and retries.
+
+        The LLM returns structured data by 'calling' a tool. We extract the
+        tool arguments as the JSON response.
+        """
+        api_model = _strip_model_prefix(model, self.config.base_url)
+        if not tools:
+            raise LLMError("no_tools")
+        forced_choice: dict | str = {
+            "type": "function",
+            "name": tools[0]["function"]["name"],
+        }
+        body: dict = {
+            "model": api_model,
+            "input": _responses_input(messages),
+            "tools": [_responses_tool(t) for t in tools],
+            "tool_choice": "auto" if api_model in self._no_forced_tool_choice else forced_choice,
+            "temperature": temperature if temperature is not None else self.config.temperature,
+            "max_output_tokens": self.config.max_tokens,
+        }
+        self._apply_reasoning(body)
+
+        async with httpx.AsyncClient(timeout=self.config.request_timeout) as client:
+            resp = await client.post(
+                self._url,
+                headers=self._build_headers(),
+                json=body,
+            )
+            if (
+                resp.status_code == 400
+                and body["tool_choice"] != "auto"
+                and "tool_choice" in resp.text.lower()
+            ):
+                logger.info("Model %s rejected forced tool_choice; retrying with auto", api_model)
+                self._no_forced_tool_choice.add(api_model)
+                body["tool_choice"] = "auto"
+                resp = await client.post(self._url, headers=self._build_headers(), json=body)
+            if resp.status_code == 400 and "reasoning" in body and "reasoning" in resp.text.lower():
+                logger.info("Model %s rejected reasoning effort; retrying without it", api_model)
+                self._no_reasoning.add(api_model)
+                body.pop("reasoning", None)
+                body["temperature"] = (
+                    temperature if temperature is not None else self.config.temperature
+                )
+                resp = await client.post(self._url, headers=self._build_headers(), json=body)
+            self._handle_error(resp)
+            data = resp.json()
+
+        self._account_usage(data)
+
+        # Check for tool calls in the response
+        output = data.get("output", [])
+        for item in output:
+            if item.get("type") == "function_call":
+                return item.get("arguments") or "{}"
+
+        # Fallback: text content
+        text = _output_text(data)
+        if text:
+            logger.warning("Model returned content instead of tool call, using content as fallback")
+            return text
+
+        raise LLMError("no_tool_call")
+
+    async def _call_llm_agentic(
+        self,
+        model: str,
+        messages: list,
+        tools: list[dict],
+        temperature: float | None = None,
+    ) -> dict:
+        """Make a tool-using LLM call without forcing a specific tool.
+
+        Returns the full assistant message (with ``tool_calls`` and ``content``)
+        so the caller can dispatch and continue the conversation.
+        """
+        if not tools:
+            raise LLMError("no_tools")
+        body: dict = {
+            "model": _strip_model_prefix(model, self.config.base_url),
+            "input": _responses_input(messages),
+            "tools": [_responses_tool(t) for t in tools],
+            "tool_choice": "auto",
+            "temperature": temperature if temperature is not None else self.config.temperature,
+            "max_output_tokens": self.config.max_tokens,
+        }
+        self._apply_reasoning(body)
+
+        async with httpx.AsyncClient(timeout=self.config.request_timeout) as client:
+            resp = await client.post(
+                self._url,
+                headers=self._build_headers(),
+                json=body,
+            )
+            if resp.status_code == 400 and "reasoning" in body and "reasoning" in resp.text.lower():
+                api_model = _strip_model_prefix(model, self.config.base_url)
+                logger.info("Model %s rejected reasoning effort; retrying without it", api_model)
+                self._no_reasoning.add(api_model)
+                body.pop("reasoning", None)
+                body["temperature"] = (
+                    temperature if temperature is not None else self.config.temperature
+                )
+                resp = await client.post(self._url, headers=self._build_headers(), json=body)
+            self._handle_error(resp)
+            data = resp.json()
+
+        self._account_usage(data)
+        return _response_message(data)

--- a/tests/test_api_style.py
+++ b/tests/test_api_style.py
@@ -1,0 +1,170 @@
+"""Tests for api_style resolution and the Models endpoint.
+
+Covers:
+- ``resolve_api_style`` precedence: DB → config → default.
+- ``llm_config_for`` setting ``api_style`` for all purposes.
+- ``set_models`` validating and persisting the api_style.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from mira.config import LLMConfig
+from mira.dashboard.api import ModelsUpdate
+from mira.dashboard.db import AppDatabase
+from mira.dashboard.models_config import (
+    API_STYLE_VALUES,
+    llm_config_for,
+    resolve_api_style,
+)
+from mira.dashboard.routers.admin import get_models, set_models
+
+
+def _admin_req():
+    from types import SimpleNamespace
+
+    user = SimpleNamespace(is_admin=True)
+    return SimpleNamespace(state=SimpleNamespace(user=user))
+
+
+@pytest.fixture
+def in_memory_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AppDatabase:
+    """Fresh per-test SQLite DB swapped in for the module-level ``_app_db``."""
+    monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+    db = AppDatabase(url="", admin_password="admin")
+    monkeypatch.setattr("mira.dashboard.api._app_db", db)
+    return db
+
+
+class TestResolveApiStyle:
+    def test_default_is_chat(self):
+        assert resolve_api_style(LLMConfig(), None) == "chat"
+
+    def test_db_wins_over_config(self):
+        cfg = LLMConfig(api_style="chat")
+        assert resolve_api_style(cfg, "responses") == "responses"
+
+    def test_falls_back_to_config(self):
+        cfg = LLMConfig(api_style="responses")
+        assert resolve_api_style(cfg, None) == "responses"
+
+    def test_unknown_db_falls_back_to_config(self):
+        cfg = LLMConfig(api_style="responses")
+        assert resolve_api_style(cfg, "garbage") == "responses"
+
+    def test_unknown_config_defaults_to_chat(self):
+        cfg = LLMConfig()
+        cfg.api_style = "unknown_value"
+        assert resolve_api_style(cfg, None) == "chat"
+
+    def test_db_responses_wins_over_config_chat(self):
+        cfg = LLMConfig(api_style="chat")
+        assert resolve_api_style(cfg, "responses") == "responses"
+
+
+class TestLLMConfigFor:
+    def test_review_picks_up_api_style(self, in_memory_db: AppDatabase):
+        in_memory_db.set_setting("api_style", "responses")
+        resolved = llm_config_for("review", LLMConfig())
+        assert resolved.api_style == "responses"
+
+    def test_indexing_picks_up_api_style(self, in_memory_db: AppDatabase):
+        in_memory_db.set_setting("api_style", "responses")
+        resolved = llm_config_for("indexing", LLMConfig())
+        assert resolved.api_style == "responses"
+
+    def test_unknown_purpose_picks_up_api_style(self, in_memory_db: AppDatabase):
+        in_memory_db.set_setting("api_style", "responses")
+        resolved = llm_config_for("other", LLMConfig())
+        assert resolved.api_style == "responses"
+
+    def test_no_db_uses_config(self, in_memory_db: AppDatabase):
+        # No api_style set in DB — config default is "chat"
+        resolved = llm_config_for("review", LLMConfig())
+        assert resolved.api_style == "chat"
+
+    def test_config_responses_with_no_db(self, in_memory_db: AppDatabase):
+        resolved = llm_config_for("review", LLMConfig(api_style="responses"))
+        assert resolved.api_style == "responses"
+
+
+class TestSetModelsApiStyle:
+    def test_rejects_invalid_api_style(self, in_memory_db: AppDatabase):
+        with pytest.raises(HTTPException) as exc_info:
+            set_models(
+                ModelsUpdate(
+                    indexing_model="gpt-4o",
+                    review_model="gpt-4o",
+                    api_style="ultra",
+                ),
+                _admin_req(),
+            )
+        assert exc_info.value.status_code == 400
+
+    def test_persists_responses(self, in_memory_db: AppDatabase):
+        set_models(
+            ModelsUpdate(
+                indexing_model="gpt-4o",
+                review_model="gpt-4o",
+                api_style="responses",
+            ),
+            _admin_req(),
+        )
+        assert in_memory_db.get_setting("api_style") == "responses"
+
+    def test_clears_on_chat(self, in_memory_db: AppDatabase):
+        set_models(
+            ModelsUpdate(
+                indexing_model="gpt-4o",
+                review_model="gpt-4o",
+                api_style="chat",
+            ),
+            _admin_req(),
+        )
+        assert in_memory_db.get_setting("api_style") == ""
+
+    def test_default_clears_and_does_not_shadow_config(self, in_memory_db: AppDatabase):
+        # Save "chat" (default) → should clear the DB entry
+        set_models(
+            ModelsUpdate(indexing_model="gpt-4o", review_model="gpt-4o"),
+            _admin_req(),
+        )
+        assert in_memory_db.get_setting("api_style") == ""
+        # Now a config-level responses should still resolve
+        resolved = resolve_api_style(
+            LLMConfig(api_style="responses"), in_memory_db.get_setting("api_style")
+        )
+        assert resolved == "responses"
+
+    def test_existing_thinking_tests_still_work(self, in_memory_db: AppDatabase):
+        """Ensure that api_style is independent of review_thinking_mode."""
+        set_models(
+            ModelsUpdate(
+                indexing_model="gpt-4o",
+                review_model="gpt-4o",
+                review_thinking_mode="high",
+                api_style="responses",
+            ),
+            _admin_req(),
+        )
+        assert in_memory_db.get_setting("api_style") == "responses"
+        assert in_memory_db.get_setting("review_thinking_mode") == "high"
+
+    def test_api_style_values_are_complete(self):
+        assert "chat" in API_STYLE_VALUES
+        assert "responses" in API_STYLE_VALUES
+
+
+class TestGetModelsEndpoint:
+    @pytest.mark.asyncio
+    async def test_api_style_fields_present_in_response(self, in_memory_db: AppDatabase):
+        """GET /api/settings/models response must include api_style fields."""
+        result = await get_models()
+        assert hasattr(result, "api_style")
+        assert hasattr(result, "api_style_options")
+        assert result.api_style == "chat"  # default
+        assert len(result.api_style_options) >= 2

--- a/tests/test_responses_provider.py
+++ b/tests/test_responses_provider.py
@@ -1,0 +1,565 @@
+"""Tests for the OpenAI Responses API provider."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mira.config import LLMConfig
+from mira.exceptions import LLMError, NonRetriableLLMError
+from mira.llm import create_llm
+from mira.llm.responses import ResponsesProvider
+
+# Set a dummy API key for tests so _get_api_key() doesn't fail
+os.environ.setdefault("OPENROUTER_API_KEY", "test-key-for-unit-tests")
+
+
+def _make_resp_text(text: str, usage: dict | None = None) -> dict:
+    """Create a mock Responses API response with text content."""
+    resp = {
+        "output": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text}],
+            }
+        ]
+    }
+    if usage is not None:
+        resp["usage"] = usage
+    return resp
+
+
+def _make_resp_usage(prompt: int, completion: int) -> dict:
+    return {"input_tokens": prompt, "output_tokens": completion}
+
+
+def _make_resp_tool(name: str, args: str, call_id: str = "call_1") -> dict:
+    return {
+        "output": [
+            {
+                "type": "function_call",
+                "id": call_id,
+                "call_id": call_id,
+                "name": name,
+                "arguments": args,
+            }
+        ],
+        "usage": _make_resp_usage(50, 30),
+    }
+
+
+def _make_resp_text_and_tool(text: str, name: str, args: str, call_id: str = "call_1") -> dict:
+    return {
+        "output": [
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": text}],
+            },
+            {
+                "type": "function_call",
+                "id": call_id,
+                "call_id": call_id,
+                "name": name,
+                "arguments": args,
+            },
+        ],
+        "usage": _make_resp_usage(50, 30),
+    }
+
+
+def _mock_httpx_response(data: dict, status_code: int = 200):
+    """Create a mock httpx.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = data
+    resp.text = json.dumps(data)
+    return resp
+
+
+def _mock_client(resp, extra_posts=None):
+    """Build a mock AsyncClient whose .post() returns the given response(s)."""
+    mock_client = AsyncMock()
+    if extra_posts:
+        mock_client.post = AsyncMock(side_effect=extra_posts)
+    else:
+        mock_client.post = AsyncMock(return_value=resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+@pytest.fixture
+def config() -> LLMConfig:
+    # api_key_env="OPENAI_API_KEY" is intentional: the module-level
+    # ``os.environ.setdefault("OPENROUTER_API_KEY", ...)`` means the
+    # fixture exercises ``_get_api_key``'s back-compat fallback chain
+    # (config env var -> profile override -> OPENROUTER_API_KEY fallback).
+    return LLMConfig(
+        model="gpt-4o",
+        base_url="https://api.openai.com/v1",
+        api_key_env="OPENAI_API_KEY",
+        api_style="responses",
+    )
+
+
+class TestResponsesProviderInit:
+    def test_default_init(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        assert provider.config is config
+        assert provider.total_prompt_tokens == 0
+        assert provider.total_completion_tokens == 0
+        assert provider._url == "https://api.openai.com/v1/responses"
+
+    def test_url_with_trailing_slash(self):
+        cfg = LLMConfig(base_url="https://api.openai.com/v1/", api_style="responses")
+        provider = ResponsesProvider(cfg)
+        assert provider._url == "https://api.openai.com/v1/responses"
+
+
+class TestComplete:
+    @pytest.mark.asyncio
+    async def test_posts_to_responses_endpoint(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_text("hello world", _make_resp_usage(100, 50))
+
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            result = await provider.complete(
+                [{"role": "user", "content": "say hello"}], json_mode=False
+            )
+
+        assert result == "hello world"
+        assert mock_client.post.call_count == 1
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "https://api.openai.com/v1/responses"
+        body = call_args[1]["json"]
+        assert "input" in body
+        assert "messages" not in body
+        assert body["input"][0]["role"] == "user"
+        assert body["input"][0]["content"] == "say hello"
+
+    @pytest.mark.asyncio
+    async def test_json_mode_body(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_text('{"key": "val"}', _make_resp_usage(10, 10))
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            await provider.complete([{"role": "user", "content": "json"}], json_mode=True)
+
+        body = mock_client.post.call_args[1]["json"]
+        assert "input" in body
+        assert "response_format" not in body
+        assert body["text"]["format"]["type"] == "json_object"
+        assert "max_output_tokens" in body
+
+    @pytest.mark.asyncio
+    async def test_token_accounting(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_text("result", _make_resp_usage(100, 50))
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            await provider.complete([{"role": "user", "content": "test"}])
+
+        assert provider.total_prompt_tokens == 100
+        assert provider.total_completion_tokens == 50
+        usage = provider.usage
+        assert usage["prompt_tokens"] == 100
+        assert usage["completion_tokens"] == 50
+        assert usage["total_tokens"] == 150
+
+    @pytest.mark.asyncio
+    async def test_non_retriable_error(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_resp = _mock_httpx_response({"error": {"message": "bad model"}}, 400)
+        mock_client = _mock_client(mock_resp)
+
+        with (
+            patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(NonRetriableLLMError),
+        ):
+            await provider.complete([{"role": "user", "content": "test"}])
+
+    @pytest.mark.asyncio
+    async def test_retriable_error(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_resp = _mock_httpx_response({"error": {"message": "rate limit"}}, 500)
+        mock_client = _mock_client(mock_resp)
+
+        with (
+            patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client),
+            pytest.raises(LLMError),
+        ):
+            await provider.complete([{"role": "user", "content": "test"}])
+
+
+class TestCompleteWithTools:
+    @pytest.mark.asyncio
+    async def test_flat_tools_format(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_tool("submit_review", '{"comments":[]}')
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "submit_review",
+                    "description": "Submit review",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            result = await provider.complete_with_tools(
+                [{"role": "user", "content": "review"}], tools=tools
+            )
+
+        assert result == '{"comments":[]}'
+        body = mock_client.post.call_args[1]["json"]
+        # Tools should be flat — no nested "function" key
+        assert len(body["tools"]) == 1
+        tool = body["tools"][0]
+        assert tool["type"] == "function"
+        assert tool["name"] == "submit_review"
+        assert "function" not in tool
+        assert "arguments" not in tool
+
+    @pytest.mark.asyncio
+    async def test_forced_tool_choice(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_tool("submit_review", "{}")
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "submit_review",
+                    "description": "Submit review",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            await provider.complete_with_tools([{"role": "user", "content": "review"}], tools=tools)
+
+        body = mock_client.post.call_args[1]["json"]
+        assert body["tool_choice"] == {
+            "type": "function",
+            "name": "submit_review",
+        }
+
+    @pytest.mark.asyncio
+    async def test_tool_choice_400_fallback(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+
+        err_resp = _mock_httpx_response({"error": "tool_choice not supported"}, 400)
+        ok_data = _make_resp_tool("submit_review", '{"ok":true}')
+        ok_resp = _mock_httpx_response(ok_data, 200)
+
+        mock_client = _mock_client(None, extra_posts=[err_resp, ok_resp])
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "submit_review",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            result = await provider.complete_with_tools(
+                [{"role": "user", "content": "review"}], tools=tools
+            )
+
+        assert result == '{"ok":true}'
+        assert mock_client.post.call_count == 2
+        # Second call should have "auto" tool_choice
+        second_body = mock_client.post.call_args_list[1][1]["json"]
+        assert second_body["tool_choice"] == "auto"
+
+
+class TestCompleteAgentic:
+    @pytest.mark.asyncio
+    async def test_returns_chat_shaped_dict(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_text_and_tool("let me check", "submit_review", '{"comments":[]}')
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            result = await provider.complete_agentic(
+                [{"role": "user", "content": "review"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "submit_review",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+        assert result["role"] == "assistant"
+        assert result["content"] == "let me check"
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["id"] == "call_1"
+        assert result["tool_calls"][0]["type"] == "function"
+        assert result["tool_calls"][0]["function"]["name"] == "submit_review"
+        assert result["tool_calls"][0]["function"]["arguments"] == '{"comments":[]}'
+
+    @pytest.mark.asyncio
+    async def test_auto_tool_choice_always(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_text("done", _make_resp_usage(10, 10))
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            await provider.complete_agentic(
+                [{"role": "user", "content": "test"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "submit_review",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            )
+
+        body = mock_client.post.call_args[1]["json"]
+        assert body["tool_choice"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_roundtrip_assistant_tool_and_tool_result(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_text("result", _make_resp_usage(10, 10))
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        messages = [
+            {"role": "user", "content": "review this"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": '{"path": "foo.py"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "print('hello')",
+            },
+        ]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read_file",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            await provider.complete_agentic(messages, tools=tools)
+
+        body = mock_client.post.call_args[1]["json"]
+        input_items = body["input"]
+
+        func_items = [i for i in input_items if i.get("type") == "function_call"]
+        assert len(func_items) == 1
+        func = func_items[0]
+        assert func["name"] == "read_file"
+        assert func["call_id"] == "call_1"
+
+        output_items = [i for i in input_items if i.get("type") == "function_call_output"]
+        assert len(output_items) == 1
+        assert output_items[0]["call_id"] == "call_1"
+        assert output_items[0]["output"] == "print('hello')"
+
+
+class TestCreateLlmDispatch:
+    def test_responses_style(self):
+        provider = create_llm(LLMConfig(api_style="responses"))
+        assert isinstance(provider, ResponsesProvider)
+
+    def test_chat_style(self):
+        from mira.llm.provider import LLMProvider
+
+        provider = create_llm(LLMConfig(api_style="chat"))
+        assert isinstance(provider, LLMProvider)
+
+    def test_bedrock_ignores_api_style(self):
+        from mira.llm.bedrock import BedrockProvider
+
+        provider = create_llm(LLMConfig(provider="bedrock", api_style="responses"))
+        assert isinstance(provider, BedrockProvider)
+
+
+class TestReviewAndWalkthrough:
+    @pytest.mark.asyncio
+    async def test_review_calls_complete_with_tools(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_tool("submit_review", '{"comments":[]}')
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            result = await provider.review([{"role": "user", "content": "review"}])
+
+        assert result == '{"comments":[]}'
+
+    @pytest.mark.asyncio
+    async def test_walkthrough_calls_complete_with_tools(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_tool("submit_walkthrough", '{"summary":"x","file_changes":[]}')
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            result = await provider.walkthrough([{"role": "user", "content": "wt"}])
+
+        assert result == '{"summary":"x","file_changes":[]}'
+
+
+class TestCountTokens:
+    def test_estimates_tokens(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        assert provider.count_tokens("hello world") == 2  # 11 chars // 4
+        assert provider.count_tokens("") == 0
+        assert provider.count_tokens("a" * 100) == 25
+
+
+class TestUsage:
+    def test_usage_before_calls(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        usage = provider.usage
+        assert usage == {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_usage_accumulates(self, config: LLMConfig):
+        provider = ResponsesProvider(config)
+        mock_data = _make_resp_text("result", _make_resp_usage(100, 50))
+        mock_resp = _mock_httpx_response(mock_data, 200)
+        mock_client = _mock_client(mock_resp)
+
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            await provider.complete([{"role": "user", "content": "test"}])
+
+        usage = provider.usage
+        assert usage["prompt_tokens"] == 100
+        assert usage["completion_tokens"] == 50
+        assert usage["total_tokens"] == 150
+
+
+class TestApplyReasoning:
+    @pytest.mark.asyncio
+    async def test_reasoning_rejection_records_fallback(self, config: LLMConfig):
+        """When a model rejects reasoning effort, ResponsesProvider records
+        it so subsequent calls skip reasoning for that model."""
+        config.reasoning_effort = "high"
+        provider = ResponsesProvider(config)
+
+        err_resp = _mock_httpx_response({"error": "reasoning not supported"}, 400)
+        ok_data = _make_resp_text("done", _make_resp_usage(10, 10))
+        ok_resp = _mock_httpx_response(ok_data, 200)
+
+        mock_client = _mock_client(None, extra_posts=[err_resp, ok_resp])
+
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "do_thing", "parameters": {"type": "object"}},
+            }
+        ]
+        with patch("mira.llm.responses.httpx.AsyncClient", return_value=mock_client):
+            await provider.complete_agentic([{"role": "user", "content": "test"}], tools=tools)
+
+        # Model should be recorded in _no_reasoning after rejection
+        assert "gpt-4o" in provider._no_reasoning
+        assert mock_client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_apply_reasoning_adds_reasoning_field(self, config: LLMConfig):
+        """_apply_reasoning adds a reasoning field to the body when effort is set."""
+        config.reasoning_effort = "high"
+        provider = ResponsesProvider(config)
+        body = {"model": "gpt-4o"}
+        provider._apply_reasoning(body)
+        assert "reasoning" in body
+        assert body["reasoning"] == {"effort": "high"}
+
+    @pytest.mark.asyncio
+    async def test_apply_reasoning_skips_when_off(self, config: LLMConfig):
+        """_apply_reasoning is a no-op when reasoning effort is off or None."""
+        provider = ResponsesProvider(config)
+        body = {"model": "gpt-4o", "temperature": 0.1}
+        provider._apply_reasoning(body)
+        assert "reasoning" not in body
+        # Temperature should NOT be popped when reasoning is off
+        assert "temperature" in body
+
+
+class TestResponseMessage:
+    def test_tool_calls_only_yields_none_content(self):
+        from mira.llm.responses import _response_message
+
+        data = {
+            "output": [
+                {
+                    "type": "function_call",
+                    "id": "call_1",
+                    "call_id": "call_1",
+                    "name": "submit_review",
+                    "arguments": "{}",
+                }
+            ]
+        }
+        result = _response_message(data)
+        assert result["role"] == "assistant"
+        assert result["content"] is None
+        assert len(result["tool_calls"]) == 1
+
+
+class TestOutputText:
+    def test_fallback_to_output_text(self):
+        from mira.llm.responses import _output_text
+
+        # When no message item exists, fallback to top-level output_text
+        data = {"output_text": "fallback text"}
+        assert _output_text(data) == "fallback text"
+
+    def test_empty_output_returns_empty_string(self):
+        from mira.llm.responses import _output_text
+
+        data = {"output": []}
+        assert _output_text(data) == ""

--- a/ui/mira/src/lib/api/settings.ts
+++ b/ui/mira/src/lib/api/settings.ts
@@ -18,18 +18,30 @@ export const settingsApi = {
       }[]
       review_options: { value: string; label: string; recommended?: boolean }[]
       review_thinking_mode: string
-      thinking_options: { value: string; label: string; recommended?: boolean }[]
+      thinking_options: {
+        value: string
+        label: string
+        recommended?: boolean
+      }[]
+      api_style: string
+      api_style_options: {
+        value: string
+        label: string
+        recommended?: boolean
+      }[]
     }>("/api/settings/models"),
 
   saveModels: (
     indexing_model: string,
     review_model: string,
     review_thinking_mode: string = "off",
+    api_style: string = "chat"
   ) =>
     putJson<{ ok: boolean }>("/api/settings/models", {
       indexing_model,
       review_model,
       review_thinking_mode,
+      api_style,
     }),
 
   getCostEstimate: () =>

--- a/ui/mira/src/pages/settings.tsx
+++ b/ui/mira/src/pages/settings.tsx
@@ -39,6 +39,8 @@ export function SettingsPage() {
   const [reviewOptions, setReviewOptions] = useState<ModelOption[]>([])
   const [thinkingMode, setThinkingMode] = useState("off")
   const [thinkingOptions, setThinkingOptions] = useState<ModelOption[]>([])
+  const [apiStyle, setApiStyle] = useState("chat")
+  const [apiStyleOptions, setApiStyleOptions] = useState<ModelOption[]>([])
   const [savingModels, setSavingModels] = useState(false)
   const [modelsSaved, setModelsSaved] = useState(false)
 
@@ -74,6 +76,8 @@ export function SettingsPage() {
       setReviewOptions(m.review_options)
       setThinkingMode(m.review_thinking_mode)
       setThinkingOptions(m.thinking_options)
+      setApiStyle(m.api_style ?? "chat")
+      setApiStyleOptions(m.api_style_options ?? [])
     })
     api.getGlobalSettings().then((s) => {
       setEffective(
@@ -99,7 +103,7 @@ export function SettingsPage() {
 
   const saveModels = async () => {
     setSavingModels(true)
-    await api.saveModels(indexingModel, reviewModel, thinkingMode)
+    await api.saveModels(indexingModel, reviewModel, thinkingMode, apiStyle)
     setSavingModels(false)
     setModelsSaved(true)
     setTimeout(() => setModelsSaved(false), 2000)
@@ -355,7 +359,9 @@ export function SettingsPage() {
               </p>
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium">Review Thinking Mode</label>
+              <label className="text-sm font-medium">
+                Review Thinking Mode
+              </label>
               <Select value={thinkingMode} onValueChange={setThinkingMode}>
                 <SelectTrigger>
                   <SelectValue />
@@ -371,10 +377,32 @@ export function SettingsPage() {
               <p className="text-xs text-muted-foreground">
                 Extended reasoning budget for reviews — improves depth on
                 capable models at the cost of latency and tokens. Works on
-                OpenRouter and Bedrock (Claude); on other endpoints it's
-                skipped automatically when unsupported.
+                OpenRouter and Bedrock (Claude); on other endpoints it's skipped
+                automatically when unsupported.
               </p>
             </div>
+            {backend !== "bedrock" && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium">API Protocol</label>
+                <Select value={apiStyle} onValueChange={setApiStyle}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {apiStyleOptions.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Protocol used to talk to this endpoint. Responses API requires
+                  a server exposing /responses (OpenAI and compatible proxies);
+                  Chat Completions works everywhere.
+                </p>
+              </div>
+            )}
             <div className="flex items-center gap-3">
               <Button size="sm" onClick={saveModels} disabled={savingModels}>
                 {savingModels && (


### PR DESCRIPTION
<!--
Thanks for contributing to Mira!

Before opening this PR, please ensure:
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

Security fixes should be reported privately first — see SECURITY.md.
-->

## Summary

- Added **ResponsesProvider**, a new LLM provider subclass that speaks OpenAI's `/responses` protocol as an alternative to the existing `/chat/completions` path.
- Introduced `LLMConfig.api_style` field (`"chat"` | `"responses"`) with DB persistence, config-file fallback via `resolve_api_style()`, and dispatch logic in `create_llm()`.
- Exposed `api_style` selection in the frontend **Settings → Models** panel (hidden for Bedrock providers) with full round-trip through the settings client.
- Added 560+ lines of tests covering `api_style` resolution, `ResponsesProvider` parity, and admin endpoint schemas.

## Motivation

OpenAI's `/responses` protocol is the newer standard for LLM interactions. Many providers now support it exclusively or prefer it over `/chat/completions`. This change lets users switch API protocols from the UI without any code changes — the selected style is persisted per-provider in the database and falls back to a global config default.

## Changes

### Backend
- **Extracted `OpenAICompatibleProvider` base class** from the existing provider: shared retry logic, header construction, reasoning parsing, and model-fallback behavior.
- **New `src/mira/llm/responses.py`** — `ResponsesProvider` subclass implementing full parity (chat, streaming, tool use, reasoning) over the `/responses` endpoint.
- **`LLMConfig.api_style`** column added with Alembic migration; `resolve_api_style()` provides DB → config-file fallback chain.
- **`create_llm()`** now dispatches to `ResponsesProvider` when `api_style == "responses"`.
- **Admin endpoints** — added `ModelsResponse`/`ModelsUpdate` Pydantic schemas and wired them to the existing admin router.
- Restored `_get_api_key` re-export from `llm/__init__.py`.

### Frontend
- Added **API protocol `<Select>` dropdown** in Settings → Models, allowing per-provider toggle between `chat` and `responses`.
- Dropdown is hidden for Bedrock providers (which don't support the Responses API).
- Settings client updated to round-trip `api_style` on save/load.

### Tests
- `tests/test_api_style.py` — 170 lines testing `resolve_api_style()` fallback chain, DB persistence, and config override behavior.
- `tests/test_responses_provider.py` — 561 lines verifying ResponsesProvider parity: chat completions, streaming, tool calls, reasoning extraction, and error handling.

## Test plan

- Ran `uv run pytest tests/test_api_style.py tests/test_responses_provider.py` — all passing.
- Manual verification: toggled `api_style` in Settings → Models, confirmed DB persistence and runtime dispatch to the correct provider class.
- Lint/format/type checks clean (`ruff`, `mypy`, `tsc --noEmit`).

## Notes for reviewers

- The `OpenAICompatibleProvider` base class is the key refactoring — it captured the shared surface between chat and responses providers. Review that class for any missed shared behavior.
- The Alembic migration for `api_style` is auto-generated; verify the column default and nullable behavior match expectations.
- No changes to existing ChatCompletionsProvider behavior — it remains the default (`api_style="chat"`).
