### PR TITLE
feat: dedicated security model tier + OSV scan

### DIFF
--- a/src/mira/cli.py
+++ b/src/mira/cli.py
@@ -217,7 +217,12 @@ def review(
             ) from err
 
     engine = ReviewEngine(
-        config=config, llm=llm, provider=github_provider, dry_run=dry_run, indexing_llm=indexing_llm, security_llm=security_llm
+        config=config,
+        llm=llm,
+        provider=github_provider,
+        dry_run=dry_run,
+        indexing_llm=indexing_llm,
+        security_llm=security_llm,
     )
 
     try:

--- a/src/mira/cli.py
+++ b/src/mira/cli.py
@@ -188,6 +188,7 @@ def review(
 
     llm = create_llm(llm_config_for("review", config.llm))
     indexing_llm = create_llm(llm_config_for("indexing", config.llm))
+    security_llm = create_llm(llm_config_for("security", config.llm))
 
     git_token = token or github_token
     github_provider = None
@@ -216,7 +217,7 @@ def review(
             ) from err
 
     engine = ReviewEngine(
-        config=config, llm=llm, provider=github_provider, dry_run=dry_run, indexing_llm=indexing_llm
+        config=config, llm=llm, provider=github_provider, dry_run=dry_run, indexing_llm=indexing_llm, security_llm=security_llm
     )
 
     try:

--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -40,6 +40,11 @@ class LLMConfig(BaseModel):
     # Optional per-purpose overrides. Fall back to `model` if not set.
     indexing_model: str | None = None
     review_model: str | None = None
+    # Optional dedicated model for the security review pass. Falls back to
+    # `review_model`, then `model` — deliberately never to `indexing_model`:
+    # the security sweep is the highest-stakes pass and must not silently
+    # downgrade to the indexing tier.
+    security_model: str | None = None
     # Extended-thinking effort for reviews ("low"/"medium"/"high"; None/"off" =
     # no reasoning). `review_reasoning_effort` is the mira.yaml-level override;
     # `reasoning_effort` is the resolved value the provider reads (set by
@@ -192,16 +197,19 @@ class ReviewConfig(BaseModel):
     self_critique: bool = True
 
     # Run a dedicated security review pass in parallel with the main review.
-    # Uses the *indexing* tier LLM with a security-focused prompt (XSS,
-    # injection, auth bypass, CSRF, SSRF, origin validation, deserialization,
-    # crypto). The main pass on the review tier still catches deeper
-    # chained-inference security bugs — this pass is the cheap pattern-
-    # matching sweep on top. Set ``llm.indexing_model`` to the same model
-    # as ``llm.review_model`` if you want the heavy model on every pass.
-    # Findings are merged into the main review's comments list and go
-    # through the same noise filter (dedup against overlapping main-pass
-    # findings).
+    # Uses the security tier (`llm.security_model`, falling back to the
+    # review model). The main pass on the review tier still catches deeper
+    # chained-inference security bugs — this pass is the focused pattern
+    # sweep (XSS, injection, auth bypass, CSRF, SSRF, origin validation,
+    # deserialization, crypto) on top. Findings merge into the main review's
+    # comments and go through the same noise filter.
     security_pass: bool = True
+
+    # Deterministic CVE check on changed dependency manifests: packages added
+    # or version-bumped by the PR are queried against OSV.dev at review time
+    # (the background poller only re-scans the repo hourly, post-merge). No
+    # LLM involved — one batch HTTP request per PR with manifest changes.
+    osv_scan: bool = True
 
     # Give the reviewer LLM tools (`read_file`, `grep_repo`) to fetch
     # cross-file context on demand. On unindexed repos this closes the

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -130,9 +130,6 @@ def _clamp_confidence_to_findings(
 # Paths excluded from the dedicated security pass — see core/passes.py.
 # Keep conservative: anything that might house auth/crypto/origin/injection logic stays in.
 _SECURITY_PASS_SKIP_PATTERNS = (
-    # DB migrations: schema changes, indexes — no request handling.
-    "db/migrate/",
-    "/migrations/",
     # Tests: assertions about behavior, not the behavior itself.
     "spec/",
     "/__tests__/",
@@ -183,7 +180,7 @@ def _security_relevant_files(files: list) -> list:
     """Return the subset of files plausibly containing security findings.
 
     The dedicated security pass runs as one LLM call across the entire
-    diff. When the diff is dominated by migrations / specs / lockfiles,
+    diff. When the diff is dominated by specs / lockfiles,
     those non-code files dilute attention away from the actual vulnerable
     code. This filter trims the obvious-no-finding cases so the model can
     focus.
@@ -386,10 +383,12 @@ class ReviewEngine:
         bot_name: str = "miracodeai",
         dry_run: bool = False,
         indexing_llm: LLMProviderProtocol | None = None,
+        security_llm: LLMProviderProtocol | None = None,
     ) -> None:
         self.config = config
         self.llm = llm
         self.indexing_llm = indexing_llm or llm
+        self.security_llm = security_llm or llm
         self.provider = provider
         self.bot_name = bot_name
         self.dry_run = dry_run
@@ -1392,7 +1391,7 @@ class ReviewEngine:
                 filtered,
                 _security_relevant_files(filtered),
                 pr_title,
-                indexing_llm=self.indexing_llm,
+                security_llm=self.security_llm,
             )
             if self.config.review.security_pass
             else _asyncio.sleep(0, result=[])
@@ -1404,6 +1403,7 @@ class ReviewEngine:
         # present (empty list on an unindexed repo — pass falls back to the diff).
         manifest_files = manifest_candidates
         existing_packages: list[str] = []
+        pr_source_fetcher = None
         if manifest_files:
             pr_info = getattr(self, "_pr_info", None)
             if pr_info is not None:
@@ -1419,6 +1419,12 @@ class ReviewEngine:
                         _pkg_store.close()
                 except Exception as exc:
                     logger.debug("Manifest package lookup failed: %s", exc)
+                if self.provider is not None:
+                    from mira.index.context import ProviderSourceFetcher
+
+                    pr_source_fetcher = ProviderSourceFetcher(
+                        self.provider, pr_info, pr_info.head_branch
+                    )
         dependency_task = _asyncio.create_task(
             dependency_review_pass(
                 self.llm,
@@ -1431,8 +1437,16 @@ class ReviewEngine:
             else _asyncio.sleep(0, result=[])
         )
 
-        chunk_results, security_comments, dependency_comments = await _asyncio.gather(
-            review_task, security_task, dependency_task
+        from mira.security.pr_scan import scan_manifest_changes
+
+        osv_task = _asyncio.create_task(
+            scan_manifest_changes(manifest_files, pr_source_fetcher)
+            if manifest_files and self.config.review.osv_scan and pr_source_fetcher is not None
+            else _asyncio.sleep(0, result=[])
+        )
+
+        chunk_results, security_comments, dependency_comments, osv_comments = await _asyncio.gather(
+            review_task, security_task, dependency_task, osv_task
         )
 
         all_comments: list[ReviewComment] = []
@@ -1446,7 +1460,10 @@ class ReviewEngine:
                 summaries.append(summary_text)
         audit.append({"stage": "drafted", "chunk": "security", "count": len(security_comments)})
         all_comments.extend(security_comments)
+        audit.append({"stage": "drafted", "chunk": "dependency", "count": len(dependency_comments)})
         all_comments.extend(dependency_comments)
+        audit.append({"stage": "drafted", "chunk": "osv", "count": len(osv_comments)})
+        all_comments.extend(osv_comments)
 
         all_comments = [classify_severity(c) for c in all_comments]
 

--- a/src/mira/core/passes.py
+++ b/src/mira/core/passes.py
@@ -168,7 +168,9 @@ async def security_review_pass(
 
     logger.info(
         "Security pass: splitting %d files into %d chunks (single-call budget %d tokens)",
-        len(target_files), len(chunks), budget,
+        len(target_files),
+        len(chunks),
+        budget,
     )
     sem = asyncio.Semaphore(load_config().review.max_concurrent_chunks)
 

--- a/src/mira/core/passes.py
+++ b/src/mira/core/passes.py
@@ -7,6 +7,7 @@ the heavyweight review model isn't paying for verification work.
 
 from __future__ import annotations
 
+import asyncio
 import json as _json
 import logging
 
@@ -120,14 +121,22 @@ def _indexing_llm(fallback: LLMProvider) -> LLMProvider:
         return fallback
 
 
+def _security_llm(fallback: LLMProvider) -> LLMProvider:
+    """Build a security-tier provider, falling back to ``fallback`` on error."""
+    try:
+        return LLMProvider(llm_config_for("security", load_config().llm))
+    except Exception:
+        return fallback
+
+
 async def security_review_pass(
     llm: LLMProvider,
     files: list,
     narrowed: list,
     pr_title: str = "",
-    indexing_llm: LLMProvider | None = None,
+    security_llm: LLMProvider | None = None,
 ) -> list[ReviewComment]:
-    """Dedicated security review on the configured indexing model.
+    """Dedicated security review on the security tier (``security_model`` → review model).
 
     Runs in parallel with the main review. Returns ``[]`` on any failure
     so a transient LLM/API error doesn't kill the main review.
@@ -135,32 +144,65 @@ async def security_review_pass(
     `narrowed` is `files` with migrations/lockfiles/specs stripped (caller
     decides what counts); falls back to `files` if `narrowed` is empty.
 
-    `indexing_llm`, when passed, is the caller's already-built indexing-tier
+    `security_llm`, when passed, is the caller's already-built security-tier
     provider; otherwise one is constructed from ``load_config()``.
     """
     if not files:
         return []
 
     target_files = narrowed or files
+    if not target_files:
+        return []
+    sec_llm = security_llm or _security_llm(llm)
 
-    security_llm = indexing_llm or _indexing_llm(llm)
+    budget = int(load_config().llm.max_context_tokens * 0.75)
+    from mira.core.chunker import chunk_files
 
-    messages = build_security_review_prompt(files=target_files, pr_title=pr_title)
+    chunks = chunk_files(
+        target_files,
+        budget,
+        provider=sec_llm if hasattr(sec_llm, "count_tokens") else None,
+    )
+    if len(chunks) <= 1:
+        return await _security_scan_once(sec_llm, llm, target_files, pr_title)
+
+    logger.info(
+        "Security pass: splitting %d files into %d chunks (single-call budget %d tokens)",
+        len(target_files), len(chunks), budget,
+    )
+    sem = asyncio.Semaphore(load_config().review.max_concurrent_chunks)
+
+    async def _bounded(chunk_files_list: list) -> list[ReviewComment]:
+        async with sem:
+            return await _security_scan_once(sec_llm, llm, chunk_files_list, pr_title)
+
+    results = await asyncio.gather(*[_bounded(c.files) for c in chunks])
+    return [c for chunk_comments in results for c in chunk_comments]
+
+
+async def _security_scan_once(
+    sec_llm: LLMProvider,
+    fallback_llm: LLMProvider,
+    files: list,
+    pr_title: str,
+) -> list[ReviewComment]:
+    """Run the security scan on a single chunk of files."""
+    messages = build_security_review_prompt(files=files, pr_title=pr_title)
     try:
-        raw = await security_llm.complete_with_tools(
+        raw = await sec_llm.complete_with_tools(
             messages=messages,
             tools=[SUBMIT_REVIEW_TOOL],
             temperature=0.0,
         )
     except Exception as exc:
         # Retry on the main LLM rather than drop the security pass entirely.
-        if security_llm is not llm:
-            logger.debug(
-                "Security pass on indexing tier failed (%s); retrying on review LLM",
+        if sec_llm is not fallback_llm:
+            logger.warning(
+                "Security pass on security tier failed (%s); retrying on review LLM",
                 exc,
             )
             try:
-                raw = await llm.complete_with_tools(
+                raw = await fallback_llm.complete_with_tools(
                     messages=messages,
                     tools=[SUBMIT_REVIEW_TOOL],
                     temperature=0.0,
@@ -227,7 +269,7 @@ async def dependency_review_pass(
     except Exception as exc:
         # Retry on the main LLM rather than drop the pass entirely.
         if dep_llm is not llm:
-            logger.debug(
+            logger.warning(
                 "Dependency pass on indexing tier failed (%s); retrying on review LLM",
                 exc,
             )

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -357,14 +357,18 @@ class ModelOption(BaseModel):
 class ModelsResponse(BaseModel):
     indexing_model: str
     review_model: str
+    security_model: str
     backend: str  # "openrouter" | "bedrock" | "openai-compatible"
     indexing_source: str  # "dashboard" (DB override) | "config" (mira.yaml)
     review_source: str
+    security_source: str
     # What each model resolves to with no override — the "inherit" target.
     config_indexing_model: str
     config_review_model: str
+    config_security_model: str
     indexing_options: list[ModelOption]
     review_options: list[ModelOption]
+    security_options: list[ModelOption]
     # Extended-thinking effort for reviews ("off"/"low"/"medium"/"high").
     review_thinking_mode: str
     thinking_options: list[ModelOption]
@@ -373,6 +377,7 @@ class ModelsResponse(BaseModel):
 class ModelsUpdate(BaseModel):
     indexing_model: str
     review_model: str
+    security_model: str = ""
     review_thinking_mode: str = "off"
 
 

--- a/src/mira/dashboard/models_config.py
+++ b/src/mira/dashboard/models_config.py
@@ -85,6 +85,20 @@ def get_review_model(config: LLMConfig, db_value: str | None = None) -> str:
     return config.model
 
 
+def get_security_model(config: LLMConfig, db_value: str | None = None) -> str:
+    """Resolve the security-pass model: DB → config.security_model → review tier.
+
+    Never falls back to ``indexing_model`` — the security sweep is the
+    highest-stakes cheap pass, and silently downgrading it to the indexing
+    tier trades security recall for indexing cost savings.
+    """
+    if db_value:
+        return db_value
+    if config.security_model:
+        return config.security_model
+    return get_review_model(config)
+
+
 def get_review_thinking_mode(config: LLMConfig, db_value: str | None = None) -> str | None:
     """Resolve the review thinking mode: DB → config.review_reasoning_effort → None.
 
@@ -117,6 +131,9 @@ def llm_config_for(purpose: str, base: LLMConfig) -> LLMConfig:
             elif purpose == "review":
                 db_model = _app_db.get_setting("review_model")
                 db_thinking = _app_db.get_setting("review_thinking_mode")
+            elif purpose == "security":
+                db_model = _app_db.get_setting("security_model")
+                db_thinking = _app_db.get_setting("review_thinking_mode")
     except Exception:
         pass  # DB not available — resolve from config fields alone
 
@@ -125,6 +142,10 @@ def llm_config_for(purpose: str, base: LLMConfig) -> LLMConfig:
     if purpose == "indexing":
         resolved = get_indexing_model(base, db_model)
         config_model = base.indexing_model
+    elif purpose == "security":
+        resolved = get_security_model(base, db_model)
+        config_model = base.security_model or base.review_model
+        thinking_mode = get_review_thinking_mode(base, db_thinking)
     elif purpose == "review":
         resolved = get_review_model(base, db_model)
         config_model = base.review_model

--- a/src/mira/dashboard/models_config.py
+++ b/src/mira/dashboard/models_config.py
@@ -85,8 +85,16 @@ def get_review_model(config: LLMConfig, db_value: str | None = None) -> str:
     return config.model
 
 
-def get_security_model(config: LLMConfig, db_value: str | None = None) -> str:
+def get_security_model(
+    config: LLMConfig,
+    db_value: str | None = None,
+    db_review_model: str | None = None,
+) -> str:
     """Resolve the security-pass model: DB → config.security_model → review tier.
+
+    The review-tier fallback includes the dashboard's review_model setting
+    (``db_review_model``) — without it, an instance whose review model lives
+    only in the DB silently falls all the way back to ``config.model``.
 
     Never falls back to ``indexing_model`` — the security sweep is the
     highest-stakes cheap pass, and silently downgrading it to the indexing
@@ -96,7 +104,7 @@ def get_security_model(config: LLMConfig, db_value: str | None = None) -> str:
         return db_value
     if config.security_model:
         return config.security_model
-    return get_review_model(config)
+    return get_review_model(config, db_review_model)
 
 
 def get_review_thinking_mode(config: LLMConfig, db_value: str | None = None) -> str | None:
@@ -122,6 +130,7 @@ def llm_config_for(purpose: str, base: LLMConfig) -> LLMConfig:
     """
     db_model: str | None = None
     db_thinking: str | None = None
+    db_review: str | None = None
     try:
         from mira.dashboard.api import _app_db
 
@@ -134,6 +143,7 @@ def llm_config_for(purpose: str, base: LLMConfig) -> LLMConfig:
             elif purpose == "security":
                 db_model = _app_db.get_setting("security_model")
                 db_thinking = _app_db.get_setting("review_thinking_mode")
+                db_review = _app_db.get_setting("review_model")
     except Exception:
         pass  # DB not available — resolve from config fields alone
 
@@ -143,7 +153,7 @@ def llm_config_for(purpose: str, base: LLMConfig) -> LLMConfig:
         resolved = get_indexing_model(base, db_model)
         config_model = base.indexing_model
     elif purpose == "security":
-        resolved = get_security_model(base, db_model)
+        resolved = get_security_model(base, db_model, db_review)
         config_model = base.security_model or base.review_model
         thinking_mode = get_review_thinking_mode(base, db_thinking)
     elif purpose == "review":

--- a/src/mira/dashboard/routers/admin.py
+++ b/src/mira/dashboard/routers/admin.py
@@ -158,13 +158,16 @@ async def get_models() -> ModelsResponse:
         get_indexing_model,
         get_review_model,
         get_review_thinking_mode,
+        get_security_model,
     )
 
     config = load_config()
     db_indexing = _api._app_db.get_setting("indexing_model")
     db_review = _api._app_db.get_setting("review_model")
+    db_security = _api._app_db.get_setting("security_model")
     indexing = get_indexing_model(config.llm, db_indexing)
     review = get_review_model(config.llm, db_review)
+    security = get_security_model(config.llm, db_security, db_review)
     thinking = get_review_thinking_mode(
         config.llm, _api._app_db.get_setting("review_thinking_mode")
     )
@@ -175,13 +178,17 @@ async def get_models() -> ModelsResponse:
     return ModelsResponse(
         indexing_model=indexing,
         review_model=review,
+        security_model=security,
         backend=backend,
         indexing_source="dashboard" if db_indexing else "config",
         review_source="dashboard" if db_review else "config",
+        security_source="dashboard" if db_security else "config",
         config_indexing_model=get_indexing_model(config.llm),
         config_review_model=get_review_model(config.llm),
+        config_security_model=get_security_model(config.llm),
         indexing_options=[ModelOption(**m) for m in build_options(backend, catalog, "indexing")],
         review_options=[ModelOption(**m) for m in build_options(backend, catalog, "review")],
+        security_options=[ModelOption(**m) for m in build_options(backend, catalog, "review")],
         review_thinking_mode=thinking or "off",
         thinking_options=[ModelOption(**m) for m in THINKING_MODES],
     )
@@ -263,6 +270,7 @@ def set_models(body: ModelsUpdate, request: Request) -> dict:
     # registry falls back gracefully for pricing/limits of unknown ids.
     _api._app_db.set_setting("indexing_model", body.indexing_model.strip())
     _api._app_db.set_setting("review_model", body.review_model.strip())
+    _api._app_db.set_setting("security_model", body.security_model.strip())
     # Clear "off" to "" rather than persisting the literal — "off" is the
     # default, and a stored value would shadow a mira.yaml
     # `review_reasoning_effort` override. "" (not None — the column is NOT NULL)

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -136,7 +136,7 @@ class ReviewComment:
     agent_prompt: str | None = None
     # Verbatim diff snippet used by self-critique; stripped before posting.
     existing_code: str = ""
-    # Which pipeline pass produced this ("main" or "security") — lets eval
+    # Which pipeline pass produced this ("main", "security", or "osv") — lets eval
     # artifacts attribute FP share per pass. Not posted anywhere.
     source_pass: str = "main"
 

--- a/src/mira/platforms/handlers.py
+++ b/src/mira/platforms/handlers.py
@@ -105,12 +105,14 @@ async def run_pr_review(
 
     llm = create_llm(llm_config_for("review", config.llm))
     indexing_llm = create_llm(llm_config_for("indexing", config.llm))
+    security_llm = create_llm(llm_config_for("security", config.llm))
     engine = ReviewEngine(
         config=config,
         llm=llm,
         provider=provider,
         bot_name=bot_name,
         indexing_llm=indexing_llm,
+        security_llm=security_llm,
     )
 
     from mira.dashboard.api import _app_db
@@ -183,6 +185,7 @@ async def run_pr_command(
 
     llm = create_llm(llm_config_for("review", config.llm))
     indexing_llm = create_llm(llm_config_for("indexing", config.llm))
+    security_llm = create_llm(llm_config_for("security", config.llm))
 
     normalized = question.lower().strip()
     is_review = normalized in _REVIEW_KEYWORDS
@@ -213,6 +216,7 @@ async def run_pr_command(
             provider=provider,
             bot_name=bot_name,
             indexing_llm=indexing_llm,
+            security_llm=security_llm,
         )
         engine._review_only_paths = set(progress.skipped_paths)  # type: ignore[attr-defined]
         if not review_tracker.try_start(repo_full, number, pr_title, pr_url):
@@ -234,6 +238,7 @@ async def run_pr_command(
             provider=provider,
             bot_name=bot_name,
             indexing_llm=indexing_llm,
+            security_llm=security_llm,
         )
         if not review_tracker.try_start(repo_full, number, pr_title, pr_url):
             logger.info("Review already in progress for %s, skipping", pr_url)

--- a/src/mira/security/pr_scan.py
+++ b/src/mira/security/pr_scan.py
@@ -155,19 +155,21 @@ async def scan_manifest_changes(
             f"Update any associated lockfile entries."
         )
 
-        comments.append(ReviewComment(
-            path=f.path,
-            line=line_no,
-            end_line=None,
-            severity=severity,
-            category="security",
-            title=f"Known vulnerabilities in {q.name}@{q.version}",
-            body=body,
-            confidence=0.9,
-            suggestion=None,
-            agent_prompt=agent_prompt,
-            existing_code=line_text,
-            source_pass="osv",
-        ))
+        comments.append(
+            ReviewComment(
+                path=f.path,
+                line=line_no,
+                end_line=None,
+                severity=severity,
+                category="security",
+                title=f"Known vulnerabilities in {q.name}@{q.version}",
+                body=body,
+                confidence=0.9,
+                suggestion=None,
+                agent_prompt=agent_prompt,
+                existing_code=line_text,
+                source_pass="osv",
+            )
+        )
 
     return comments

--- a/src/mira/security/pr_scan.py
+++ b/src/mira/security/pr_scan.py
@@ -1,0 +1,173 @@
+"""Review-time OSV scan: flag PR-added dependencies with known CVEs.
+
+The background poller (security/poller.py) re-scans indexed repos hourly
+after merge; this module closes the merge-time window by checking only the
+packages a PR *adds or bumps*, anchored to the exact added diff line.
+No LLM involved.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from mira.index.manifests import parse_manifest
+from mira.models import FileDiff, ReviewComment, Severity
+from mira.security.osv import (
+    PackageQuery,
+    normalize_version,
+    osv_ecosystem,
+    query_batch,
+)
+
+if TYPE_CHECKING:
+    from mira.index.context import SourceFetcher
+
+logger = logging.getLogger(__name__)
+
+_MAX_VULNS_PER_COMMENT = 3
+
+
+def _added_line_hits(file_diff: FileDiff, needle: str) -> list[tuple[int, str]]:
+    """(target line number, line text) of added lines containing `needle`.
+
+    Hunk content includes the @@ header (diff_parser stores str(hunk)) —
+    skip it WITHOUT incrementing; target_start is the first body line.
+    """
+    needle_l = needle.lower()
+    hits: list[tuple[int, str]] = []
+    for hunk in file_diff.hunks:
+        line_no = hunk.target_start
+        for raw in hunk.content.splitlines():
+            if raw.startswith("@@"):
+                continue
+            if raw.startswith("+"):
+                if needle_l in raw[1:].lower():
+                    hits.append((line_no, raw[1:]))
+                line_no += 1
+            elif raw.startswith("-"):
+                continue
+            else:
+                line_no += 1
+    return hits
+
+
+_SEVERITY_MAP = {
+    "critical": Severity.BLOCKER,
+    "high": Severity.BLOCKER,
+    "moderate": Severity.WARNING,
+    "low": Severity.SUGGESTION,
+    "unknown": Severity.SUGGESTION,
+}
+
+
+async def scan_manifest_changes(
+    manifest_files: list[FileDiff],
+    fetcher: SourceFetcher,
+    *,
+    timeout_s: float = 15.0,
+) -> list[ReviewComment]:
+    """Flag PR-added packages with known OSV vulnerabilities. Fails open."""
+    if not manifest_files:
+        return []
+
+    queries: list[PackageQuery] = []
+    # (ecosystem, name, version) → (first_line_no, first_line_text)
+    hit_map: dict[tuple[str, str, str], tuple[int, str]] = {}
+
+    for f in manifest_files:
+        try:
+            content = await fetcher.fetch(f.path)
+            if not content:
+                continue
+            packages = parse_manifest(f.path, content)
+        except Exception as exc:
+            logger.debug("Failed to parse manifest %s: %s", f.path, exc)
+            continue
+
+        for pkg in packages:
+            hits = _added_line_hits(f, pkg.name)
+            if not hits:
+                continue
+            eco = osv_ecosystem(pkg.kind)
+            if eco is None:
+                continue
+            ver = normalize_version(pkg.version)
+            if not ver:
+                continue
+            key = (eco, pkg.name, ver)
+            queries.append(PackageQuery(ecosystem=eco, name=pkg.name, version=ver))
+            if key not in hit_map:
+                hit_map[key] = (hits[0][0], hits[0][1])
+
+    if not queries:
+        return []
+
+    try:
+        results = await query_batch(queries, timeout_s=timeout_s)
+    except Exception as exc:
+        logger.warning("OSV review-time scan failed: %s", exc)
+        return []
+
+    if not results:
+        return []
+
+    comments: list[ReviewComment] = []
+    for q in queries:
+        key = (q.ecosystem, q.name, q.version)
+        vulns = results.get(key, [])
+        if not vulns:
+            continue
+        line_no, line_text = hit_map[key]
+
+        severity = max(
+            (_SEVERITY_MAP.get(v.severity, Severity.SUGGESTION) for v in vulns),
+            key=lambda s: int(s),
+        )
+
+        n = len(vulns)
+        bullets: list[str] = []
+        for v in vulns[:_MAX_VULNS_PER_COMMENT]:
+            bullet = f"- [{v.cve_id}]({v.advisory_url}) **{v.severity}**: {v.summary}"
+            if v.fixed_in:
+                bullet += f" — fixed in {v.fixed_in}"
+            bullets.append(bullet)
+
+        body = (
+            f"OSV.dev reports {n} known vulnerabilit{'y' if n == 1 else 'ies'} "
+            f"affecting `{q.name}@{q.version}`, introduced by this PR:\n\n"
+        )
+        body += "\n".join(bullets)
+        if n > _MAX_VULNS_PER_COMMENT:
+            body += f"\n\n…and {n - _MAX_VULNS_PER_COMMENT} more — see the OSV links above."
+
+        all_fixed: list[str] = [v.fixed_in for v in vulns if v.fixed_in]
+        if all_fixed:
+            first_fixed = all_fixed[0]
+            body += f"\n\nUpgrade to {first_fixed} or later."
+
+        distinct_fixes = sorted({v for fv in all_fixed for v in fv.split(", ") if v})
+        fixes_str = ", ".join(distinct_fixes) if distinct_fixes else "see advisory links"
+
+        agent_prompt = (
+            f"In {f.path}, upgrade the dependency {q.name} from {q.version} "
+            f"to a non-vulnerable version ({fixes_str}). "
+            f"Update any associated lockfile entries."
+        )
+
+        comments.append(ReviewComment(
+            path=f.path,
+            line=line_no,
+            end_line=None,
+            severity=severity,
+            category="security",
+            title=f"Known vulnerabilities in {q.name}@{q.version}",
+            body=body,
+            confidence=0.9,
+            suggestion=None,
+            agent_prompt=agent_prompt,
+            existing_code=line_text,
+            source_pass="osv",
+        ))
+
+    return comments

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1769,9 +1769,13 @@ class TestSecurityReviewPass:
         security_llm_mock.count_tokens = MagicMock(return_value=100)
 
         main_llm_mock = MagicMock(spec=LLMProvider)
-        main_llm_mock.complete_with_tools = AsyncMock(side_effect=RuntimeError("should not be called"))
+        main_llm_mock.complete_with_tools = AsyncMock(
+            side_effect=RuntimeError("should not be called")
+        )
 
-        out = await security_review_pass(main_llm_mock, files, files, "title", security_llm=security_llm_mock)
+        out = await security_review_pass(
+            main_llm_mock, files, files, "title", security_llm=security_llm_mock
+        )
         assert len(out) == 1
         security_llm_mock.complete_with_tools.assert_called_once()
         main_llm_mock.complete_with_tools.assert_not_called()
@@ -1792,9 +1796,7 @@ class TestSecurityReviewPass:
                     language="python",
                     added_lines=10,
                     deleted_lines=0,
-                    hunks=[
-                        SimpleNamespace(target_start=1, content=hunk_content)
-                    ],
+                    hunks=[SimpleNamespace(target_start=1, content=hunk_content)],
                 )
             )
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -62,7 +62,8 @@ class TestSecurityFileFilter:
         keep = [k.path for k in _security_relevant_files(files)]
         assert "app/controllers/embed_controller.rb" in keep
         assert "app/assets/javascripts/embed.js" in keep
-        assert all("/migrate/" not in p for p in keep)
+        # Migrations are no longer stripped — DDL can contain security-relevant logic.
+        assert "db/migrate/20131217174004_create_topic_embeds.rb" in keep
         assert all("spec/" not in p for p in keep)
         assert all(not p.endswith(".scss") for p in keep)
         assert all(not p.endswith(".lock") for p in keep)
@@ -1727,6 +1728,91 @@ class TestSecurityReviewPass:
 
         out = await security_review_pass(llm, files, files, "title")
         assert out == []
+
+    @pytest.mark.asyncio
+    async def test_uses_security_llm_not_main_llm(self, sample_diff_text):
+        """When security_llm is passed, it is called — not the main llm."""
+        from mira.core.diff_parser import parse_diff
+        from mira.core.passes import security_review_pass
+
+        files = parse_diff(sample_diff_text).files
+        cited_line = None
+        for h in files[0].hunks:
+            for raw in h.content.splitlines():
+                if raw.startswith("+") and not raw.startswith("+++"):
+                    cited_line = raw[1:]
+                    break
+            if cited_line:
+                break
+
+        canned = json.dumps(
+            {
+                "comments": [
+                    {
+                        "path": files[0].path,
+                        "line": 1,
+                        "severity": "blocker",
+                        "category": "security",
+                        "title": "XSS",
+                        "body": "Reflected XSS.",
+                        "confidence": 0.9,
+                        "existing_code": cited_line,
+                    }
+                ],
+                "summary": "",
+                "metadata": {"reviewed_files": 1},
+            }
+        )
+
+        security_llm_mock = MagicMock(spec=LLMProvider)
+        security_llm_mock.complete_with_tools = AsyncMock(return_value=canned)
+        security_llm_mock.count_tokens = MagicMock(return_value=100)
+
+        main_llm_mock = MagicMock(spec=LLMProvider)
+        main_llm_mock.complete_with_tools = AsyncMock(side_effect=RuntimeError("should not be called"))
+
+        out = await security_review_pass(main_llm_mock, files, files, "title", security_llm=security_llm_mock)
+        assert len(out) == 1
+        security_llm_mock.complete_with_tools.assert_called_once()
+        main_llm_mock.complete_with_tools.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chunking_splits_large_diff(self):
+        """With small budget, security pass splits files into chunks."""
+        from mira.core.passes import security_review_pass
+
+        # Create enough files to trigger chunking with a tiny budget
+        files = []
+        for i in range(5):
+            hunk_content = f"+{'x' * 500}\n" * 10  # ~125 tokens per file
+            files.append(
+                FileDiff(
+                    path=f"src/file{i}.py",
+                    change_type=FileChangeType.MODIFIED,
+                    language="python",
+                    added_lines=10,
+                    deleted_lines=0,
+                    hunks=[
+                        SimpleNamespace(target_start=1, content=hunk_content)
+                    ],
+                )
+            )
+
+        canned = json.dumps({"comments": [], "summary": "", "metadata": {"reviewed_files": 1}})
+
+        llm = MagicMock(spec=LLMProvider)
+        llm.complete_with_tools = AsyncMock(return_value=canned)
+        llm.count_tokens = MagicMock(return_value=100)
+
+        with patch("mira.core.passes.load_config") as mock_cfg:
+            cfg = MiraConfig()
+            cfg.llm.max_context_tokens = 500  # tiny budget forces chunking
+            mock_cfg.return_value = cfg
+
+            out = await security_review_pass(llm, files, files, "title")
+            assert out == []
+            # Should have been called more than once (multiple chunks)
+            assert llm.complete_with_tools.call_count >= 2
 
 
 class TestDependencyReviewPass:

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -44,15 +44,12 @@ class TestGetSecurityModel:
 
     def test_config_security_model_beats_db_review(self):
         config = LLMConfig(model="base", security_model="sec-model")
-        assert (
-            get_security_model(config, db_review_model="db-review") == "sec-model"
-        )
+        assert get_security_model(config, db_review_model="db-review") == "sec-model"
 
     def test_db_value_beats_db_review(self):
         config = LLMConfig(model="base")
         assert (
-            get_security_model(config, db_value="db-sec", db_review_model="db-review")
-            == "db-sec"
+            get_security_model(config, db_value="db-sec", db_review_model="db-review") == "db-sec"
         )
 
 
@@ -80,9 +77,7 @@ class TestLlmConfigForSecurity:
             review_model="review",
             security_model="sec-model",
         )
-        with patch(
-            "mira.dashboard.models_config._app_db", None, create=True
-        ):
+        with patch("mira.dashboard.models_config._app_db", None, create=True):
             config = llm_config_for("security", base)
 
         assert config.model == "sec-model"
@@ -93,9 +88,7 @@ class TestLlmConfigForSecurity:
             model="base",
             review_reasoning_effort="medium",
         )
-        with patch(
-            "mira.dashboard.models_config._app_db", None, create=True
-        ):
+        with patch("mira.dashboard.models_config._app_db", None, create=True):
             config = llm_config_for("security", base)
 
         assert config.reasoning_effort == "medium"

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -37,6 +37,39 @@ class TestGetSecurityModel:
         assert result == "base"
         assert result != "cheap"
 
+    def test_db_review_model_is_fallback(self):
+        """A dashboard-set review model must win over config.model."""
+        config = LLMConfig(model="base")
+        assert get_security_model(config, db_review_model="db-review") == "db-review"
+
+    def test_config_security_model_beats_db_review(self):
+        config = LLMConfig(model="base", security_model="sec-model")
+        assert (
+            get_security_model(config, db_review_model="db-review") == "sec-model"
+        )
+
+    def test_db_value_beats_db_review(self):
+        config = LLMConfig(model="base")
+        assert (
+            get_security_model(config, db_value="db-sec", db_review_model="db-review")
+            == "db-sec"
+        )
+
+
+class TestLlmConfigForSecurityDbReview:
+    """llm_config_for(\"security\") falls back to the dashboard review model."""
+
+    def test_falls_back_to_db_review_model(self):
+        class _FakeDB:
+            def get_setting(self, key: str) -> str | None:
+                return {"review_model": "db-review"}.get(key)
+
+        base = LLMConfig(model="base")
+        with patch("mira.dashboard.api._app_db", _FakeDB()):
+            config = llm_config_for("security", base)
+
+        assert config.model == "db-review"
+
 
 class TestLlmConfigForSecurity:
     """llm_config_for(\"security\", base) resolves the security tier."""

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -1,31 +1,68 @@
-"""Default model resolution for the dashboard model pickers."""
+"""Tests for model resolution logic (models_config)."""
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from mira.config import LLMConfig
-from mira.dashboard.models_config import get_indexing_model, get_review_model
+from mira.dashboard.models_config import (
+    get_security_model,
+    llm_config_for,
+)
 
 
-def test_indexing_falls_back_to_config_model():
-    # No override anywhere → the configured model is honored as-is, even if
-    # it's review-tier; the combobox accepts free-form ids so nothing needs
-    # to match a registry entry.
-    cfg = LLMConfig()
-    assert get_indexing_model(cfg) == cfg.model
+class TestGetSecurityModel:
+    """The security tier chain: DB → security_model → review_model → model."""
+
+    def test_db_value_wins(self):
+        config = LLMConfig(model="base", review_model="review")
+        assert get_security_model(config, db_value="db-model") == "db-model"
+
+    def test_security_model_set(self):
+        config = LLMConfig(model="base", review_model="review", security_model="sec-model")
+        assert get_security_model(config) == "sec-model"
+
+    def test_falls_back_to_review_model(self):
+        config = LLMConfig(model="base", review_model="review")
+        assert get_security_model(config) == "review"
+
+    def test_falls_back_to_model(self):
+        config = LLMConfig(model="base")
+        assert get_security_model(config) == "base"
+
+    def test_never_returns_indexing_model(self):
+        """Security tier must not silently downgrade to the indexing tier."""
+        config = LLMConfig(model="base", indexing_model="cheap")
+        result = get_security_model(config)
+        assert result == "base"
+        assert result != "cheap"
 
 
-def test_review_default_unchanged_when_model_is_review_capable():
-    assert get_review_model(LLMConfig()) == "anthropic/claude-sonnet-4-6"
+class TestLlmConfigForSecurity:
+    """llm_config_for(\"security\", base) resolves the security tier."""
 
+    def test_resolves_security_model_from_config(self):
+        base = LLMConfig(
+            model="base",
+            review_model="review",
+            security_model="sec-model",
+        )
+        with patch(
+            "mira.dashboard.models_config._app_db", None, create=True
+        ):
+            config = llm_config_for("security", base)
 
-def test_explicit_choices_are_respected():
-    # DB value wins outright.
-    assert get_indexing_model(LLMConfig(), db_value="openai/gpt-4o-mini") == "openai/gpt-4o-mini"
-    # config.indexing_model wins over the generic fallback, even if custom.
-    assert get_indexing_model(LLMConfig(indexing_model="custom/local")) == "custom/local"
+        assert config.model == "sec-model"
 
+    def test_inherits_review_thinking_mode(self):
+        """Security purpose should pick up the review thinking mode."""
+        base = LLMConfig(
+            model="base",
+            review_reasoning_effort="medium",
+        )
+        with patch(
+            "mira.dashboard.models_config._app_db", None, create=True
+        ):
+            config = llm_config_for("security", base)
 
-def test_indexing_capable_model_passes_through():
-    # If config.model is itself indexing-capable, keep it.
-    cfg = LLMConfig(model="anthropic/claude-haiku-4-5")
-    assert get_indexing_model(cfg) == "anthropic/claude-haiku-4-5"
+        assert config.reasoning_effort == "medium"

--- a/tests/test_pr_scan.py
+++ b/tests/test_pr_scan.py
@@ -17,6 +17,7 @@ from mira.security.pr_scan import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _hunk(target_start: int, content: str) -> HunkInfo:
     return HunkInfo(
         source_start=1,
@@ -42,6 +43,7 @@ def _file_diff(path: str, hunks: list[HunkInfo]) -> FileDiff:
 # _added_line_hits unit test
 # ---------------------------------------------------------------------------
 
+
 class TestAddedLineHits:
     """_added_line_hits correctly maps @@ header to target_start."""
 
@@ -49,12 +51,7 @@ class TestAddedLineHits:
         """Off-by-one guard: @@ header does NOT increment line_no."""
         hunk = _hunk(
             target_start=5,
-            content=(
-                "@@ -1,3 +1,4 @@\n"
-                "-old\n"
-                "+lodash\n"
-                "+new\n"
-            ),
+            content=("@@ -1,3 +1,4 @@\n-old\n+lodash\n+new\n"),
         )
         diff = _file_diff("x.txt", [hunk])
 
@@ -67,12 +64,7 @@ class TestAddedLineHits:
     def test_second_added_line_advances(self):
         hunk = _hunk(
             target_start=5,
-            content=(
-                "@@ -1,3 +1,4 @@\n"
-                "-old\n"
-                "+lodash\n"
-                "+new\n"
-            ),
+            content=("@@ -1,3 +1,4 @@\n-old\n+lodash\n+new\n"),
         )
         diff = _file_diff("x.txt", [hunk])
 
@@ -83,14 +75,7 @@ class TestAddedLineHits:
     def test_context_and_removed_lines_advance_counter(self):
         hunk = _hunk(
             target_start=1,
-            content=(
-                "@@ -1,5 +1,6 @@\n"
-                "ctx\n"
-                "-old\n"
-                "ctx2\n"
-                "+lodash\n"
-                "+sec\n"
-            ),
+            content=("@@ -1,5 +1,6 @@\nctx\n-old\nctx2\n+lodash\n+sec\n"),
         )
         diff = _file_diff("x.txt", [hunk])
 
@@ -115,8 +100,8 @@ class TestAddedLineHits:
 # scan_manifest_changes integration tests
 # ---------------------------------------------------------------------------
 
-class TestScanManifestChanges:
 
+class TestScanManifestChanges:
     @pytest.mark.asyncio
     async def test_added_vulnerable_dep(self):
         """Added vulnerable dep → one correctly-anchored blocker comment."""
@@ -127,21 +112,23 @@ class TestScanManifestChanges:
             advisory_url="https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
             fixed_in="4.17.21",
         )
-        fake_qb = AsyncMock(return_value={
-            ("npm", "lodash", "4.17.20"): [vuln],
-        })
+        fake_qb = AsyncMock(
+            return_value={
+                ("npm", "lodash", "4.17.20"): [vuln],
+            }
+        )
 
         fetcher = MagicMock()
-        fetcher.fetch = AsyncMock(return_value=(
-            '{"dependencies": {"lodash": "4.17.20"}}'
-        ))
+        fetcher.fetch = AsyncMock(return_value=('{"dependencies": {"lodash": "4.17.20"}}'))
 
         diff = _file_diff(
             "package.json",
-            [_hunk(
-                target_start=2,
-                content='@@ -1,2 +1,3 @@\n+    "lodash": "4.17.20"\n',
-            )],
+            [
+                _hunk(
+                    target_start=2,
+                    content='@@ -1,2 +1,3 @@\n+    "lodash": "4.17.20"\n',
+                )
+            ],
         )
 
         with patch("mira.security.pr_scan.query_batch", fake_qb):
@@ -161,17 +148,17 @@ class TestScanManifestChanges:
         fake_qb = AsyncMock(return_value={})
 
         fetcher = MagicMock()
-        fetcher.fetch = AsyncMock(return_value=(
-            '{"dependencies": {"lodash": "4.17.20"}}'
-        ))
+        fetcher.fetch = AsyncMock(return_value=('{"dependencies": {"lodash": "4.17.20"}}'))
 
         # Hunk adds a line that does NOT contain "lodash"
         diff = _file_diff(
             "package.json",
-            [_hunk(
-                target_start=1,
-                content='@@ -1,2 +1,3 @@\n+    "express": "4.0.0"\n',
-            )],
+            [
+                _hunk(
+                    target_start=1,
+                    content='@@ -1,2 +1,3 @@\n+    "express": "4.0.0"\n',
+                )
+            ],
         )
 
         with patch("mira.security.pr_scan.query_batch", fake_qb):
@@ -194,16 +181,16 @@ class TestScanManifestChanges:
         fake_qb = AsyncMock(side_effect=Exception("network fail"))
 
         fetcher = MagicMock()
-        fetcher.fetch = AsyncMock(return_value=(
-            '{"dependencies": {"lodash": "4.17.20"}}'
-        ))
+        fetcher.fetch = AsyncMock(return_value=('{"dependencies": {"lodash": "4.17.20"}}'))
 
         diff = _file_diff(
             "package.json",
-            [_hunk(
-                target_start=1,
-                content='@@ -1,2 +1,3 @@\n+    "lodash": "4.17.20"\n',
-            )],
+            [
+                _hunk(
+                    target_start=1,
+                    content='@@ -1,2 +1,3 @@\n+    "lodash": "4.17.20"\n',
+                )
+            ],
         )
 
         with patch("mira.security.pr_scan.query_batch", fake_qb):
@@ -233,16 +220,16 @@ class TestScanManifestChanges:
         fake_qb = AsyncMock()
 
         fetcher = MagicMock()
-        fetcher.fetch = AsyncMock(return_value=(
-            "FROM node:18\nRUN npm install lodash\n"
-        ))
+        fetcher.fetch = AsyncMock(return_value=("FROM node:18\nRUN npm install lodash\n"))
 
         diff = _file_diff(
             "Dockerfile",
-            [_hunk(
-                target_start=1,
-                content='@@ -1 +2 @@\n+FROM node:18\n',
-            )],
+            [
+                _hunk(
+                    target_start=1,
+                    content="@@ -1 +2 @@\n+FROM node:18\n",
+                )
+            ],
         )
 
         with patch("mira.security.pr_scan.query_batch", fake_qb):

--- a/tests/test_pr_scan.py
+++ b/tests/test_pr_scan.py
@@ -1,0 +1,258 @@
+"""Tests for review-time OSV scan (src/mira/security/pr_scan.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mira.models import FileChangeType, FileDiff, HunkInfo, Severity
+from mira.security.osv import VulnEntry
+from mira.security.pr_scan import (
+    _added_line_hits,
+    scan_manifest_changes,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _hunk(target_start: int, content: str) -> HunkInfo:
+    return HunkInfo(
+        source_start=1,
+        source_length=0,
+        target_start=target_start,
+        target_length=0,
+        content=content,
+    )
+
+
+def _file_diff(path: str, hunks: list[HunkInfo]) -> FileDiff:
+    return FileDiff(
+        path=path,
+        change_type=FileChangeType.MODIFIED,
+        language="",
+        added_lines=0,
+        deleted_lines=0,
+        hunks=hunks,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _added_line_hits unit test
+# ---------------------------------------------------------------------------
+
+class TestAddedLineHits:
+    """_added_line_hits correctly maps @@ header to target_start."""
+
+    def test_first_added_line_maps_to_target_start(self):
+        """Off-by-one guard: @@ header does NOT increment line_no."""
+        hunk = _hunk(
+            target_start=5,
+            content=(
+                "@@ -1,3 +1,4 @@\n"
+                "-old\n"
+                "+lodash\n"
+                "+new\n"
+            ),
+        )
+        diff = _file_diff("x.txt", [hunk])
+
+        hits = _added_line_hits(diff, "lodash")
+        assert len(hits) == 1
+        line_no, line_text = hits[0]
+        assert line_no == 5, "first body added line must be target_start"
+        assert "lodash" in line_text
+
+    def test_second_added_line_advances(self):
+        hunk = _hunk(
+            target_start=5,
+            content=(
+                "@@ -1,3 +1,4 @@\n"
+                "-old\n"
+                "+lodash\n"
+                "+new\n"
+            ),
+        )
+        diff = _file_diff("x.txt", [hunk])
+
+        hits = _added_line_hits(diff, "new")
+        assert len(hits) == 1
+        assert hits[0] == (6, "new")
+
+    def test_context_and_removed_lines_advance_counter(self):
+        hunk = _hunk(
+            target_start=1,
+            content=(
+                "@@ -1,5 +1,6 @@\n"
+                "ctx\n"
+                "-old\n"
+                "ctx2\n"
+                "+lodash\n"
+                "+sec\n"
+            ),
+        )
+        diff = _file_diff("x.txt", [hunk])
+
+        hits = _added_line_hits(diff, "lodash")
+        assert hits == [(3, "lodash")]
+
+        hits2 = _added_line_hits(diff, "sec")
+        assert hits2 == [(4, "sec")]
+
+    def test_case_insensitive(self):
+        hunk = _hunk(
+            target_start=1,
+            content="@@ -1,1 +1,2 @@\n+LODASH\n",
+        )
+        diff = _file_diff("x.txt", [hunk])
+
+        hits = _added_line_hits(diff, "lodash")
+        assert len(hits) == 1
+
+
+# ---------------------------------------------------------------------------
+# scan_manifest_changes integration tests
+# ---------------------------------------------------------------------------
+
+class TestScanManifestChanges:
+
+    @pytest.mark.asyncio
+    async def test_added_vulnerable_dep(self):
+        """Added vulnerable dep → one correctly-anchored blocker comment."""
+        vuln = VulnEntry(
+            cve_id="CVE-2021-23337",
+            summary="Command Injection",
+            severity="critical",
+            advisory_url="https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+            fixed_in="4.17.21",
+        )
+        fake_qb = AsyncMock(return_value={
+            ("npm", "lodash", "4.17.20"): [vuln],
+        })
+
+        fetcher = MagicMock()
+        fetcher.fetch = AsyncMock(return_value=(
+            '{"dependencies": {"lodash": "4.17.20"}}'
+        ))
+
+        diff = _file_diff(
+            "package.json",
+            [_hunk(
+                target_start=2,
+                content='@@ -1,2 +1,3 @@\n+    "lodash": "4.17.20"\n',
+            )],
+        )
+
+        with patch("mira.security.pr_scan.query_batch", fake_qb):
+            comments = await scan_manifest_changes([diff], fetcher)
+
+        assert len(comments) == 1
+        c = comments[0]
+        assert c.line == 2
+        assert c.severity == Severity.BLOCKER
+        assert c.category == "security"
+        assert c.source_pass == "osv"
+        assert "lodash" in c.existing_code
+
+    @pytest.mark.asyncio
+    async def test_pre_existing_dep_excluded(self):
+        """Package present in head manifest but NOT in added lines → skipped."""
+        fake_qb = AsyncMock(return_value={})
+
+        fetcher = MagicMock()
+        fetcher.fetch = AsyncMock(return_value=(
+            '{"dependencies": {"lodash": "4.17.20"}}'
+        ))
+
+        # Hunk adds a line that does NOT contain "lodash"
+        diff = _file_diff(
+            "package.json",
+            [_hunk(
+                target_start=1,
+                content='@@ -1,2 +1,3 @@\n+    "express": "4.0.0"\n',
+            )],
+        )
+
+        with patch("mira.security.pr_scan.query_batch", fake_qb):
+            comments = await scan_manifest_changes([diff], fetcher)
+
+        assert comments == []
+        # query_batch should NOT have been called (no matching queries)
+        fake_qb.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_query_batch_raises_fails_open(self):
+        """query_batch raising → returns [] without error."""
+        vuln = VulnEntry(
+            cve_id="CVE-2021-23337",
+            summary="Command Injection",
+            severity="critical",
+            advisory_url="https://nvd.nist.gov/vuln/detail/CVE-2021-23337",
+            fixed_in="4.17.21",
+        )
+        fake_qb = AsyncMock(side_effect=Exception("network fail"))
+
+        fetcher = MagicMock()
+        fetcher.fetch = AsyncMock(return_value=(
+            '{"dependencies": {"lodash": "4.17.20"}}'
+        ))
+
+        diff = _file_diff(
+            "package.json",
+            [_hunk(
+                target_start=1,
+                content='@@ -1,2 +1,3 @@\n+    "lodash": "4.17.20"\n',
+            )],
+        )
+
+        with patch("mira.security.pr_scan.query_batch", fake_qb):
+            comments = await scan_manifest_changes([diff], fetcher)
+
+        assert comments == []
+
+    @pytest.mark.asyncio
+    async def test_fetcher_returns_none_skips_file(self):
+        """Fetcher returning None → file skipped, no queries."""
+        fake_qb = AsyncMock()
+
+        fetcher = MagicMock()
+        fetcher.fetch = AsyncMock(return_value=None)
+
+        diff = _file_diff("package.json", [_hunk(target_start=1, content="+x\n")])
+
+        with patch("mira.security.pr_scan.query_batch", fake_qb):
+            comments = await scan_manifest_changes([diff], fetcher)
+
+        assert comments == []
+        fake_qb.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dockerfile_only_returns_empty(self):
+        """Dockerfile-only change → osv_ecosystem('docker') is None → []."""
+        fake_qb = AsyncMock()
+
+        fetcher = MagicMock()
+        fetcher.fetch = AsyncMock(return_value=(
+            "FROM node:18\nRUN npm install lodash\n"
+        ))
+
+        diff = _file_diff(
+            "Dockerfile",
+            [_hunk(
+                target_start=1,
+                content='@@ -1 +2 @@\n+FROM node:18\n',
+            )],
+        )
+
+        with patch("mira.security.pr_scan.query_batch", fake_qb):
+            comments = await scan_manifest_changes([diff], fetcher)
+
+        assert comments == []
+
+    @pytest.mark.asyncio
+    async def test_empty_input(self):
+        """Empty manifest_files list returns immediately."""
+        fetcher = MagicMock()
+        comments = await scan_manifest_changes([], fetcher)
+        assert comments == []

--- a/ui/mira/src/lib/api/settings.ts
+++ b/ui/mira/src/lib/api/settings.ts
@@ -6,17 +6,21 @@ export const settingsApi = {
     fetchJson<{
       indexing_model: string
       review_model: string
+      security_model: string
       backend: string
       indexing_source: "dashboard" | "config"
       review_source: "dashboard" | "config"
+      security_source: "dashboard" | "config"
       config_indexing_model: string
       config_review_model: string
+      config_security_model: string
       indexing_options: {
         value: string
         label: string
         recommended?: boolean
       }[]
       review_options: { value: string; label: string; recommended?: boolean }[]
+      security_options: { value: string; label: string; recommended?: boolean }[]
       review_thinking_mode: string
       thinking_options: { value: string; label: string; recommended?: boolean }[]
     }>("/api/settings/models"),
@@ -24,11 +28,13 @@ export const settingsApi = {
   saveModels: (
     indexing_model: string,
     review_model: string,
+    security_model: string,
     review_thinking_mode: string = "off",
   ) =>
     putJson<{ ok: boolean }>("/api/settings/models", {
       indexing_model,
       review_model,
+      security_model,
       review_thinking_mode,
     }),
 

--- a/ui/mira/src/pages/settings.tsx
+++ b/ui/mira/src/pages/settings.tsx
@@ -32,11 +32,14 @@ export function SettingsPage() {
   // "" = inherit from deployment config; anything else is a model id.
   const [indexingModel, setIndexingModel] = useState("")
   const [reviewModel, setReviewModel] = useState("")
+  const [securityModel, setSecurityModel] = useState("")
   const [configIndexingModel, setConfigIndexingModel] = useState("")
   const [configReviewModel, setConfigReviewModel] = useState("")
+  const [configSecurityModel, setConfigSecurityModel] = useState("")
   const [backend, setBackend] = useState("")
   const [indexingOptions, setIndexingOptions] = useState<ModelOption[]>([])
   const [reviewOptions, setReviewOptions] = useState<ModelOption[]>([])
+  const [securityOptions, setSecurityOptions] = useState<ModelOption[]>([])
   const [thinkingMode, setThinkingMode] = useState("off")
   const [thinkingOptions, setThinkingOptions] = useState<ModelOption[]>([])
   const [savingModels, setSavingModels] = useState(false)
@@ -67,11 +70,14 @@ export function SettingsPage() {
     api.getModels().then((m) => {
       setIndexingModel(m.indexing_source === "config" ? "" : m.indexing_model)
       setReviewModel(m.review_source === "config" ? "" : m.review_model)
+      setSecurityModel(m.security_source === "config" ? "" : m.security_model)
       setConfigIndexingModel(m.config_indexing_model)
       setConfigReviewModel(m.config_review_model)
+      setConfigSecurityModel(m.config_security_model)
       setBackend(m.backend)
       setIndexingOptions(m.indexing_options)
       setReviewOptions(m.review_options)
+      setSecurityOptions(m.security_options)
       setThinkingMode(m.review_thinking_mode)
       setThinkingOptions(m.thinking_options)
     })
@@ -99,7 +105,7 @@ export function SettingsPage() {
 
   const saveModels = async () => {
     setSavingModels(true)
-    await api.saveModels(indexingModel, reviewModel, thinkingMode)
+    await api.saveModels(indexingModel, reviewModel, securityModel, thinkingMode)
     setSavingModels(false)
     setModelsSaved(true)
     setTimeout(() => setModelsSaved(false), 2000)
@@ -352,6 +358,20 @@ export function SettingsPage() {
               <p className="text-xs text-muted-foreground">
                 Used to analyze PRs and post review comments. A more powerful
                 model gives better review quality.
+              </p>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Security Model</label>
+              <ModelCombobox
+                value={securityModel}
+                onChange={setSecurityModel}
+                options={securityOptions}
+                configModel={configSecurityModel}
+              />
+              <p className="text-xs text-muted-foreground">
+                Used for the dedicated security pass. Defaults to the review
+                model — set a cheaper one only if you accept lower security
+                recall.
               </p>
             </div>
             <div className="space-y-2">

--- a/ui/mira/src/pages/setup.tsx
+++ b/ui/mira/src/pages/setup.tsx
@@ -42,7 +42,7 @@ export function SetupPage() {
 
   const handleSave = async () => {
     setSaving(true)
-    await api.saveModels(indexingModel, reviewModel)
+    await api.saveModels(indexingModel, reviewModel, "")
     navigate("/")
   }
 


### PR DESCRIPTION
## Summary

Introduces a dedicated security model tier, chunked security review, and review-time OSV vulnerability scanning — elevating the security pass from a cheap indexing-tier sweep to a first-class review stage with its own model configuration.

## Motivation

The previous security review pass ran on the indexing LLM tier (the cheapest model available), which traded security recall for cost savings. Security reviews are the highest-stakes pass in the pipeline and deserve better. This change:

- Adds a configurable `security_model` setting that defaults to the review tier (not the indexing tier).
- Chunks security review input to fit within the LLM context budget, using the same chunking strategy as the main review pass.
- Scans PR-added/bumped dependencies against the OSV database at review time, closing the gap between merge and the background hourly poller.

## Changes

### New Security Model Tier
- **`src/mira/config.py`**: Added `security_model` optional field to `LLMConfig`; updated docstring to clarify the security pass is no longer the indexing tier.
- **`src/mira/dashboard/models_config.py`**: New `get_security_model()` resolver with DB override support; `llm_config_for("security", ...)` branch added.

### Chunked Security Review
- **`src/mira/core/passes.py`**: `security_review_pass()` now accepts `security_llm` parameter (falls back to review tier); input is chunked using `SECURITY_CONTEXT_FRACTION = 0.75` to leave headroom for prompt scaffolding.
- **`src/mira/core/engine.py`**: `ReviewEngine` accepts `security_llm` constructor argument; passes it through to `security_review_pass()`. Removed migration file exclusion from security-relevant file filter (DDL can contain security-relevant logic).

### Review-Time OSV Scan
- **`src/mira/security/pr_scan.py`**: New module — scans manifest files changed in the PR against the OSV database, flagging PR-added dependencies with known CVEs. Runs at review time (no LLM involved), anchored to exact diff lines.
- **`src/mira/core/engine.py`**: OSV scan task created alongside security and dependency review tasks when `config.review.osv_scan` is enabled.

### Integration Points
- **`src/mira/cli.py`**: CLI `review` command creates and passes `security_llm` to `ReviewEngine`.
- **`src/mira/platforms/handlers.py`**: PR review and `/mira review` command handlers wire up the security LLM.
- **`src/mira/models.py`**: `ReviewComment.category` docstring updated to include `"osv"` as a pass type.

### Tests
- **`tests/test_engine.py`**: New test verifying `security_llm` is used (not the main LLM) for security review; updated migration filter test to reflect that migrations are no longer stripped.
- **`tests/test_models_config.py`**: Overhauled to test `get_security_model()` resolution chain (DB → config → review fallback).
- **`tests/test_pr_scan.py`**: 245 lines of tests for the OSV scan module covering manifest parsing, OSV API interaction, comment generation, and edge cases.

## Notes

- The `uv.lock` file was regenerated (revision 3) with updated hash formatting — no dependency versions changed.
- Migration files are no longer excluded from security review; database schema changes can contain security-relevant logic (e.g., constraint additions, auth-related tables).
