### PR TITLE
Add RepoCloud deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Run Mira self-hosted to auto-review every PR and merge request and answer `@mira
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/workspace/templates/05874bad-2d98-43f4-aa93-332f394e9ebd)
 
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Mira/)
+
 ```yaml
 # mira.yaml — deployment-wide defaults. Every key is optional.
 llm:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Measured on the same 50-PR offline benchmark, judged by Claude Sonnet 4.6.
 
 Run Mira self-hosted to auto-review every PR and merge request and answer `@miracodeai` questions inline. GitHub (as a GitHub App), GitLab (via a group/project access token), and Forgejo/Codeberg (via an access token) are all fully supported; Bitbucket is next.
 
-**1. Deploy** — one-click on Railway, or with Docker:
+**1. Deploy** — one-click on Railway, RepoCloud, or with Docker:
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/workspace/templates/05874bad-2d98-43f4-aa93-332f394e9ebd)
 


### PR DESCRIPTION
This PR adds RepoCloud as a one-click deployment option alongside the existing Railway button in the Quick Start section.