### PR TITLE
fix: prevent overlapping PR reviews across workers

### DIFF
--- a/src/mira/dashboard/db.py
+++ b/src/mira/dashboard/db.py
@@ -107,6 +107,20 @@ CREATE TABLE IF NOT EXISTS pr_review_progress (
     PRIMARY KEY (platform, owner, repo, pr_number)
 );
 
+-- A renewable lease prevents two webhook workers from reviewing the same PR
+-- at the same time. The token makes refresh/release ownership-safe, while the
+-- expiry lets another worker recover the claim after a crash.
+CREATE TABLE IF NOT EXISTS review_claims (
+    platform TEXT NOT NULL DEFAULT 'github',
+    owner TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    claim_token TEXT NOT NULL,
+    claimed_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
+    PRIMARY KEY (platform, owner, repo, pr_number)
+);
+
 -- ── Contributor analytics ──
 -- People who contribute to indexed repos, keyed provider-agnostically so a
 -- future non-GitHub provider slots in without a schema change.
@@ -272,6 +286,17 @@ CREATE TABLE IF NOT EXISTS pr_review_progress (
     chunk_index INTEGER NOT NULL DEFAULT 0,
     last_reviewed_sha TEXT NOT NULL DEFAULT '',
     updated_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (platform, owner, repo, pr_number)
+);
+
+CREATE TABLE IF NOT EXISTS review_claims (
+    platform TEXT NOT NULL DEFAULT 'github',
+    owner TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    claim_token TEXT NOT NULL,
+    claimed_at DOUBLE PRECISION NOT NULL,
+    expires_at DOUBLE PRECISION NOT NULL,
     PRIMARY KEY (platform, owner, repo, pr_number)
 );
 
@@ -491,6 +516,7 @@ class AppDatabase:
         self._admin_password = admin_password
         self._pg_conn = None
         self._pg_lock = threading.Lock()
+        self._sqlite_lock = threading.Lock()
         self._sqlite_conn: sqlite3.Connection | None = None
 
         if url.startswith("postgresql://") or url.startswith("postgres://"):
@@ -513,6 +539,7 @@ class AppDatabase:
         if parent:
             os.makedirs(parent, exist_ok=True)
         self._sqlite_conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._sqlite_conn.execute("PRAGMA busy_timeout=5000")
         self._sqlite_conn.execute("PRAGMA journal_mode=WAL")
         self._sqlite_conn.execute("PRAGMA foreign_keys=ON")
         self._sqlite_conn.executescript(_SQLITE_SCHEMA)
@@ -1474,6 +1501,110 @@ class AppDatabase:
         return [f"{r.title}: {r.content}" for r in rules if r.enabled][:20]
 
     # ── PR review progress ──
+
+    def try_claim_review(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        *,
+        platform: str = "github",
+        ttl_seconds: float = 3600,
+    ) -> str | None:
+        """Acquire a renewable per-PR lease, or return ``None`` if one is active.
+
+        The single INSERT/UPSERT statement is atomic in both SQLite and
+        PostgreSQL, so separate worker processes and replicas cannot both win.
+        """
+        now = time.time()
+        token = secrets.token_urlsafe(24)
+        expires_at = now + ttl_seconds
+        params = (platform, owner, repo, pr_number, token, now, expires_at, now)
+        if self._backend == "sqlite":
+            assert self._sqlite_conn is not None
+            with self._sqlite_lock:
+                cur = self._sqlite_conn.execute(
+                    "INSERT INTO review_claims "
+                    "(platform, owner, repo, pr_number, claim_token, claimed_at, expires_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?) "
+                    "ON CONFLICT(platform, owner, repo, pr_number) DO UPDATE SET "
+                    "claim_token=excluded.claim_token, claimed_at=excluded.claimed_at, "
+                    "expires_at=excluded.expires_at WHERE review_claims.expires_at <= ?",
+                    params,
+                )
+                self._sqlite_conn.commit()
+                acquired = cur.rowcount == 1
+        else:
+            with self._pg_cursor() as cur:
+                cur.execute(
+                    "INSERT INTO review_claims "
+                    "(platform, owner, repo, pr_number, claim_token, claimed_at, expires_at) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s) "
+                    "ON CONFLICT(platform, owner, repo, pr_number) DO UPDATE SET "
+                    "claim_token=EXCLUDED.claim_token, claimed_at=EXCLUDED.claimed_at, "
+                    "expires_at=EXCLUDED.expires_at WHERE review_claims.expires_at <= %s",
+                    params,
+                )
+                acquired = cur.rowcount == 1
+        return token if acquired else None
+
+    def refresh_review_claim(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        claim_token: str,
+        *,
+        platform: str = "github",
+        ttl_seconds: float = 3600,
+    ) -> bool:
+        """Extend a lease only when ``claim_token`` still owns it."""
+        expires_at = time.time() + ttl_seconds
+        if self._backend == "sqlite":
+            assert self._sqlite_conn is not None
+            with self._sqlite_lock:
+                cur = self._sqlite_conn.execute(
+                    "UPDATE review_claims SET expires_at=? WHERE platform=? AND owner=? "
+                    "AND repo=? AND pr_number=? AND claim_token=?",
+                    (expires_at, platform, owner, repo, pr_number, claim_token),
+                )
+                self._sqlite_conn.commit()
+                return cur.rowcount == 1
+        with self._pg_cursor() as cur:
+            cur.execute(
+                "UPDATE review_claims SET expires_at=%s WHERE platform=%s AND owner=%s "
+                "AND repo=%s AND pr_number=%s AND claim_token=%s",
+                (expires_at, platform, owner, repo, pr_number, claim_token),
+            )
+            return cur.rowcount == 1
+
+    def release_review_claim(
+        self,
+        owner: str,
+        repo: str,
+        pr_number: int,
+        claim_token: str,
+        *,
+        platform: str = "github",
+    ) -> bool:
+        """Release a lease only when ``claim_token`` still owns it."""
+        if self._backend == "sqlite":
+            assert self._sqlite_conn is not None
+            with self._sqlite_lock:
+                cur = self._sqlite_conn.execute(
+                    "DELETE FROM review_claims WHERE platform=? AND owner=? AND repo=? "
+                    "AND pr_number=? AND claim_token=?",
+                    (platform, owner, repo, pr_number, claim_token),
+                )
+                self._sqlite_conn.commit()
+                return cur.rowcount == 1
+        with self._pg_cursor() as cur:
+            cur.execute(
+                "DELETE FROM review_claims WHERE platform=%s AND owner=%s AND repo=%s "
+                "AND pr_number=%s AND claim_token=%s",
+                (platform, owner, repo, pr_number, claim_token),
+            )
+            return cur.rowcount == 1
 
     def upsert_pr_review_progress(
         self, progress: PRReviewProgress, platform: str = "github"

--- a/src/mira/platforms/handlers.py
+++ b/src/mira/platforms/handlers.py
@@ -4,8 +4,11 @@ none is tied to a specific platform's payload shape."""
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +49,82 @@ PAUSE_LABEL = "mira-paused"
 _PAUSE_KEYWORDS = {"pause"}
 
 _RESUME_KEYWORDS = {"resume"}
+
+_REVIEW_CLAIM_TTL_SECONDS = 3600
+_REVIEW_CLAIM_REFRESH_SECONDS = 300
+
+
+async def _refresh_review_claim(
+    db: Any,
+    owner: str,
+    repo: str,
+    number: int,
+    claim_token: str,
+    platform: str,
+) -> None:
+    """Keep a long-running review's durable lease alive."""
+    while True:
+        await asyncio.sleep(_REVIEW_CLAIM_REFRESH_SECONDS)
+        try:
+            refreshed = db.refresh_review_claim(
+                owner,
+                repo,
+                number,
+                claim_token,
+                platform=platform,
+                ttl_seconds=_REVIEW_CLAIM_TTL_SECONDS,
+            )
+        except Exception:
+            logger.exception("Failed to refresh review claim for %s/%s#%d", owner, repo, number)
+            continue
+        if not refreshed:
+            logger.error("Review claim ownership lost for %s/%s#%d", owner, repo, number)
+            return
+
+
+@asynccontextmanager
+async def _review_claim(
+    owner: str,
+    repo: str,
+    number: int,
+    pr_title: str,
+    pr_url: str,
+    platform: str,
+) -> AsyncIterator[bool]:
+    """Claim one PR across all workers and mirror its status in memory."""
+    from mira.dashboard.api import _app_db
+
+    claim_token = _app_db.try_claim_review(
+        owner,
+        repo,
+        number,
+        platform=platform,
+        ttl_seconds=_REVIEW_CLAIM_TTL_SECONDS,
+    )
+    if claim_token is None:
+        yield False
+        return
+
+    repo_full = f"{owner}/{repo}"
+    review_tracker.start(repo_full, number, pr_title, pr_url)
+    refresh_task = asyncio.create_task(
+        _refresh_review_claim(_app_db, owner, repo, number, claim_token, platform)
+    )
+    try:
+        yield True
+    finally:
+        refresh_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await refresh_task
+        try:
+            released = _app_db.release_review_claim(
+                owner, repo, number, claim_token, platform=platform
+            )
+        except Exception:
+            logger.exception("Failed to release review claim for %s", pr_url)
+        else:
+            if not released:
+                logger.warning("Review claim was no longer owned for %s", pr_url)
 
 
 def _open_store(owner: str, repo: str, platform: str = "github") -> IndexStore:
@@ -93,41 +172,40 @@ async def run_pr_review(
     """
     repo_full = f"{owner}/{repo}"
 
-    # Atomically claim the slot — avoids stacking redundant runs when
-    # two concurrent webhooks arrive. Returns False if already reviewing.
-    if not review_tracker.try_start(repo_full, number, pr_title, pr_url):
-        logger.info("Review already in progress for %s, skipping", pr_url)
-        return
+    async with _review_claim(owner, repo, number, pr_title, pr_url, platform) as claimed:
+        if not claimed:
+            logger.info("Review already in progress for %s, skipping", pr_url)
+            return
 
-    config = load_config()
-    from mira.dashboard.models_config import llm_config_for
+        config = load_config()
+        from mira.dashboard.models_config import llm_config_for
 
-    llm = create_llm(llm_config_for("review", config.llm))
-    indexing_llm = create_llm(llm_config_for("indexing", config.llm))
-    engine = ReviewEngine(
-        config=config,
-        llm=llm,
-        provider=provider,
-        bot_name=bot_name,
-        indexing_llm=indexing_llm,
-    )
+        llm = create_llm(llm_config_for("review", config.llm))
+        indexing_llm = create_llm(llm_config_for("indexing", config.llm))
+        engine = ReviewEngine(
+            config=config,
+            llm=llm,
+            provider=provider,
+            bot_name=bot_name,
+            indexing_llm=indexing_llm,
+        )
 
-    from mira.dashboard.api import _app_db
+        from mira.dashboard.api import _app_db
 
-    # Keep visibility current — the blast-radius filter relies on it to avoid
-    # naming private repos in a public repo's review.
-    _app_db.set_repo_visibility(owner, repo, is_private, platform=platform)
+        # Keep visibility current — the blast-radius filter relies on it to avoid
+        # naming private repos in a public repo's review.
+        _app_db.set_repo_visibility(owner, repo, is_private, platform=platform)
 
-    repo_record = _app_db.get_repo(owner, repo, platform=platform)
-    is_indexed = bool(repo_record and repo_record.status == "ready")
+        repo_record = _app_db.get_repo(owner, repo, platform=platform)
+        is_indexed = bool(repo_record and repo_record.status == "ready")
 
-    logger.info("Reviewing %s (indexed=%s)", pr_url, is_indexed)
-    try:
-        result = await engine.review_pr(pr_url)
-        review_tracker.complete(repo_full, number)
-    except Exception as exc:
-        review_tracker.fail(repo_full, number, str(exc))
-        raise
+        logger.info("Reviewing %s (indexed=%s)", pr_url, is_indexed)
+        try:
+            result = await engine.review_pr(pr_url)
+            review_tracker.complete(repo_full, number)
+        except Exception as exc:
+            review_tracker.fail(repo_full, number, str(exc))
+            raise
 
     # The walkthrough comment already carries the "more accurate after indexing"
     # nudge for unindexed repos, so we don't post a separate note here — that
@@ -211,18 +289,22 @@ async def run_pr_command(
             indexing_llm=indexing_llm,
         )
         engine._review_only_paths = set(progress.skipped_paths)  # type: ignore[attr-defined]
-        if not review_tracker.try_start(repo_full, number, pr_title, pr_url):
-            logger.info("Review already in progress for %s, skipping", pr_url)
-            return
-        logger.info(
-            "review-rest on %s by @%s — %d file(s)", pr_url, actor, len(progress.skipped_paths)
-        )
-        try:
-            await engine.review_pr(pr_url)
-            review_tracker.complete(repo_full, number)
-        except Exception as exc:
-            review_tracker.fail(repo_full, number, str(exc))
-            raise
+        async with _review_claim(owner, repo, number, pr_title, pr_url, platform) as claimed:
+            if not claimed:
+                logger.info("Review already in progress for %s, skipping", pr_url)
+                return
+            logger.info(
+                "review-rest on %s by @%s — %d file(s)",
+                pr_url,
+                actor,
+                len(progress.skipped_paths),
+            )
+            try:
+                await engine.review_pr(pr_url)
+                review_tracker.complete(repo_full, number)
+            except Exception as exc:
+                review_tracker.fail(repo_full, number, str(exc))
+                raise
     elif is_review:
         engine = ReviewEngine(
             config=config,
@@ -231,16 +313,17 @@ async def run_pr_command(
             bot_name=bot_name,
             indexing_llm=indexing_llm,
         )
-        if not review_tracker.try_start(repo_full, number, pr_title, pr_url):
-            logger.info("Review already in progress for %s, skipping", pr_url)
-            return
-        logger.info("Re-review triggered for %s by @%s", pr_url, actor)
-        try:
-            await engine.review_pr(pr_url)
-            review_tracker.complete(repo_full, number)
-        except Exception as exc:
-            review_tracker.fail(repo_full, number, str(exc))
-            raise
+        async with _review_claim(owner, repo, number, pr_title, pr_url, platform) as claimed:
+            if not claimed:
+                logger.info("Review already in progress for %s, skipping", pr_url)
+                return
+            logger.info("Re-review triggered for %s by @%s", pr_url, actor)
+            try:
+                await engine.review_pr(pr_url)
+                review_tracker.complete(repo_full, number)
+            except Exception as exc:
+                review_tracker.fail(repo_full, number, str(exc))
+                raise
     else:
         pr_info = await provider.get_pr_info(pr_url)
         diff_text = await provider.get_pr_diff(pr_info)

--- a/tests/test_review_claims.py
+++ b/tests/test_review_claims.py
@@ -1,0 +1,91 @@
+"""Tests for durable, cross-worker PR review claims."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mira.dashboard.db import AppDatabase
+from mira.platforms.handlers import _review_claim
+
+
+def _db(path: str) -> AppDatabase:
+    return AppDatabase(url=path, admin_password="admin")
+
+
+def test_only_one_database_instance_can_claim_a_pr(tmp_path) -> None:
+    db_path = str(tmp_path / "app.db")
+    first = _db(db_path)
+    second = _db(db_path)
+    barrier = Barrier(2)
+
+    def claim(db: AppDatabase) -> str | None:
+        barrier.wait()
+        return db.try_claim_review("acme", "api", 42, platform="forgejo")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        tokens = list(pool.map(claim, (first, second)))
+
+    assert sum(token is not None for token in tokens) == 1
+
+
+def test_expired_claim_can_be_recovered_but_old_owner_cannot_release_it(tmp_path) -> None:
+    db_path = str(tmp_path / "app.db")
+    first = _db(db_path)
+    second = _db(db_path)
+
+    expired_token = first.try_claim_review("acme", "api", 42, platform="forgejo", ttl_seconds=-1)
+    replacement_token = second.try_claim_review("acme", "api", 42, platform="forgejo")
+
+    assert expired_token is not None
+    assert replacement_token is not None
+    assert replacement_token != expired_token
+    assert not first.release_review_claim("acme", "api", 42, expired_token, platform="forgejo")
+    assert second.refresh_review_claim("acme", "api", 42, replacement_token, platform="forgejo")
+    assert second.release_review_claim("acme", "api", 42, replacement_token, platform="forgejo")
+
+
+@pytest.mark.asyncio
+async def test_review_claim_releases_lease_when_review_fails() -> None:
+    db = MagicMock()
+    db.try_claim_review.return_value = "owned-token"
+    db.release_review_claim.return_value = True
+    tracker = MagicMock()
+
+    with (
+        patch("mira.dashboard.api._app_db", db),
+        patch("mira.platforms.handlers.review_tracker", tracker),
+        pytest.raises(RuntimeError, match="review failed"),
+    ):
+        async with _review_claim(
+            "acme", "api", 42, "Improve API", "https://forgejo/pr/42", "forgejo"
+        ) as claimed:
+            assert claimed
+            raise RuntimeError("review failed")
+
+    tracker.start.assert_called_once()
+    db.release_review_claim.assert_called_once_with(
+        "acme", "api", 42, "owned-token", platform="forgejo"
+    )
+
+
+@pytest.mark.asyncio
+async def test_review_claim_skips_when_another_worker_owns_pr() -> None:
+    db = MagicMock()
+    db.try_claim_review.return_value = None
+    tracker = MagicMock()
+
+    with (
+        patch("mira.dashboard.api._app_db", db),
+        patch("mira.platforms.handlers.review_tracker", tracker),
+    ):
+        async with _review_claim(
+            "acme", "api", 42, "Improve API", "https://forgejo/pr/42", "forgejo"
+        ) as claimed:
+            assert not claimed
+
+    tracker.start.assert_not_called()
+    db.release_review_claim.assert_not_called()


### PR DESCRIPTION
## Summary

- replace the process-local overlap guard with an atomic database-backed lease keyed by platform, repository, and PR number
- renew leases during long reviews and require an ownership token for refresh/release, while allowing expired claims to recover after a worker crash
- keep the existing in-memory tracker as the dashboard status view rather than the concurrency authority

Fixes #195.

## Test plan

- [x] `ruff check src/ tests/`
- [x] `ruff format --check src/ tests/`
- [x] `pytest tests/ --ignore=tests/evals --ignore=tests/test_integration.py` — 1,196 passed, 1 skipped, 1 deselected
- [x] added a two-connection SQLite race test proving exactly one worker acquires a claim
- [x] added expiry, ownership-safe release, failure cleanup, and duplicate-skip coverage
- [ ] `mypy src/mira/ --ignore-missing-imports` — the branch and untouched `main` both report the same existing 75 errors in 19 files

## Notes for reviewers

SQLite and PostgreSQL use the same single-statement `INSERT ... ON CONFLICT ... WHERE expires_at <= now` claim operation. The one-hour lease is refreshed every five minutes; a token prevents an expired worker from releasing a replacement worker's claim.
