### PR TITLE
fix(ui): card hiding overflow causing issues with setup

### DIFF
--- a/scripts/local_setup.sh
+++ b/scripts/local_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 echo "=== Mira Local Setup ==="

--- a/scripts/start_local.sh
+++ b/scripts/start_local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # cd to project root (parent of scripts/)
@@ -78,7 +78,7 @@ sleep 2
 
 # Start frontend
 echo "Starting frontend on port 5173..."
-cd UI/mira
+cd ui/mira
 VITE_API_URL=http://localhost:8100 npm run dev &
 UI_PID=$!
 cd ../..

--- a/ui/mira/src/components/ui/card.tsx
+++ b/ui/mira/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-4 overflow-hidden rounded-lg bg-card py-4 text-xs/relaxed text-card-foreground ring-1 ring-foreground/10 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg",
+        "group/card flex flex-col gap-4 rounded-lg bg-card py-4 text-xs/relaxed text-card-foreground ring-1 ring-foreground/10 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
Before opening this PR, please ensure:
- [ ] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [ ] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [x] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`


## Summary

Currently on the setup page the model drop downs aren't viable.

before:
<img width="593" height="475" alt="image" src="https://github.com/user-attachments/assets/59d0b34f-315c-4f10-b94d-1804993e0abb" />

after:
<img width="667" height="691" alt="image" src="https://github.com/user-attachments/assets/f704b986-5045-4a6f-ad36-25617c34b502" />


## Test plan
removed the class anc checked if the drop down was visable, the other places that still use card looked fine but they also have the className set to include overflow-hidden.

## Notes for reviewers
I also fixed some small things I ran into when trying to set this up locally, I can split these out into separate PR's if you'd prefer 

I updated the shebangs in the scripts to be a more universal one since trying to run `#!/bin/bash` will error on some system like on nix
```
 ./scripts/start_local.sh
zsh: ./scripts/start_local.sh: bad interpreter: /bin/bash: no such file or directory
```

I also updated the cd to use ui instead of UI since linux is case sensitive, I believe macos isn't so this probably works fine for some people too.

also also, even tho I didn't change any python code, I did try and run `uv run pytest tests/` but one test fails even on main for not having a bedrock provider and says `Install with: pip install mira-reviewer[bedrock]` should this be in the uv or something in the CONTRIBUTING.md?

same thing with `uv run mypy src/mira/ --ignore-missing-imports` also errors on main