### PR TITLE
fix(github): fall back to per-file patches when PR diff 406s over the 20k-line cap

### DIFF
--- a/src/mira/providers/github.py
+++ b/src/mira/providers/github.py
@@ -147,6 +147,34 @@ def parse_pr_url(pr_url: str) -> tuple[str, str, int]:
     return match.group("owner"), match.group("repo"), int(match.group("number"))
 
 
+def _file_to_diff(f: dict[str, Any]) -> str:
+    """Rebuild a unified-diff file section from a GitHub files-API entry.
+
+    The API returns each file's ``patch`` without the ``diff --git`` /
+    ``---`` / ``+++`` headers unidiff needs, so reconstruct them from the
+    entry's ``filename``/``status``/``previous_filename``.
+    """
+    path = f["filename"]
+    status = f.get("status", "modified")
+    patch = f["patch"]
+    if status == "renamed":
+        prev = f.get("previous_filename") or path
+        header = [
+            f"diff --git a/{prev} b/{path}",
+            f"rename from {prev}",
+            f"rename to {path}",
+            f"--- a/{prev}",
+            f"+++ b/{path}",
+        ]
+    elif status == "added":
+        header = [f"diff --git a/{path} b/{path}", "--- /dev/null", f"+++ b/{path}"]
+    elif status == "removed":
+        header = [f"diff --git a/{path} b/{path}", f"--- a/{path}", "+++ /dev/null"]
+    else:
+        header = [f"diff --git a/{path} b/{path}", f"--- a/{path}", f"+++ b/{path}"]
+    return "\n".join(header) + "\n" + patch
+
+
 class GitHubProvider(BaseProvider):
     """GitHub code hosting provider."""
 
@@ -196,6 +224,17 @@ class GitHubProvider(BaseProvider):
         async def _fetch_diff() -> str:
             async with httpx.AsyncClient() as client:
                 resp = await client.get(diff_url, headers=headers, follow_redirects=True)
+                if resp.status_code == 406:
+                    # GitHub 406s once a PR diff exceeds its ~20,000-line cap.
+                    # Fall back to per-file patches from the files API.
+                    logger.info(
+                        "PR diff too large for single fetch (406); falling back to per-file patches"
+                    )
+                    return await self._fetch_files_diff(
+                        client,
+                        f"{_GITHUB_API_URL}/repos/{pr_info.owner}/{pr_info.repo}/pulls/{pr_info.number}/files",
+                        pr_info,
+                    )
                 resp.raise_for_status()
                 return resp.text
 
@@ -205,6 +244,52 @@ class GitHubProvider(BaseProvider):
             raise
         except Exception as e:
             raise ProviderError(f"Failed to fetch PR diff: {e}") from e
+
+    async def _fetch_files_diff(
+        self, client: httpx.AsyncClient, files_url: str, pr_info: PRInfo
+    ) -> str:
+        """Synthesize a unified diff from per-file patches (files API).
+
+        Fallback for when the .diff media type 406s (diff over GitHub's
+        ~20,000-line cap). Paginates up to GitHub's 3000-file ceiling; files
+        too large for an individual patch arrive without one and are skipped
+        with a warning.
+        """
+        headers = {
+            "Authorization": f"token {self._token}",
+            "Accept": "application/vnd.github+json",
+        }
+        files: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            resp = await client.get(
+                files_url,
+                headers=headers,
+                params={"per_page": 100, "page": page},
+                follow_redirects=True,
+            )
+            resp.raise_for_status()
+            batch = resp.json()
+            files.extend(batch)
+            if len(batch) < 100 or len(files) >= 3000:
+                break
+            page += 1
+
+        parts: list[str] = []
+        skipped: list[str] = []
+        for f in files:
+            if f.get("patch"):
+                parts.append(_file_to_diff(f))
+            else:
+                skipped.append(f.get("filename", "?"))
+        if skipped:
+            logger.warning(
+                "Per-file diff fallback: %d file(s) too large for individual patches, skipped in %s: %s",
+                len(skipped),
+                pr_info.url,
+                ", ".join(skipped[:10]) + ("…" if len(skipped) > 10 else ""),
+            )
+        return "\n\n".join(parts)
 
     async def get_compare_diff(
         self,

--- a/src/mira/providers/github.py
+++ b/src/mira/providers/github.py
@@ -167,9 +167,19 @@ def _file_to_diff(f: dict[str, Any]) -> str:
             f"+++ b/{path}",
         ]
     elif status == "added":
-        header = [f"diff --git a/{path} b/{path}", "--- /dev/null", f"+++ b/{path}"]
+        header = [
+            f"diff --git a/{path} b/{path}",
+            "new file mode 100644",
+            "--- /dev/null",
+            f"+++ b/{path}",
+        ]
     elif status == "removed":
-        header = [f"diff --git a/{path} b/{path}", f"--- a/{path}", "+++ /dev/null"]
+        header = [
+            f"diff --git a/{path} b/{path}",
+            "deleted file mode 100644",
+            f"--- a/{path}",
+            "+++ /dev/null",
+        ]
     else:
         header = [f"diff --git a/{path} b/{path}", f"--- a/{path}", f"+++ b/{path}"]
     return "\n".join(header) + "\n" + patch

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -1405,10 +1405,9 @@ class TestGetPRDiff406Fallback:
 
         parsed = parse_diff(result)
 
-        # unidiff emits a ghost MODIFIED entry for /dev/null added-files,
-        # so the real file count is 101 but unidiff reports 102.
-        meaningful = [f for f in parsed.files if f.added_lines + f.deleted_lines > 0]
-        assert len(meaningful) == 101
+        # With "new file mode" header, all 101 files parse correctly as
+        # their true change_type (no ghost MODIFIED entry for added files).
+        assert len(parsed.files) == 101
 
         # Verify the added file from page 2 round-trips
         assert "+++ b/page2/added.py" in result
@@ -1458,3 +1457,70 @@ class TestGetPRDiff406Fallback:
         assert len(parsed.files) == 1
         assert parsed.files[0].change_type == FileChangeType.RENAMED
         assert parsed.files[0].old_path == "old.py"
+
+    @pytest.mark.asyncio
+    async def test_406_fallback_all_statuses_parse(self):
+        """Each file status round-trips through parse_diff with correct change_type."""
+        provider = GitHubProvider.__new__(GitHubProvider)
+        provider._token = "test-token"
+        pr_info = _make_pr_info()
+
+        call_count = 0
+
+        async def _mock_get(self, url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(
+                    406,
+                    text="",
+                    request=httpx.Request("GET", url),
+                )
+            files = [
+                {
+                    "filename": "added.py",
+                    "status": "added",
+                    "patch": "@@ -0,0 +1,1 @@\n+new",
+                },
+                {
+                    "filename": "removed.py",
+                    "status": "removed",
+                    "patch": "@@ -1,1 +0,0 @@\n-gone",
+                },
+                {
+                    "filename": "renamed.py",
+                    "previous_filename": "old.py",
+                    "status": "renamed",
+                    "patch": "@@ -1 +1 @@\n-old\n+new",
+                },
+                {
+                    "filename": "modified.py",
+                    "status": "modified",
+                    "patch": "@@ -1 +1 @@\n-old\n+new",
+                },
+            ]
+            return httpx.Response(
+                200,
+                json=files,
+                request=httpx.Request("GET", url),
+            )
+
+        with patch.object(httpx.AsyncClient, "get", _mock_get):
+            result = await provider.get_pr_diff(pr_info)
+
+        # All four statuses must parse without error
+        parsed = parse_diff(result)
+        assert len(parsed.files) == 4
+
+        # Verify each file has the correct change_type
+        by_path = {f.path: f for f in parsed.files}
+
+        assert by_path["added.py"].change_type == FileChangeType.ADDED
+        assert by_path["removed.py"].change_type == FileChangeType.DELETED
+        assert by_path["modified.py"].change_type == FileChangeType.MODIFIED
+
+        # Renamed file: old_path is the source, path is the destination
+        renamed = [f for f in parsed.files if f.change_type == FileChangeType.RENAMED]
+        assert len(renamed) == 1
+        assert renamed[0].old_path == "old.py"
+        assert renamed[0].path == "renamed.py"

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -1411,7 +1411,11 @@ class TestGetPRDiff406Fallback:
 
         # Verify the added file from page 2 round-trips
         assert "+++ b/page2/added.py" in result
-        added = [f for f in parsed.files if f.path == "page2/added.py" and f.change_type == FileChangeType.ADDED]
+        added = [
+            f
+            for f in parsed.files
+            if f.path == "page2/added.py" and f.change_type == FileChangeType.ADDED
+        ]
         assert len(added) == 1
         assert added[0].change_type == FileChangeType.ADDED
 

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -9,8 +9,9 @@ import httpx
 import pytest
 from github import GithubException
 
+from mira.core.diff_parser import parse_diff
 from mira.exceptions import ProviderError
-from mira.models import PRInfo, ReviewComment, ReviewResult, Severity
+from mira.models import FileChangeType, PRInfo, ReviewComment, ReviewResult, Severity
 from mira.providers.github import (
     _CATEGORY_DISPLAY,
     GitHubProvider,
@@ -1296,3 +1297,164 @@ class TestRemoveLabel:
 
         # Should not raise
         await provider.remove_label(pr_info, "mira-paused")
+
+
+class TestGetPRDiff406Fallback:
+    """Tests for PR diff 406 fallback to per-file patches."""
+
+    @pytest.mark.asyncio
+    async def test_406_fallback_with_patch_and_skipped_file(self):
+        """406 triggers files-API fallback; files without patch are skipped."""
+        provider = GitHubProvider.__new__(GitHubProvider)
+        provider._token = "test-token"
+        pr_info = _make_pr_info()
+
+        call_count = 0
+
+        async def _mock_get(self, url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call — the .diff endpoint returns 406
+                return httpx.Response(
+                    406,
+                    text="",
+                    request=httpx.Request("GET", url),
+                )
+            # Second call — files API returns JSON
+            files = [
+                {
+                    "filename": "src/a.py",
+                    "status": "modified",
+                    "patch": "@@ -1,1 +1,2 @@\n context\n+added",
+                },
+                {
+                    "filename": "src/binary.dat",
+                    "status": "modified",
+                    "patch": None,
+                },
+            ]
+            return httpx.Response(
+                200,
+                json=files,
+                request=httpx.Request("GET", url),
+            )
+
+        with patch.object(httpx.AsyncClient, "get", _mock_get):
+            result = await provider.get_pr_diff(pr_info)
+
+        # Synthesized diff contains the file with patch
+        assert "diff --git a/src/a.py b/src/a.py" in result
+        assert "+added" in result
+        # Skipped file should NOT appear
+        assert "src/binary.dat" not in result
+
+        # Parseability check
+        parsed = parse_diff(result)
+        assert len(parsed.files) == 1
+        assert parsed.files[0].path == "src/a.py"
+        assert parsed.files[0].added_lines == 1
+
+    @pytest.mark.asyncio
+    async def test_406_fallback_pagination(self):
+        """Pagination across multiple pages yields all files."""
+        provider = GitHubProvider.__new__(GitHubProvider)
+        provider._token = "test-token"
+        pr_info = _make_pr_info()
+
+        call_count = 0
+
+        async def _mock_get(self, url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(
+                    406,
+                    text="",
+                    request=httpx.Request("GET", url),
+                )
+            params = kwargs.get("params", {})
+            page = params.get("page", 1)
+            if page == 1:
+                # 100 entries on page 1 — all modified with patch
+                files = [
+                    {
+                        "filename": f"page1/file_{i}.py",
+                        "status": "modified",
+                        "patch": "@@ -1 +1 @@\n-old\n+new",
+                    }
+                    for i in range(100)
+                ]
+            else:
+                # 1 entry on page 2 — an added file
+                files = [
+                    {
+                        "filename": "page2/added.py",
+                        "status": "added",
+                        "patch": "@@ -0,0 +1,1 @@\n+new",
+                    }
+                ]
+            return httpx.Response(
+                200,
+                json=files,
+                request=httpx.Request("GET", url),
+            )
+
+        with patch.object(httpx.AsyncClient, "get", _mock_get):
+            result = await provider.get_pr_diff(pr_info)
+
+        parsed = parse_diff(result)
+
+        # unidiff emits a ghost MODIFIED entry for /dev/null added-files,
+        # so the real file count is 101 but unidiff reports 102.
+        meaningful = [f for f in parsed.files if f.added_lines + f.deleted_lines > 0]
+        assert len(meaningful) == 101
+
+        # Verify the added file from page 2 round-trips
+        assert "+++ b/page2/added.py" in result
+        added = [f for f in parsed.files if f.path == "page2/added.py" and f.change_type == FileChangeType.ADDED]
+        assert len(added) == 1
+        assert added[0].change_type == FileChangeType.ADDED
+
+    @pytest.mark.asyncio
+    async def test_406_fallback_rename_synthesis(self):
+        """Renames produce rename from/to headers parseable as RENAMED."""
+        provider = GitHubProvider.__new__(GitHubProvider)
+        provider._token = "test-token"
+        pr_info = _make_pr_info()
+
+        call_count = 0
+
+        async def _mock_get(self, url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return httpx.Response(
+                    406,
+                    text="",
+                    request=httpx.Request("GET", url),
+                )
+            files = [
+                {
+                    "filename": "new.py",
+                    "previous_filename": "old.py",
+                    "status": "renamed",
+                    "patch": "@@ -1 +1 @@\n-old\n+new",
+                }
+            ]
+            return httpx.Response(
+                200,
+                json=files,
+                request=httpx.Request("GET", url),
+            )
+
+        with patch.object(httpx.AsyncClient, "get", _mock_get):
+            result = await provider.get_pr_diff(pr_info)
+
+        assert "rename from old.py" in result
+        assert "rename to new.py" in result
+
+        parsed = parse_diff(result)
+        assert len(parsed.files) == 1
+        assert parsed.files[0].change_type == FileChangeType.RENAMED
+        assert parsed.files[0].old_path == "old.py"


### PR DESCRIPTION
Fixes #230.

When a PR's diff exceeds GitHub's ~20,000-line cap, the `.diff` endpoint returns **406 Not Acceptable** and `get_pr_diff` aborts the entire review — large PRs get no review at all.

**Fix**: on 406, fall back to the paginated files API (`pulls/{n}/files`, up to the 3000-file ceiling), synthesize a unified diff from each entry's `patch` (reconstructing `diff --git`/`---`/`+++` headers from `filename`/`status`/`previous_filename`, including rename headers), and feed it to the normal parser. Files too large for individual patches arrive patchless and are skipped with a warning naming them.

Notes:
- 406 is not in the retried exception set, so the fallback triggers immediately without burning retries.
- `get_compare_diff` (round-2+ incremental reviews) has the same theoretical 406 path; left alone here since incremental ranges are typically small — happy to follow up if wanted.
- Tests cover: fallback + parse-through-`parse_diff` (added/modified), pagination across the 100-per-page boundary, and rename header synthesis.