### PR TITLE
feat(engine): skip review when PR has merge conflicts

### DIFF
--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -522,6 +522,30 @@ class ReviewEngine:
         pr_info = await self.provider.get_pr_info(pr_url)
         self._pr_info = pr_info
 
+        # Merge conflicts make the PR diff unreliable (and often empty). Post an
+        # explicit skip instead of a quiet "0 comments" walkthrough (#253).
+        if pr_info.mergeable_state == "dirty":
+            reason = (
+                "this PR has merge conflicts, so the diff could not be read "
+                "reliably. Resolve the conflicts and comment `@mira review` to re-run."
+            )
+            result = ReviewResult(
+                summary="Skipped — merge conflicts",
+                skipped_reason=reason,
+            )
+            if not self.dry_run:
+                body = (
+                    "## Mira PR Walkthrough
+
+"
+                    f"*⚠️ Skipped — {reason}*"
+                )
+                try:
+                    await self.provider.post_comment(pr_info, body)
+                except Exception as exc:
+                    logger.warning("Failed to post merge-conflict skip comment: %s", exc)
+            return result
+
         async def _resolve_threads() -> tuple[
             int, int, list[UnresolvedThread], list[ThreadDecision]
         ]:

--- a/src/mira/models.py
+++ b/src/mira/models.py
@@ -421,6 +421,11 @@ class PRInfo:
     # and surfaced (with avatar) in the activity dashboard.
     author: str = ""
     author_avatar_url: str = ""
+    # GitHub mergeability: "clean" / "dirty" / "unstable" / "blocked" / "unknown"
+    # (or "" when the host did not report one). "dirty" means merge conflicts.
+    # While GitHub is still computing, providers leave this empty rather than
+    # guessing — callers must treat "" as unknown, not as a conflict.
+    mergeable_state: str = ""
 
 
 @dataclass

--- a/src/mira/providers/forgejo.py
+++ b/src/mira/providers/forgejo.py
@@ -133,6 +133,11 @@ class ForgejoProvider(BaseProvider):
             repo=repo,
             head_sha=(pr.get("head") or {}).get("sha") or "",
             platform="forgejo",
+            mergeable_state=(
+                "dirty"
+                if pr.get("mergeable") is False
+                else ("clean" if pr.get("mergeable") is True else "")
+            ),
         )
 
     async def get_pr_diff(self, pr_info: PRInfo) -> str:

--- a/src/mira/providers/github.py
+++ b/src/mira/providers/github.py
@@ -202,6 +202,9 @@ class GitHubProvider(BaseProvider):
             gh_repo = self._github.get_repo(f"{owner}/{repo}")
             pr = gh_repo.get_pull(number)
             user = pr.user
+            # mergeable_state is None while GitHub is still computing; leave
+            # empty so callers treat it as unknown rather than a conflict.
+            state = getattr(pr, "mergeable_state", None) or ""
             return PRInfo(
                 title=pr.title or "",
                 description=pr.body or "",
@@ -214,6 +217,7 @@ class GitHubProvider(BaseProvider):
                 head_sha=pr.head.sha or "",
                 author=(user.login or "") if user else "",
                 author_avatar_url=(user.avatar_url or "") if user else "",
+                mergeable_state=state,
             )
 
         try:

--- a/tests/test_merge_conflict_skip.py
+++ b/tests/test_merge_conflict_skip.py
@@ -1,0 +1,86 @@
+"""Regression: merge-conflict PRs must not look like clean empty reviews."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mira.core.engine import ReviewEngine
+from mira.models import PRInfo, ReviewResult
+
+
+@pytest.mark.asyncio
+async def test_review_pr_skips_when_mergeable_state_dirty():
+    provider = MagicMock()
+    provider.get_pr_info = AsyncMock(
+        return_value=PRInfo(
+            title="t",
+            description="",
+            base_branch="main",
+            head_branch="feat",
+            url="https://github.com/o/r/pull/1",
+            number=1,
+            owner="o",
+            repo="r",
+            mergeable_state="dirty",
+        )
+    )
+    provider.post_comment = AsyncMock()
+    provider.get_pr_diff = AsyncMock(side_effect=AssertionError("diff must not be fetched"))
+
+    engine = ReviewEngine.__new__(ReviewEngine)
+    engine.provider = provider
+    engine.dry_run = False
+    engine.bot_name = "mira"
+    engine.config = MagicMock()
+    engine.config.review.auto_resolve_conversations = False
+
+    result = await ReviewEngine.review_pr(engine, "https://github.com/o/r/pull/1")
+
+    assert isinstance(result, ReviewResult)
+    assert result.skipped_reason is not None
+    assert "merge conflicts" in result.skipped_reason
+    assert result.comments == []
+    provider.post_comment.assert_awaited()
+    provider.get_pr_diff.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_review_pr_continues_when_mergeable_state_unknown():
+    """Empty mergeable_state means GitHub is still computing — do not skip."""
+    provider = MagicMock()
+    provider.get_pr_info = AsyncMock(
+        return_value=PRInfo(
+            title="t",
+            description="",
+            base_branch="main",
+            head_branch="feat",
+            url="https://github.com/o/r/pull/2",
+            number=2,
+            owner="o",
+            repo="r",
+            mergeable_state="",
+        )
+    )
+    # Short-circuit the rest of the pipeline after the dirty check.
+    provider.get_pr_diff = AsyncMock(return_value="")
+    provider.get_all_bot_threads = AsyncMock(return_value=[])
+
+    engine = ReviewEngine.__new__(ReviewEngine)
+    engine.provider = provider
+    engine.dry_run = True
+    engine.bot_name = "mira"
+    engine.config = MagicMock()
+    engine.config.review.auto_resolve_conversations = False
+    engine.config.review.blast_radius = False
+    engine.llm = MagicMock()
+
+    # May proceed into review; only assert we did not take the dirty early-return
+    # without fetching the diff.
+    try:
+        await ReviewEngine.review_pr(engine, "https://github.com/o/r/pull/2")
+    except Exception:
+        # Pipeline may fail later without full engine wiring; that is OK.
+        pass
+    provider.get_pr_diff.assert_awaited()


### PR DESCRIPTION
## Summary
When a PR's `mergeable_state` is `dirty`, Mira currently continues into review with an empty/unreliable diff and can post a walkthrough that looks like a clean "0 comments" result.

This change:

- Adds `PRInfo.mergeable_state` (empty = unknown / still computing)
- Populates it from GitHub (`mergeable_state`) and Forgejo/Gitea (`mergeable` bool)
- Skips the review pipeline for `dirty` and posts an explicit ⚠️ skip comment

Fixes #253

## Test plan
- [ ] `tests/test_merge_conflict_skip.py` — dirty skips without fetching diff; unknown still proceeds
- [ ] Manual: open a conflicted PR and confirm the skip walkthrough instead of an empty review
