### PR TITLE
feat(review): add xhigh thinking mode for reviews

### DIFF
--- a/src/mira/config.py
+++ b/src/mira/config.py
@@ -45,8 +45,8 @@ class LLMConfig(BaseModel):
     # the security sweep is the highest-stakes pass and must not silently
     # downgrade to the indexing tier.
     security_model: str | None = None
-    # Extended-thinking effort for reviews ("low"/"medium"/"high"; None/"off" =
-    # no reasoning). `review_reasoning_effort` is the mira.yaml-level override;
+    # Extended-thinking effort for reviews ("off"/"low"/"medium"/"high"/"xhigh"/"max";
+    # None/"off" = no reasoning). `review_reasoning_effort` is the mira.yaml-level override;
     # `reasoning_effort` is the resolved value the provider reads (set by
     # `llm_config_for`, the same way `model` is resolved from `review_model`).
     review_reasoning_effort: str | None = None

--- a/src/mira/dashboard/api.py
+++ b/src/mira/dashboard/api.py
@@ -369,7 +369,7 @@ class ModelsResponse(BaseModel):
     indexing_options: list[ModelOption]
     review_options: list[ModelOption]
     security_options: list[ModelOption]
-    # Extended-thinking effort for reviews ("off"/"low"/"medium"/"high").
+    # Extended-thinking effort for reviews ("off"/"low"/"medium"/"high"/"xhigh"/"max").
     review_thinking_mode: str
     thinking_options: list[ModelOption]
     # Protocol dialect for the OpenAI-compatible endpoint ("chat"/"responses"),

--- a/src/mira/dashboard/models_config.py
+++ b/src/mira/dashboard/models_config.py
@@ -19,15 +19,17 @@ MODEL_PRICING: dict[str, tuple[float, float]] = {
 }
 
 # Thinking-mode options for the review model. "off" disables extended thinking
-# (today's behavior); low/medium/high map to OpenRouter's unified
-# ``reasoning.effort``. Single source for the dashboard dropdown and validation.
+# (today's behavior); low/medium/high/xhigh map to the provider's unified
+# ``reasoning.effort``; "max" is a top level remapped per provider (OpenRouter
+# sends it as "xhigh"). Single source for the dashboard dropdown and validation.
 THINKING_MODES: list[dict[str, str]] = [
     {"value": "off", "label": "Off"},
     {"value": "low", "label": "Low"},
     {"value": "medium", "label": "Medium"},
     {"value": "high", "label": "High"},
-    # DeepSeek's top "max" level (sent as "xhigh" on OpenRouter, which rejects
-    # "max"). Not every provider supports it.
+    {"value": "xhigh", "label": "XHigh"},
+    # Top "max" level (sent as "xhigh" on OpenRouter, which rejects "max").
+    # Sits above "xhigh". Not every provider supports it.
     {"value": "max", "label": "Max"},
 ]
 THINKING_MODE_VALUES = {m["value"] for m in THINKING_MODES}

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -199,6 +199,32 @@ class TestComplete:
             body = mock_client.post.call_args.kwargs["json"]
             assert body["reasoning"] == {"effort": "max"}
 
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "high"),
+            ("xhigh", "xhigh"),
+            ("max", "xhigh"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_all_effort_levels_map_on_openrouter(self, effort, expected):
+        config = LLMConfig(model="test-model", reasoning_effort=effort)
+        provider = LLMProvider(config)
+        mock_resp = _mock_httpx_response(_make_response_json("ok"))
+        with patch("mira.llm.provider.httpx.AsyncClient") as cls:
+            client = AsyncMock()
+            client.post = AsyncMock(return_value=mock_resp)
+            client.__aenter__ = AsyncMock(return_value=client)
+            client.__aexit__ = AsyncMock(return_value=False)
+            cls.return_value = client
+            await provider.complete([{"role": "user", "content": "hi"}])
+            body = client.post.call_args.kwargs["json"]
+            assert body["reasoning"] == {"effort": expected}
+            assert "temperature" not in body
+
     @pytest.mark.asyncio
     async def test_reasoning_off_leaves_body_unchanged(self):
         for effort in (None, "off"):

--- a/tests/test_models_config_thinking.py
+++ b/tests/test_models_config_thinking.py
@@ -99,6 +99,15 @@ class TestSetModelsThinkingValidation:
         assert set_models(body, _admin_req()) == {"ok": True}
         assert in_memory_db.get_setting("review_thinking_mode") == "medium"
 
+    def test_persists_xhigh_thinking_mode(self, in_memory_db: AppDatabase):
+        body = ModelsUpdate(
+            indexing_model="anthropic/claude-haiku-4-5",
+            review_model="anthropic/claude-sonnet-4-6",
+            review_thinking_mode="xhigh",
+        )
+        assert set_models(body, _admin_req()) == {"ok": True}
+        assert in_memory_db.get_setting("review_thinking_mode") == "xhigh"
+
     def test_off_clears_setting_so_config_can_win(self, in_memory_db: AppDatabase):
         # "off" must not be persisted as a literal — it'd shadow a mira.yaml
         # override. It's stored as "" (the column is NOT NULL) and reads as unset.

--- a/tests/test_responses_provider.py
+++ b/tests/test_responses_provider.py
@@ -664,6 +664,15 @@ class TestApplyReasoning:
         assert body["reasoning"] == {"effort": "high"}
 
     @pytest.mark.asyncio
+    async def test_apply_reasoning_xhigh(self, config: LLMConfig):
+        """xhigh passes through verbatim on non-OpenRouter OpenAI-compatible hosts."""
+        config.reasoning_effort = "xhigh"
+        provider = ResponsesProvider(config)
+        body = {"model": "gpt-4o"}
+        provider._apply_reasoning(body)
+        assert body["reasoning"] == {"effort": "xhigh"}
+
+    @pytest.mark.asyncio
     async def test_apply_reasoning_skips_when_off(self, config: LLMConfig):
         """_apply_reasoning is a no-op when reasoning effort is off or None."""
         provider = ResponsesProvider(config)


### PR DESCRIPTION
## Summary

Add xhigh as a selectable review thinking mode. It flows to the provider verbatim as `reasoning.effort` on every OpenAI-compatible endpoint (chat completions, Responses API, custom).

## Motivation

Mira's review thinking mode offered low/medium/high/max, but the widely supported xhigh level was not selectable — the dashboard rejected it in validation and it never appeared in the dropdown.

## Changes

- The dashboard thinking-mode list (single source for the dropdown and validation) now includes xhigh.
- xhigh flows through the shared reasoning writer verbatim on chat, Responses, and custom endpoints — no provider branching required.
- New unit tests lock in the xhigh wire value and dashboard acceptance.

## Notes

Bedrock is intentionally out of scope: it has no effort levels, so xhigh falls back to the default 8192-token budget.
