### PR TITLE
feat(security): run the agentic read_file/grep_repo loop on the security pass

### DIFF
--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -210,6 +210,13 @@ class ReviewConfig(BaseModel):
     # comments and go through the same noise filter.
     security_pass: bool = True
 
+    # Agentic loop (`read_file`, `grep_repo`) for the security pass on the
+    # security-tier model, so it can verify cross-file claims before filing,
+    # like the main pass. Falls back to the one-shot call when the loop bails
+    # without a submission. Gated on `agentic_tools` plus a live source
+    # fetcher — without either, the pass runs the one-shot path unchanged.
+    security_agentic: bool = True
+
     # Deterministic CVE check on changed dependency manifests: packages added
     # or version-bumped by the PR are queried against OSV.dev at review time
     # (the background poller only re-scans the repo hourly, post-merge). No

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -1385,6 +1385,23 @@ class ReviewEngine:
                     return [], [], ""
 
         review_task = _asyncio.gather(*[_review_chunk(i, c) for i, c in enumerate(chunks)])
+        # Per-chunk executors (fresh per call) so each chunk gets its own
+        # 50KB tool-output budget; one shared executor would let an early
+        # chunk exhaust the budget and wedge later chunks.
+        _security_executor_factory = None
+        if (
+            self.config.review.security_agentic
+            and self.config.review.agentic_tools
+            and self._agentic_source_fetcher is not None
+        ):
+            from mira.llm.agentic_tools import AgenticToolExecutor
+
+            def _security_executor_factory() -> AgenticToolExecutor:
+                return AgenticToolExecutor(
+                    source_fetcher=self._agentic_source_fetcher,
+                    repo_tree=list(self._agentic_repo_tree),
+                )
+
         security_task = _asyncio.create_task(
             security_review_pass(
                 self.llm,
@@ -1392,6 +1409,7 @@ class ReviewEngine:
                 _security_relevant_files(filtered),
                 pr_title,
                 security_llm=self.security_llm,
+                agentic_executor_factory=_security_executor_factory,
             )
             if self.config.review.security_pass
             else _asyncio.sleep(0, result=[])

--- a/src/mira/core/passes.py
+++ b/src/mira/core/passes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json as _json
 import logging
+from collections.abc import Callable
 
 from mira.config import load_config
 from mira.dashboard.models_config import llm_config_for
@@ -135,6 +136,7 @@ async def security_review_pass(
     narrowed: list,
     pr_title: str = "",
     security_llm: LLMProvider | None = None,
+    agentic_executor_factory: Callable[[], object] | None = None,
 ) -> list[ReviewComment]:
     """Dedicated security review on the security tier (``security_model`` → review model).
 
@@ -146,6 +148,10 @@ async def security_review_pass(
 
     `security_llm`, when passed, is the caller's already-built security-tier
     provider; otherwise one is constructed from ``load_config()``.
+
+    `agentic_executor_factory`, when passed, builds one fresh tool executor
+    per chunk so the pass can run the agentic read_file/grep_repo loop
+    (falling back to the one-shot call when the loop bails).
     """
     if not files:
         return []
@@ -164,7 +170,13 @@ async def security_review_pass(
         provider=sec_llm if hasattr(sec_llm, "count_tokens") else None,
     )
     if len(chunks) <= 1:
-        return await _security_scan_once(sec_llm, llm, target_files, pr_title)
+        return await _security_scan_once(
+            sec_llm,
+            llm,
+            target_files,
+            pr_title,
+            executor=agentic_executor_factory() if agentic_executor_factory else None,
+        )
 
     logger.info(
         "Security pass: splitting %d files into %d chunks (single-call budget %d tokens)",
@@ -176,7 +188,13 @@ async def security_review_pass(
 
     async def _bounded(chunk_files_list: list) -> list[ReviewComment]:
         async with sem:
-            return await _security_scan_once(sec_llm, llm, chunk_files_list, pr_title)
+            return await _security_scan_once(
+                sec_llm,
+                llm,
+                chunk_files_list,
+                pr_title,
+                executor=agentic_executor_factory() if agentic_executor_factory else None,
+            )
 
     results = await asyncio.gather(*[_bounded(c.files) for c in chunks])
     return [c for chunk_comments in results for c in chunk_comments]
@@ -187,15 +205,35 @@ async def _security_scan_once(
     fallback_llm: LLMProvider,
     files: list,
     pr_title: str,
+    executor: object | None = None,
 ) -> list[ReviewComment]:
-    """Run the security scan on a single chunk of files."""
+    """Run the security scan on a single chunk of files.
+
+    When ``executor`` is given, the agentic tool-use loop runs first on the
+    security-tier provider. Whether it bails (returns "") or raises
+    (executor bug, uncaught tool error), the one-shot call below is the
+    floor; the existing ``except`` path then retries on ``fallback_llm``,
+    so the pass still returns ``[]`` on total failure rather than
+    propagating into the main review.
+    """
     messages = build_security_review_prompt(files=files, pr_title=pr_title)
+    raw = ""
+    if executor is not None:
+        try:
+            raw = await agentic_review_loop(sec_llm, messages, executor)
+        except Exception as exc:
+            logger.warning(
+                "Security pass agentic loop failed (%s); falling back to one-shot",
+                exc,
+            )
+            raw = ""
     try:
-        raw = await sec_llm.complete_with_tools(
-            messages=messages,
-            tools=[SUBMIT_REVIEW_TOOL],
-            temperature=0.0,
-        )
+        if not raw:
+            raw = await sec_llm.complete_with_tools(
+                messages=messages,
+                tools=[SUBMIT_REVIEW_TOOL],
+                temperature=0.0,
+            )
     except Exception as exc:
         # Retry on the main LLM rather than drop the security pass entirely.
         if sec_llm is not fallback_llm:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2342,3 +2342,221 @@ class TestAgenticToolsOnIndexedRepos:
         await engine.review_pr("https://github.com/test/repo/pull/1")
 
         assert engine._agentic_source_fetcher is None
+
+
+class TestAgenticSecurityPass(TestAgenticToolsOnIndexedRepos):
+    """Security pass runs the agentic loop when enabled; one-shot when it bails."""
+
+    _SECURITY_FILE_DIFF = FileDiff(
+        path="src/auth.py",
+        change_type=FileChangeType.MODIFIED,
+        language="python",
+        added_lines=3,
+        deleted_lines=0,
+        hunks=[
+            SimpleNamespace(
+                target_start=1,
+                target_length=4,
+                content=" x = 0\n+y = 1\n+if y == SECRET:\n+    login()\n",
+            )
+        ],
+    )
+
+    _SECURITY_CANNED = json.dumps(
+        {
+            "comments": [
+                {
+                    "path": "src/auth.py",
+                    "line": 2,
+                    "severity": "blocker",
+                    "category": "security",
+                    "title": "Hardcoded secret",
+                    "body": "Do not hardcode the auth token.",
+                    "confidence": 0.9,
+                }
+            ],
+            "summary": "s",
+            "metadata": {"reviewed_files": 1},
+        }
+    )
+
+    async def _engine_with_index(self, monkeypatch, tmp_path, **config_overrides):
+        from mira.config import MiraConfig
+        from mira.core.engine import ReviewEngine
+        from mira.index.store import FileSummary, IndexStore
+
+        monkeypatch.setenv("MIRA_INDEX_DIR", str(tmp_path))
+
+        store = IndexStore.open("test", "repo")
+        store.upsert_summary(
+            FileSummary(path="src/a.py", language="python", summary="Module a", content_hash="h")
+        )
+        store.close()
+
+        config = MiraConfig()
+        config.review.agentic_tools = True
+        config.review.code_context = True
+        config.review.self_critique = False
+        for key, value in config_overrides.items():
+            setattr(config.review, key, value)
+
+        mock_llm = MagicMock()
+        mock_llm.review = AsyncMock(return_value="{}")
+        mock_llm.count_tokens = MagicMock(return_value=100)
+        mock_llm.usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+        engine = ReviewEngine(config=config, llm=mock_llm, provider=self._make_provider())
+        await engine.review_pr("https://github.com/test/repo/pull/1")
+        return engine
+
+    @pytest.mark.asyncio
+    async def test_security_agentic_factory_built(self, monkeypatch, tmp_path):
+        """security_agentic on (default) + live fetcher → pass gets a factory
+        that yields per-chunk AgenticToolExecutor instances."""
+        from mira.core import engine as engine_mod
+        from mira.llm.agentic_tools import AgenticToolExecutor
+
+        seen: dict = {}
+
+        async def fake_sec_pass(llm, files, narrowed, pr_title="", **kw):
+            seen.update(kw)
+            return []
+
+        monkeypatch.setattr(engine_mod, "security_review_pass", fake_sec_pass)
+
+        engine = await self._engine_with_index(
+            monkeypatch, tmp_path, security_pass=True, security_agentic=True
+        )
+
+        assert engine._agentic_source_fetcher is not None
+        factory = seen["agentic_executor_factory"]
+        assert callable(factory)
+
+        exec1, exec2 = factory(), factory()
+        assert isinstance(exec1, AgenticToolExecutor)
+        assert isinstance(exec2, AgenticToolExecutor)
+        assert exec1 is not exec2, "factory must yield a fresh executor per chunk"
+        assert exec1.source_fetcher is engine._agentic_source_fetcher
+        assert exec1.repo_tree == list(engine._agentic_repo_tree)
+        assert seen["security_llm"] is engine.security_llm
+
+    @pytest.mark.asyncio
+    async def test_security_agentic_off_no_factory(self, monkeypatch, tmp_path):
+        """security_agentic=False → factory stays None even with a live fetcher."""
+        from mira.core import engine as engine_mod
+
+        seen: dict = {}
+
+        async def fake_sec_pass(llm, files, narrowed, pr_title="", **kw):
+            seen.update(kw)
+            return []
+
+        monkeypatch.setattr(engine_mod, "security_review_pass", fake_sec_pass)
+
+        engine = await self._engine_with_index(
+            monkeypatch, tmp_path, security_pass=True, security_agentic=False
+        )
+
+        assert engine._agentic_source_fetcher is not None
+        assert seen["agentic_executor_factory"] is None
+
+    @pytest.mark.asyncio
+    async def test_agentic_loop_used_when_factory_given(self, monkeypatch):
+        """With a factory, the agentic loop runs on the security tier and the
+        one-shot fallback is never attempted."""
+        from mira.core.passes import security_review_pass
+
+        loop_mock = AsyncMock(return_value=self._SECURITY_CANNED)
+        monkeypatch.setattr("mira.core.passes.agentic_review_loop", loop_mock)
+
+        sec_llm = MagicMock(spec=LLMProvider)
+        sec_llm.count_tokens = MagicMock(return_value=100)
+        sec_llm.complete_with_tools = AsyncMock(
+            side_effect=AssertionError("one-shot fallback must not run when the loop submits")
+        )
+        main_llm = MagicMock(spec=LLMProvider)
+        main_llm.complete_with_tools = AsyncMock(
+            side_effect=AssertionError("one-shot fallback must not run when the loop submits")
+        )
+
+        with patch("mira.core.passes.load_config") as mock_cfg:
+            mock_cfg.return_value = MiraConfig()
+            out = await security_review_pass(
+                main_llm,
+                [self._SECURITY_FILE_DIFF],
+                [self._SECURITY_FILE_DIFF],
+                "title",
+                security_llm=sec_llm,
+                agentic_executor_factory=lambda: MagicMock(),
+            )
+
+        loop_mock.assert_awaited_once()
+        provider = loop_mock.call_args[0][0]
+        assert provider is sec_llm, "loop must run on the security-tier provider"
+        main_llm.complete_with_tools.assert_not_called()
+        assert out
+        assert all(c.source_pass == "security" and c.category == "security" for c in out)
+
+    @pytest.mark.asyncio
+    async def test_loop_bails_falls_back_to_one_shot(self, monkeypatch):
+        """Loop bails (returns "") → one-shot security-tier call is the floor
+        and its comments still come back tagged security."""
+        from mira.core.passes import security_review_pass
+
+        loop_mock = AsyncMock(return_value="")
+        monkeypatch.setattr("mira.core.passes.agentic_review_loop", loop_mock)
+
+        llm = MagicMock(spec=LLMProvider)
+        llm.count_tokens = MagicMock(return_value=100)
+        llm.complete_with_tools = AsyncMock(return_value=self._SECURITY_CANNED)
+
+        with patch("mira.core.passes.load_config") as mock_cfg:
+            mock_cfg.return_value = MiraConfig()
+            out = await security_review_pass(
+                llm,
+                [self._SECURITY_FILE_DIFF],
+                [self._SECURITY_FILE_DIFF],
+                "title",
+                security_llm=llm,
+                agentic_executor_factory=lambda: MagicMock(),
+            )
+
+        loop_mock.assert_awaited_once()
+        llm.complete_with_tools.assert_called_once()
+        assert len(out) == 1
+        assert out[0].source_pass == "security"
+        assert out[0].category == "security"
+
+    @pytest.mark.asyncio
+    async def test_loop_raises_falls_back_to_one_shot(self, monkeypatch):
+        """If the loop ever raises (executor bug, uncaught tool error), the
+        exception must be contained and the one-shot retry path must still
+        run — the pass must never propagate into the main review."""
+        from mira.core.passes import security_review_pass
+
+        loop_mock = AsyncMock(side_effect=RuntimeError("executor blew up"))
+        monkeypatch.setattr("mira.core.passes.agentic_review_loop", loop_mock)
+
+        sec_llm = MagicMock(spec=LLMProvider)
+        sec_llm.count_tokens = MagicMock(return_value=100)
+        sec_llm.complete_with_tools = AsyncMock(side_effect=RuntimeError("security tier down"))
+        main_llm = MagicMock(spec=LLMProvider)
+        main_llm.complete_with_tools = AsyncMock(return_value=self._SECURITY_CANNED)
+
+        with patch("mira.core.passes.load_config") as mock_cfg:
+            mock_cfg.return_value = MiraConfig()
+            # Must return, not raise — and land on the fallback-LLM retry.
+            out = await security_review_pass(
+                main_llm,
+                [self._SECURITY_FILE_DIFF],
+                [self._SECURITY_FILE_DIFF],
+                "title",
+                security_llm=sec_llm,
+                agentic_executor_factory=lambda: MagicMock(),
+            )
+
+        loop_mock.assert_awaited_once()
+        sec_llm.complete_with_tools.assert_called_once()
+        main_llm.complete_with_tools.assert_called_once()
+        assert len(out) == 1
+        assert out[0].source_pass == "security"


### PR DESCRIPTION
## Summary

The security pass (`security_review_pass` → `_security_scan_once`) is a one-shot LLM call per chunk at temperature 0.0 — it cannot pull a file to check whether a suspected sink is actually sanitized upstream, or verify a cross-file claim. The main review pass already has the agentic loop (`agentic_review_loop`) with exactly those tools. This PR lets the security pass run the same loop on the **security-tier** model, so the highest-stakes pass can investigate before filing.

## Changes

- **`src/mira/config.py`** — new `review.security_agentic` flag (default `True`), next to `security_pass`/`agentic_tools`.
- **`src/mira/core/passes.py`** — `security_review_pass` gains `agentic_executor_factory: Callable[[], object] | None = None`; each chunk invokes it for a fresh `AgenticToolExecutor` (per-chunk 50KB tool-budget isolation). `_security_scan_once` runs `agentic_review_loop(sec_llm, messages, executor)` first; if the loop bails (`""`), the existing one-shot `complete_with_tools` + fallback-LLM retry is the untouched floor.
- **`src/mira/core/engine.py`** — builds the factory (gated on `security_agentic` ∧ `agentic_tools` ∧ live `_agentic_source_fetcher`) and passes it at the security-task call site. Unindexed/no-provider paths (CLI/stdin) auto-skip to one-shot.
- **`tests/test_engine.py`** — new `TestAgenticSecurityPass` (4 tests): factory built/wired + per-chunk freshness + `security_agentic=False` → `None`; loop used on the security-tier provider with no one-shot call; loop-bails → one-shot fallback floor with `source_pass="security"` comments.

## Why it's safe

- Hop cap 6 + `""` fallback: worst case is identical cost/behavior to today's one-shot.
- Tier resolution untouched; the executor is model-agnostic (pure fetcher/grep).
- Default `agentic_executor_factory=None` keeps all existing callers/tests on current behavior.

## Verification

- `pytest tests/test_engine.py -k "agentic or security" tests/test_agentic_tools.py -q` — 30 passed
- Full suite: **1345 passed**, 1 skipped, 34 deselected
- `ruff check` clean on all four touched files
- Live smoke (post-merge, needs a real PR): a finding that requires a cross-file check (e.g. an un-sanitized sink whose sanitizer lives in another file) should now surface where the one-shot pass previously couldn't prove it.