### PR TITLE
feat(security): deterministic secrets scan over added diff lines

### DIFF
--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -216,6 +216,12 @@ class ReviewConfig(BaseModel):
     # LLM involved — one batch HTTP request per PR with manifest changes.
     osv_scan: bool = True
 
+    # Deterministic regex+entropy scan of added diff lines for hardcoded
+    # keys/tokens/passwords. No LLM involved — pure in-memory regex pass,
+    # no network. Complements the LLM security pass (which has no key-format
+    # rules).
+    secrets_scan: bool = True
+
     # Give the reviewer LLM tools (`read_file`, `grep_repo`) to fetch
     # cross-file context on demand. On unindexed repos this closes the
     # Java/Go gaps JIT pre-fetch can't reach; on indexed repos it lets the

--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -59,6 +59,7 @@ from mira.models import (
     build_review_stats,
 )
 from mira.providers.base import BaseProvider
+from mira.security.secrets_scan import scan_secrets
 
 logger = logging.getLogger(__name__)
 
@@ -1445,8 +1446,20 @@ class ReviewEngine:
             else _asyncio.sleep(0, result=[])
         )
 
-        chunk_results, security_comments, dependency_comments, osv_comments = await _asyncio.gather(
-            review_task, security_task, dependency_task, osv_task
+        secrets_task = _asyncio.create_task(
+            scan_secrets(filtered)
+            if filtered and self.config.review.secrets_scan
+            else _asyncio.sleep(0, result=[])
+        )
+
+        (
+            chunk_results,
+            security_comments,
+            dependency_comments,
+            osv_comments,
+            secrets_comments,
+        ) = await _asyncio.gather(
+            review_task, security_task, dependency_task, osv_task, secrets_task
         )
 
         all_comments: list[ReviewComment] = []
@@ -1464,6 +1477,8 @@ class ReviewEngine:
         all_comments.extend(dependency_comments)
         audit.append({"stage": "drafted", "chunk": "osv", "count": len(osv_comments)})
         all_comments.extend(osv_comments)
+        audit.append({"stage": "drafted", "chunk": "secrets", "count": len(secrets_comments)})
+        all_comments.extend(secrets_comments)
 
         all_comments = [classify_severity(c) for c in all_comments]
 

--- a/src/mira/security/pr_scan.py
+++ b/src/mira/security/pr_scan.py
@@ -9,6 +9,7 @@ No LLM involved.
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 
 from mira.index.manifests import parse_manifest
@@ -28,13 +29,31 @@ logger = logging.getLogger(__name__)
 _MAX_VULNS_PER_COMMENT = 3
 
 
-def _added_line_hits(file_diff: FileDiff, needle: str) -> list[tuple[int, str]]:
-    """(target line number, line text) of added lines containing `needle`.
+def _added_line_hits(file_diff: FileDiff, needle: str | re.Pattern | None) -> list[tuple[int, str]]:
+    """(target line number, line text) of added lines matching `needle`.
 
     Hunk content includes the @@ header (diff_parser stores str(hunk)) —
     skip it WITHOUT incrementing; target_start is the first body line.
+
+    - `str`: case-insensitive substring match (existing behavior).
+    - compiled `re.Pattern`: `needle.search(line)` on the raw added line
+      (the pattern carries its own flags, no lowercasing).
+    - `None`: every added line.
     """
-    needle_l = needle.lower()
+    if isinstance(needle, str):
+        needle_l = needle.lower()
+
+        def _match(line: str) -> bool:
+            return needle_l in line.lower()
+    elif isinstance(needle, re.Pattern):
+
+        def _match(line: str) -> bool:
+            return needle.search(line) is not None
+    else:
+
+        def _match(line: str) -> bool:
+            return True
+
     hits: list[tuple[int, str]] = []
     for hunk in file_diff.hunks:
         line_no = hunk.target_start
@@ -42,7 +61,7 @@ def _added_line_hits(file_diff: FileDiff, needle: str) -> list[tuple[int, str]]:
             if raw.startswith("@@"):
                 continue
             if raw.startswith("+"):
-                if needle_l in raw[1:].lower():
+                if _match(raw[1:]):
                     hits.append((line_no, raw[1:]))
                 line_no += 1
             elif raw.startswith("-"):

--- a/src/mira/security/secrets_scan.py
+++ b/src/mira/security/secrets_scan.py
@@ -1,0 +1,162 @@
+"""Review-time deterministic secrets scan: flag hardcoded credentials in the diff.
+
+The LLM security pass sweeps for known vulnerability classes (XSS, injection,
+auth bypass, …) but has no key-format rules — a PR that commits a real
+`ghp_…` token slips through if the critic isn't in the mood. This module
+closes that gap with a pure-Python, in-memory, no-network regex+entropy pass
+over the added lines of the diff, mirroring pr_scan.py (which scans added
+manifest entries against OSV).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections import Counter
+
+from mira.models import FileDiff, ReviewComment, Severity
+from mira.security.pr_scan import _added_line_hits
+
+logger = logging.getLogger(__name__)
+
+# Cap deterministic findings per file so a generated-file-heavy PR can't
+# drown the review in noise. Stop scanning that file once the cap is hit.
+_MAX_PER_FILE = 5
+
+# Placeholder-ish literals the entropy gate must reject even if entropy is
+# high (e.g. "your_super_secret_key" style scaffolding).
+_PLACEHOLDER_RE = re.compile(r"xxx|your_|placeholder|example|changeme|dummy|<[^>]*>", re.IGNORECASE)
+
+# (compiled regex, label, severity) over ONE added line (raw[1:]).
+# Pattern 1 stays case-sensitive — its prefix set is uppercase by spec;
+# the rest use re.IGNORECASE where the literal already mixes case.
+_SECRET_PATTERNS: list[tuple[re.Pattern, str, Severity]] = [
+    (
+        re.compile(r"\b(AKIA|ASIA|ABIA|ACCA)[A-Z0-9]{16}\b"),
+        "AWS access key",
+        Severity.BLOCKER,
+    ),
+    (
+        re.compile(r"\b(gh[pousr]_[A-Za-z0-9]{36,255})\b", re.IGNORECASE),
+        "GitHub token",
+        Severity.BLOCKER,
+    ),
+    (
+        re.compile(r"\bglpat-[A-Za-z0-9\-_]{20,}\b", re.IGNORECASE),
+        "GitLab personal access token",
+        Severity.BLOCKER,
+    ),
+    (
+        re.compile(r"\bAIza[0-9A-Za-z\-_]{35}\b", re.IGNORECASE),
+        "Google API key",
+        Severity.BLOCKER,
+    ),
+    (
+        re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{10,}\b", re.IGNORECASE),
+        "Slack token",
+        Severity.BLOCKER,
+    ),
+    (
+        re.compile(r"\bsk_live_[0-9a-zA-Z]{24,}\b", re.IGNORECASE),
+        "Stripe secret key",
+        Severity.BLOCKER,
+    ),
+    (
+        re.compile(r"-----BEGIN (RSA |EC |OPENSSH |)PRIVATE KEY-----"),
+        "private key block",
+        Severity.BLOCKER,
+    ),
+    (
+        re.compile(
+            r"(?:api[_-]?key|secret|token|password|passwd)\s*[:=]\s*[\"']([^\"']{12,})[\"']",
+            re.IGNORECASE,
+        ),
+        "credential assignment",
+        Severity.BLOCKER,
+    ),
+]
+
+# The credential assignment pattern (last entry) captures the quoted literal
+# in group 1 for the entropy gate.
+_CREDENTIAL_ASSIGNMENT_RE = _SECRET_PATTERNS[-1][0]
+_ENTROPY_THRESHOLD = 3.5
+
+
+def shannon_entropy(s: str) -> float:
+    """Shannon entropy (base 2), 0 for empty. Used to reject placeholder-ish
+    low-entropy literals like 'aaaaaaaa' or 'examplepassword'."""
+    if not s:
+        return 0.0
+    counts = Counter(s)
+    n = float(len(s))
+    return -sum((c / n) * math.log2(c / n) for c in counts.values())
+
+
+def _capture_literal(line: str) -> str | None:
+    """Quoted literal from a credential assignment match, or None."""
+    m = _CREDENTIAL_ASSIGNMENT_RE.search(line)
+    if m is None:
+        return None
+    return m.group(1)
+
+
+def _assignment_gate(line: str) -> bool:
+    """Pattern 8 gate: entropy >= threshold and not a known placeholder."""
+    literal = _capture_literal(line)
+    if literal is None or shannon_entropy(literal) < _ENTROPY_THRESHOLD:
+        return False
+    return _PLACEHOLDER_RE.search(literal) is None
+
+
+async def scan_secrets(files: list[FileDiff]) -> list[ReviewComment]:
+    """Scan added diff lines for hardcoded credentials. Pure in-memory, fails open."""
+    if not files:
+        return []
+    comments: list[ReviewComment] = []
+    try:
+        for f in files:
+            per_file: list[ReviewComment] = []
+            added = _added_line_hits(f, needle=None)
+            for pat, label, sev in _SECRET_PATTERNS:
+                if len(per_file) >= _MAX_PER_FILE:
+                    break
+                hit = None
+                for line_no, text in added:
+                    if pat.search(text) is None:
+                        continue
+                    if pat is _CREDENTIAL_ASSIGNMENT_RE and not _assignment_gate(text):
+                        continue
+                    hit = (line_no, text)
+                    break
+                if hit is None:
+                    continue
+                line_no, text = hit
+                per_file.append(
+                    ReviewComment(
+                        path=f.path,
+                        line=line_no,
+                        end_line=None,
+                        severity=sev,
+                        category="security",
+                        title=f"Hardcoded {label} in diff",
+                        body=(
+                            f"Deterministic scan found a {label} on the added line. "
+                            f"Rotate/remove this key and move it to a secret store. "
+                            f"Confidence 0.9."
+                        ),
+                        confidence=0.9,
+                        suggestion=None,
+                        agent_prompt=(
+                            f"In {f.path}:{line_no}, remove the {label} and load it "
+                            f"from the environment/secret manager instead of the source."
+                        ),
+                        existing_code=text,
+                        source_pass="secrets",
+                    )
+                )
+            comments.extend(per_file)
+    except Exception as exc:
+        logger.warning("Secrets scan failed: %s", exc)
+        return []
+    return comments

--- a/tests/test_secrets_scan.py
+++ b/tests/test_secrets_scan.py
@@ -1,0 +1,205 @@
+"""Tests for the deterministic secrets scanner (src/mira/security/secrets_scan.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from mira.models import FileChangeType, FileDiff, HunkInfo, Severity
+from mira.security import secrets_scan
+from mira.security.secrets_scan import scan_secrets, shannon_entropy
+
+# ---------------------------------------------------------------------------
+# Helpers (cloned from tests/test_pr_scan.py)
+# ---------------------------------------------------------------------------
+
+
+def _hunk(target_start: int, content: str) -> HunkInfo:
+    return HunkInfo(
+        source_start=1,
+        source_length=0,
+        target_start=target_start,
+        target_length=0,
+        content=content,
+    )
+
+
+def _file_diff(path: str, hunks: list[HunkInfo]) -> FileDiff:
+    return FileDiff(
+        path=path,
+        change_type=FileChangeType.MODIFIED,
+        language="",
+        added_lines=0,
+        deleted_lines=0,
+        hunks=hunks,
+    )
+
+
+# The key-format patterns are anchored with \b, so the key must not sit
+# immediately inside quotes (the opening quote breaks the boundary) — mirror
+# the plan's unquoted example form.
+AWS_KEY_LINE = "aws_access_key_id = AKIAABCDEFGHIJKLMNOP"
+GITHUB_TOKEN = "ghp_" + "a1B2c3D4e5F6g7H8i9J0kLmNoPqRsTuVwXyZ"  # 40 chars after ghp_
+
+# ---------------------------------------------------------------------------
+# shannon_entropy
+# ---------------------------------------------------------------------------
+
+
+class TestShannonEntropy:
+    def test_empty_is_zero(self):
+        assert shannon_entropy("") == 0.0
+
+    def test_single_char_is_zero(self):
+        assert shannon_entropy("aaaaaaaaaaaaaaaaaaaa") == 0.0
+
+    def test_mixed_is_high(self):
+        assert shannon_entropy("aB3$x9Zk2mQp7wLt") > 3.5
+
+
+# ---------------------------------------------------------------------------
+# Pattern matches
+# ---------------------------------------------------------------------------
+
+
+class TestSecretMatches:
+    @pytest.mark.asyncio
+    async def test_aws_key(self):
+        """One added line with an AWS key → exactly one correctly-anchored comment."""
+        diff = _file_diff(
+            "config.py",
+            [_hunk(target_start=7, content=f"@@ -1,1 +1,2 @@\n+{AWS_KEY_LINE}\n")],
+        )
+
+        comments = await scan_secrets([diff])
+        assert len(comments) == 1
+        c = comments[0]
+        assert c.path == "config.py"
+        assert c.line == 7
+        assert c.severity == Severity.BLOCKER
+        assert c.category == "security"
+        assert c.source_pass == "secrets"
+        assert "AKIA" in c.existing_code
+        assert c.confidence == 0.9
+        assert c.title == "Hardcoded AWS access key in diff"
+
+    @pytest.mark.asyncio
+    async def test_github_token(self):
+        diff = _file_diff(
+            "ci.sh",
+            [_hunk(target_start=3, content=f"@@ -1,1 +1,2 @@\n+GITHUB_TOKEN={GITHUB_TOKEN}\n")],
+        )
+
+        comments = await scan_secrets([diff])
+        assert len(comments) == 1
+        assert "GitHub token" in comments[0].title
+        assert comments[0].line == 3
+
+    @pytest.mark.asyncio
+    async def test_high_entropy_assignment(self):
+        line = "password = 'aB3$x9Zk2mQp7wLt'"
+        diff = _file_diff(
+            "setup.py",
+            [_hunk(target_start=2, content=f"@@ -1,1 +1,2 @@\n+{line}\n")],
+        )
+
+        comments = await scan_secrets([diff])
+        assert len(comments) == 1
+        assert "credential assignment" in comments[0].title
+
+    @pytest.mark.asyncio
+    async def test_placeholder_assignment_not_matched(self):
+        """'changeme' is on the placeholder reject list → no comment."""
+        line = 'api_key = "changeme"'
+        diff = _file_diff(
+            "setup.py",
+            [_hunk(target_start=2, content=f"@@ -1,1 +1,2 @@\n+{line}\n")],
+        )
+
+        assert await scan_secrets([diff]) == []
+
+    @pytest.mark.asyncio
+    async def test_low_entropy_assignment_not_matched(self):
+        """All-same-char literal has entropy 0 → no comment."""
+        line = 'api_key = "aaaaaaaaaaaaaaaaaaaa"'
+        diff = _file_diff(
+            "setup.py",
+            [_hunk(target_start=2, content=f"@@ -1,1 +1,2 @@\n+{line}\n")],
+        )
+
+        assert await scan_secrets([diff]) == []
+
+
+# ---------------------------------------------------------------------------
+# Dedup and cap
+# ---------------------------------------------------------------------------
+
+
+class TestDedupAndCap:
+    @pytest.mark.asyncio
+    async def test_same_pattern_twice_one_comment(self):
+        """Same AWS key on two added lines in the same file → exactly one comment."""
+        diff = _file_diff(
+            "config.py",
+            [
+                _hunk(
+                    target_start=1,
+                    content=f"@@ -1,1 +1,3 @@\n+{AWS_KEY_LINE}\n+other\n+{AWS_KEY_LINE}\n",
+                )
+            ],
+        )
+
+        comments = await scan_secrets([diff])
+        assert len(comments) == 1
+        assert comments[0].line == 1, "first added line wins"
+
+    @pytest.mark.asyncio
+    async def test_per_file_cap(self):
+        """Six distinct secret patterns in one file → capped at 5 comments."""
+        lines = [
+            AWS_KEY_LINE,
+            f"token={GITHUB_TOKEN}",
+            "glpat-AbCdEfGhIjKlMnOpQrSt",
+            "AIza" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r",  # AIza + 35 chars
+            "xoxb-1234567890abcdef",
+            "sk_live_" + "AbCdEfGhIjKlMnOpQrStUvWx",
+        ]
+        content = "@@ -1,1 +1,7 @@\n" + "".join(f"+{line}\n" for line in lines)
+        diff = _file_diff("creds.env", [_hunk(target_start=1, content=content)])
+
+        comments = await scan_secrets([diff])
+        assert len(comments) == 5
+        assert {c.title for c in comments} == {
+            "Hardcoded AWS access key in diff",
+            "Hardcoded GitHub token in diff",
+            "Hardcoded GitLab personal access token in diff",
+            "Hardcoded Google API key in diff",
+            "Hardcoded Slack token in diff",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and fail-open
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_empty_files(self):
+        assert await scan_secrets([]) == []
+
+    @pytest.mark.asyncio
+    async def test_no_secrets(self):
+        diff = _file_diff(
+            "README.md",
+            [_hunk(target_start=1, content="@@ -1,1 +1,2 @@\n+just some prose\n")],
+        )
+        assert await scan_secrets([diff]) == []
+
+    @pytest.mark.asyncio
+    async def test_fail_open(self):
+        """Any exception inside the scan → warn + return [], never raise."""
+        diff = _file_diff("x.py", [_hunk(target_start=1, content="@@ -1,1 +1,2 @@\n+pass\n")])
+        with patch.object(secrets_scan, "_added_line_hits", side_effect=RuntimeError("boom")):
+            assert await scan_secrets([diff]) == []


### PR DESCRIPTION
## Summary

Mira now deterministically detects hardcoded credentials in the diff and posts security review comments for them — a pure-Python, in-memory, no-network regex+entropy pass that runs in parallel with the other review passes, catching key-format secrets the LLM security pass has no rules for.

## Motivation

The LLM security pass sweeps for vulnerability classes (XSS, injection, auth bypass, …) but has no key-format rules — a PR committing a real `ghp_…` token, AWS access key, or Stripe secret can slip through if the critic isn't in the mood. Other platforms cover this with deterministic engines (gitleaks/trufflehog); this closes the same gap in-tree with zero new dependencies.

## Changes

- New `src/mira/security/secrets_scan.py`: 8 compiled patterns (AWS, GitHub, GitLab, Google API, Slack, Stripe, PEM private key) plus a generic credential-assignment pattern gated on Shannon entropy (>= 3.5) with a placeholder reject list. One comment per (file, pattern, first hit), capped at 5 per file.
- `pr_scan._added_line_hits` generalized additively to accept `str | re.Pattern | None` — existing pr_scan callers (str path) unchanged.
- `ReviewConfig.secrets_scan: bool = True` — new toggle, default on.
- Engine runs `scan_secrets(filtered)` in the existing gather alongside the other passes; findings flow through `classify_severity` and `filter_noise` like every other pass, with an audit entry for the chunk.
- `tests/test_secrets_scan.py` (new, 205 lines): AWS-key anchoring, GitHub token match, entropy-gate placeholder rejection, per-file dedupe and 5-cap, empty input, and the fail-open path.

## Notes

- **Severity is capped to WARNING**: the comment title contains the keyword "Hardcoded", which is a member of `classify_severity`'s security-smell keywords, so the posted severity is capped from BLOCKER (set at build time) to WARNING. This is an accepted design decision — it mirrors how OSV findings with "vulnerability" titles are capped, and engineering the title to dodge the cap would be fragile and misleading.
- **`category` stays `"security"`** (not `"secrets"`) deliberately: the noise filter dedupes against the LLM security pass on the same line only when categories match. `source_pass="secrets"` still distinguishes the source of a comment.
- **The v1 pattern list is intentionally small (8 patterns)** — additions are a follow-up, not this PR. The entropy-gated generic pattern covers unnamed assignments in the meantime. If a common format is missed, extend the pattern table; don't change the structure.
- **Fail-open**: any exception during the scan logs a warning and returns no comments — a scanner bug never blocks a review.
