### PR TITLE
feat: enable agentic reviewer tools on indexed repos

### DIFF
--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -203,11 +203,12 @@ class ReviewConfig(BaseModel):
     # findings).
     security_pass: bool = True
 
-    # When the repo is not indexed, give the reviewer LLM tools (`read_file`,
-    # `grep_repo`) it can call to fetch cross-file context on demand. Closes
-    # the gap on Java/Go cross-file findings that JIT pre-fetch can't reach
-    # (those languages need build-system parsing to resolve imports).
-    # No effect when the repo is indexed.
+    # Give the reviewer LLM tools (`read_file`, `grep_repo`) to fetch
+    # cross-file context on demand. On unindexed repos this closes the
+    # Java/Go gaps JIT pre-fetch can't reach; on indexed repos it lets the
+    # reviewer trace callers and dispatch points beyond the pre-fetched
+    # index context. Disable to force single-shot reviews (cheaper, less
+    # thorough).
     agentic_tools: bool = True
 
     # Whether the JIT cross-file resolver should attempt Java + Go imports.

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -1065,28 +1065,29 @@ class ReviewEngine:
                     index_has_data_for_changed = bool(store.get_summaries(changed_paths))
                     self._jit_needed = not index_has_data_for_changed
                     self._index_was_empty = not bool(store.all_paths())
+
+                    # Hoisted: agentic fetcher/tree setup runs whenever a source fetcher exists
+                    # (indexed or not), so the reviewer tools are available on indexed repos too.
+                    tree_paths: set[str] | None = None
+                    if source_fetcher is not None and (
+                        self.config.review.agentic_tools or not index_has_data_for_changed
+                    ):
+                        self._agentic_source_fetcher = source_fetcher
+                        if hasattr(self.provider, "get_repo_tree"):
+                            try:
+                                tree_paths = set(
+                                    await self.provider.get_repo_tree(pr_info, pr_info.head_branch)
+                                )
+                            except Exception as exc:
+                                logger.debug("Repo tree fetch failed: %s", exc)
+                        self._agentic_repo_tree = sorted(tree_paths) if tree_paths else []
+
                     if not index_has_data_for_changed and source_fetcher is not None:
                         try:
                             from mira.index.jit_context import (
                                 build_jit_cross_file_context,
                             )
 
-                            tree_paths: set[str] | None = None
-                            if hasattr(self.provider, "get_repo_tree"):
-                                try:
-                                    tree_paths = set(
-                                        await self.provider.get_repo_tree(
-                                            pr_info,
-                                            pr_info.head_branch,
-                                        )
-                                    )
-                                except Exception as exc:
-                                    logger.debug(
-                                        "JIT: tree fetch failed: %s",
-                                        exc,
-                                    )
-                            self._agentic_source_fetcher = source_fetcher
-                            self._agentic_repo_tree = sorted(tree_paths) if tree_paths else []
                             jit = await build_jit_cross_file_context(
                                 changed_files=filtered,
                                 source_fetcher=source_fetcher,
@@ -1257,7 +1258,6 @@ class ReviewEngine:
                     raw_response = ""
                     use_agentic = (
                         self.config.review.agentic_tools
-                        and getattr(self, "_jit_needed", False)
                         and self._agentic_source_fetcher is not None
                     )
                     if use_agentic:

--- a/src/mira/core/passes.py
+++ b/src/mira/core/passes.py
@@ -49,7 +49,7 @@ async def agentic_review_loop(
     if convo and convo[0].get("role") == "system":
         convo[0]["content"] = (
             convo[0]["content"] + "\n\n## Tools\n\n"
-            "This repo isn't indexed, so you have two helpers for "
+            "You have two helpers for "
             "cross-file checks: `read_file(path)` and "
             "`grep_repo(pattern, path_glob?, path_only?)`. Use them when, "
             "and ONLY when, you need to verify a cross-file claim before "

--- a/src/mira/llm/agentic_tools.py
+++ b/src/mira/llm/agentic_tools.py
@@ -1,14 +1,12 @@
-"""Tools the reviewer LLM can call when the repo isn't indexed.
+"""Tools the reviewer LLM can call during review (`read_file`, `grep_repo`).
 
-When a repo has no pre-built index, JIT cross-file context covers Python /
-JS / TS / Ruby (parseable imports) but leaves Java and Go gaps because their
-import resolution needs build-system context. To close that gap, give the
-reviewer two tools — `read_file` and `grep_repo` — and let it pull the
-specific cross-file context it actually needs to verify a candidate finding.
+On unindexed repos the tools cover what JIT pre-fetch can't reach
+(Java/Go import resolution); on indexed repos they let the model trace
+callers and dispatch points beyond the pre-fetched index context.
 
 This module owns the tool *schemas* and a per-review *executor* that
 dispatches calls, caches results, and hard-caps total output. The agentic
-loop itself lives in `engine.py:_review_chunk`.
+loop itself lives in ``passes.py:agentic_review_loop``.
 """
 
 from __future__ import annotations

--- a/src/mira/llm/prompts/templates/review.jinja2
+++ b/src/mira/llm/prompts/templates/review.jinja2
@@ -1,4 +1,4 @@
-You are Mira, an expert AI code reviewer. Your job is to review pull request diffs and provide high-quality, actionable feedback. A clean PR with zero comments is a perfectly good outcome — only speak up when you have something genuinely worth saying.
+You are Mira, an expert AI code reviewer. Your job is to review pull request diffs and provide high-quality, actionable feedback. A clean PR with zero comments is a good outcome, but a missed real bug is worse than a comment you can defend. When unsure whether something is a problem, investigate with the codebase context and tools available before deciding to stay silent.
 
 ## Instructions
 
@@ -14,7 +14,7 @@ You are Mira, an expert AI code reviewer. Your job is to review pull request dif
 - The `suggestion` field must contain raw replacement code only — do NOT wrap it in backticks or markdown code fences. It will be automatically placed inside a code block.
 - In `body`, use single backticks for inline code references. Do NOT use triple-backtick code blocks — they break the comment formatting.
 - Set confidence to reflect how certain you are (0.0–1.0). Only include comments with confidence >= {{ confidence_threshold }}.
-- Aim for **{{ max_comments }} or fewer** comments. Fewer is better — every comment costs the developer's attention.
+- Aim for **{{ max_comments }} or fewer** comments. Do not suppress a genuine issue just to stay under the target — but never pad with trivia either.
 {% if has_code_context %}
 - You have access to diff hunks, codebase context, and **actual source code** of affected functions fetched from the PR's head branch. Use this to verify interface contracts (parameter types, return types, call signatures) and check for pattern consistency and potential side effects on dependent code.
 - Do not suggest changes that duplicate existing functionality visible in the source code or summaries.
@@ -31,6 +31,15 @@ You are Mira, an expert AI code reviewer. Your job is to review pull request dif
 {% else %}
 - You may suggest improvements for code quality, readability, and performance in addition to bugs.
 {% endif %}
+
+## Cross-Boundary Tracing
+
+For every new type, variant, value, or behavior the patch introduces that crosses a function or module boundary (event, message, command, enum variant, queue item, IPC payload, callback, hook):
+1. Locate the **dispatch point** — the switch, router, filter chain, handler registry, or loop body that receives and routes values of that kind on the **consuming** side.
+2. Confirm the new value has an explicit branch, or that the existing catch-all forwards it correctly.
+3. If it falls through to a silent drop, no-op, or discard (e.g. an unmatched `if`/`switch` that simply returns), report it as a defect.
+
+The dispatch point is frequently **outside the diff**. Use the codebase context provided and the `read_file`/`grep_repo` tools (when available) to read the consuming side before concluding the producing side is correct. Tracing only the emitting code while skipping the consuming routing logic is the single most common source of missed integration bugs.
 
 ## Do NOT Suggest
 
@@ -53,8 +62,8 @@ You only know what's in the diff and the project context provided to you. You do
 
 - **Do NOT flag model IDs, package versions, library names, or API endpoints as "may not exist" or "may be invalid"** unless the diff itself shows clear evidence (a typo, a reference to a removed symbol, etc.). Your training cutoff is in the past — versions you don't recognise are usually real, not invalid.
 - **Do NOT speculate about external systems** — what versions of OpenRouter / npm / PyPI / etc. currently host. If the only basis for a comment is "I don't recognise this name", drop the comment.
-- **Do NOT make claims about timing, ordering, or concurrency that depend on lines you can't see.** Async/await ordering arguments must cite specific lines in the diff that prove the race exists. If your reasoning is "a concurrent caller could observe X before Y", verify the caller actually exists in the shown code before flagging.
-- **Hedged language is a smell.** If you find yourself writing "may not be", "could potentially", "appears to" without a concrete line citation, the comment isn't ready. Either cite specifically or drop it.
+- **Do NOT make claims about timing, ordering, or concurrency that depend on lines you can't see.** Async/await ordering arguments must cite specific lines in the diff that prove the race exists. If your reasoning is "a concurrent caller could observe X before Y", verify the caller actually exists — in the shown code, in the provided codebase context, or via the tools when available — before flagging.
+- **Hedged language is a smell.** If you find yourself writing "may not be", "could potentially", "appears to" without a concrete line citation, the comment isn't ready. Verify it with the codebase context or the tools available; if you still can't cite specifically, drop it.
 
 ## Severity Guide
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2048,3 +2048,108 @@ class TestRestrictDiffToPaths:
         out = _restrict_diff_to_paths(_TWO_FILE_DIFF, {"src/a.py"})
         patch_set = parse_diff(out)
         assert [f.path for f in patch_set.files] == ["src/a.py"]
+
+
+class TestAgenticToolsOnIndexedRepos:
+    """Agentic tools should be available on indexed repos when enabled."""
+
+    def _make_provider(self) -> MagicMock:
+        from mira.models import PRInfo
+
+        mock_provider = MagicMock()
+        mock_provider.get_pr_info = AsyncMock(
+            return_value=PRInfo(
+                title="t",
+                description="",
+                base_branch="main",
+                head_branch="f",
+                url="https://github.com/test/repo/pull/1",
+                number=1,
+                owner="test",
+                repo="repo",
+            )
+        )
+        mock_provider.get_pr_diff = AsyncMock(return_value=_TWO_FILE_DIFF)
+        mock_provider.get_repo_tree = AsyncMock(return_value=["src/a.py", "src/b.py"])
+        mock_provider.get_unresolved_bot_threads = AsyncMock(return_value=[])
+        mock_provider.find_bot_comment = AsyncMock(return_value=None)
+        mock_provider.post_comment = AsyncMock()
+        mock_provider.update_comment = AsyncMock()
+        mock_provider.resolve_outdated_review_threads = AsyncMock(return_value=0)
+        return mock_provider
+
+    @pytest.mark.asyncio
+    async def test_fetcher_set_on_indexed_repo_with_agentic_tools(
+        self, monkeypatch, tmp_path
+    ):
+        """When agentic_tools=True and index has data, _agentic_source_fetcher
+        is set so the reviewer can use read_file/grep_repo."""
+        from unittest.mock import MagicMock
+
+        from mira.config import MiraConfig
+        from mira.core.engine import ReviewEngine
+        from mira.index.store import FileSummary, IndexStore
+
+        monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+
+        store = IndexStore.open("test", "repo")
+        store.upsert_summary(
+            FileSummary(path="src/a.py", language="python", summary="Module a", content_hash="h")
+        )
+        store.close()
+
+        config = MiraConfig()
+        config.review.agentic_tools = True
+        config.review.code_context = True
+        config.review.security_pass = False
+        config.review.self_critique = False
+
+        mock_llm = MagicMock()
+        mock_llm.review = AsyncMock(return_value="{}")
+        mock_llm.count_tokens = MagicMock(return_value=100)
+        mock_llm.usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+        engine = ReviewEngine(
+            config=config, llm=mock_llm, provider=self._make_provider()
+        )
+        await engine.review_pr("https://github.com/test/repo/pull/1")
+
+        assert engine._agentic_source_fetcher is not None
+
+    @pytest.mark.asyncio
+    async def test_fetcher_not_set_when_agentic_tools_disabled(
+        self, monkeypatch, tmp_path
+    ):
+        """When agentic_tools=False, _agentic_source_fetcher stays None even
+        on indexed repos."""
+        from unittest.mock import MagicMock
+
+        from mira.config import MiraConfig
+        from mira.core.engine import ReviewEngine
+        from mira.index.store import FileSummary, IndexStore
+
+        monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+
+        store = IndexStore.open("test", "repo")
+        store.upsert_summary(
+            FileSummary(path="src/a.py", language="python", summary="Module a", content_hash="h")
+        )
+        store.close()
+
+        config = MiraConfig()
+        config.review.agentic_tools = False
+        config.review.code_context = True
+        config.review.security_pass = False
+        config.review.self_critique = False
+
+        mock_llm = MagicMock()
+        mock_llm.review = AsyncMock(return_value="{}")
+        mock_llm.count_tokens = MagicMock(return_value=100)
+        mock_llm.usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+        engine = ReviewEngine(
+            config=config, llm=mock_llm, provider=self._make_provider()
+        )
+        await engine.review_pr("https://github.com/test/repo/pull/1")
+
+        assert engine._agentic_source_fetcher is None

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2079,9 +2079,7 @@ class TestAgenticToolsOnIndexedRepos:
         return mock_provider
 
     @pytest.mark.asyncio
-    async def test_fetcher_set_on_indexed_repo_with_agentic_tools(
-        self, monkeypatch, tmp_path
-    ):
+    async def test_fetcher_set_on_indexed_repo_with_agentic_tools(self, monkeypatch, tmp_path):
         """When agentic_tools=True and index has data, _agentic_source_fetcher
         is set so the reviewer can use read_file/grep_repo."""
         from unittest.mock import MagicMock
@@ -2109,17 +2107,13 @@ class TestAgenticToolsOnIndexedRepos:
         mock_llm.count_tokens = MagicMock(return_value=100)
         mock_llm.usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
-        engine = ReviewEngine(
-            config=config, llm=mock_llm, provider=self._make_provider()
-        )
+        engine = ReviewEngine(config=config, llm=mock_llm, provider=self._make_provider())
         await engine.review_pr("https://github.com/test/repo/pull/1")
 
         assert engine._agentic_source_fetcher is not None
 
     @pytest.mark.asyncio
-    async def test_fetcher_not_set_when_agentic_tools_disabled(
-        self, monkeypatch, tmp_path
-    ):
+    async def test_fetcher_not_set_when_agentic_tools_disabled(self, monkeypatch, tmp_path):
         """When agentic_tools=False, _agentic_source_fetcher stays None even
         on indexed repos."""
         from unittest.mock import MagicMock
@@ -2147,9 +2141,7 @@ class TestAgenticToolsOnIndexedRepos:
         mock_llm.count_tokens = MagicMock(return_value=100)
         mock_llm.usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
-        engine = ReviewEngine(
-            config=config, llm=mock_llm, provider=self._make_provider()
-        )
+        engine = ReviewEngine(config=config, llm=mock_llm, provider=self._make_provider())
         await engine.review_pr("https://github.com/test/repo/pull/1")
 
         assert engine._agentic_source_fetcher is None

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -220,3 +220,21 @@ class TestBuildDependencyReviewPrompt:
         messages = build_dependency_review_prompt(self._manifest(), existing_packages=[])
         system = messages[0]["content"]
         assert "isn't indexed" in system
+
+
+class TestReviewPromptCrossBoundaryTracing:
+    def test_cross_boundary_tracing_section_present(self):
+        files = [
+            FileDiff(
+                path="test.py",
+                change_type=FileChangeType.MODIFIED,
+                hunks=[HunkInfo(1, 5, 1, 5, "content")],
+                language="python",
+                added_lines=1,
+                deleted_lines=1,
+            )
+        ]
+        config = MiraConfig()
+        messages = build_review_prompt(files, config)
+        system = messages[0]["content"]
+        assert "## Cross-Boundary Tracing" in system


### PR DESCRIPTION
## Summary
Enable agentic reviewer tools on indexed repos and recall-rebalance the review prompt

## Motivation
Mira's reviewer LLM has `read_file`/`grep_repo` tools, but they only activated when the index lacked summaries for the PR's changed files (`_jit_needed`). On indexed repos — the normal case — the reviewer couldn't trace cross-file code (callers, dispatch points), causing it to drop correct findings it couldn't prove from the hunk alone.

The review prompt was also precision-biased ("zero comments is a perfectly good outcome", drop-on-hedge rules), suppressing recall. A missed real bug is worse than a defensible false positive.

## Changes
- **Hoisted fetcher/tree setup** out of the JIT-only branch in `_build_code_context` — the source fetcher and repo tree are now assigned whenever `agentic_tools` is enabled, regardless of index coverage
- **Removed `_jit_needed` gate** from the `use_agentic` decision in `_review_chunk`
- **Recall-rebalanced the review prompt**: encouraging investigation before silence, relaxing the "zero comments" framing, adding a dedicated Cross-Boundary Tracing section for dispatch-point verification, and updating concurrency/hedging guidance to reference available tools
- **Updated docstrings and config comments** that incorrectly claimed agentic tools were unindexed-only
- **Three new tests**: indexed-repo fetcher assertion, disabled flag negative test, prompt rendering verification

## Notes
One additional `get_repo_tree` API call per review on indexed repos when `agentic_tools` is on. Failure-tolerant — tree fetch failure leaves an empty tree, tools still function.
