### PR TITLE
fix(review): enforce hard character cap on review summaries

### DIFF
--- a/src/mira/core/engine.py
+++ b/src/mira/core/engine.py
@@ -21,6 +21,7 @@ from mira.core.file_filter import filter_files
 from mira.core.noise_filter import drop_already_posted, filter_noise
 from mira.core.passes import (
     agentic_review_loop,
+    cap_review_summary,
     dependency_review_pass,
     regenerate_summary,
     security_review_pass,
@@ -1568,6 +1569,7 @@ class ReviewEngine:
             except Exception as exc:
                 logger.warning("Summary regeneration failed, using original: %s", exc)
                 summary = original_summary or "No issues found."
+            summary = cap_review_summary(summary)
         else:
             summary = ""
 

--- a/src/mira/core/passes.py
+++ b/src/mira/core/passes.py
@@ -31,6 +31,23 @@ from mira.models import KeyIssue, ReviewComment, Severity
 
 logger = logging.getLogger(__name__)
 
+_MAX_REVIEW_SUMMARY_CHARS = 2_000
+_MAX_REVIEW_SUMMARY_TOKENS = 512
+_SUMMARY_TRUNCATION_MARKER = " … [summary truncated]"
+
+
+def cap_review_summary(text: str) -> str:
+    text = text.strip()
+    if len(text) <= _MAX_REVIEW_SUMMARY_CHARS:
+        return text
+
+    content_limit = _MAX_REVIEW_SUMMARY_CHARS - len(_SUMMARY_TRUNCATION_MARKER)
+    prefix = text[:content_limit].rstrip()
+    boundary = max(prefix.rfind(" "), prefix.rfind("\n"), prefix.rfind("\t"))
+    if boundary > 0:
+        prefix = prefix[:boundary].rstrip()
+    return prefix + _SUMMARY_TRUNCATION_MARKER
+
 
 async def agentic_review_loop(
     llm: LLMProviderProtocol,
@@ -569,10 +586,10 @@ async def regenerate_summary(
             messages=[{"role": "user", "content": prompt}],
             json_mode=False,
             temperature=0.0,
+            max_tokens=_MAX_REVIEW_SUMMARY_TOKENS,
         )
     except Exception as exc:
         logger.warning("Summary regen LLM call failed: %s", exc)
-        return fallback or "No issues found."
+        return cap_review_summary(fallback) or "No issues found."
 
-    text = (text or "").strip()
-    return text or fallback or "No issues found."
+    return cap_review_summary(text or "") or cap_review_summary(fallback) or "No issues found."

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2049,6 +2049,43 @@ class TestRegenerateSummary:
         )
         assert out == "fallback"
 
+    @pytest.mark.asyncio
+    async def test_caps_generated_summary_and_output_tokens(self, monkeypatch):
+        """Runaway model output is bounded before it can reach a provider."""
+        from mira.core.passes import regenerate_summary
+        from mira.llm import provider as provider_mod
+
+        async def fake_complete(self, messages, json_mode=True, temperature=None, max_tokens=None):
+            assert max_tokens == 512
+            return "word " * 1_000
+
+        monkeypatch.setattr(provider_mod.LLMProvider, "complete", fake_complete)
+
+        out = await regenerate_summary(
+            AsyncMock(), [self._comment()], [], "t", "d", fallback="fallback"
+        )
+
+        assert len(out) <= 2_000
+        assert out.endswith("… [summary truncated]")
+
+    @pytest.mark.asyncio
+    async def test_caps_fallback_after_llm_failure(self, monkeypatch):
+        """The fallback path has the same hard character limit."""
+        from mira.core.passes import regenerate_summary
+        from mira.llm import provider as provider_mod
+
+        async def fake_complete(self, messages, json_mode=True, temperature=None, max_tokens=None):
+            raise RuntimeError("LLM down")
+
+        monkeypatch.setattr(provider_mod.LLMProvider, "complete", fake_complete)
+
+        out = await regenerate_summary(
+            AsyncMock(), [self._comment()], [], "t", "d", fallback="fallback " * 1_000
+        )
+
+        assert len(out) <= 2_000
+        assert out.endswith("… [summary truncated]")
+
 
 class TestDropOrphanKeyIssues:
     """Key Issues table must stay in sync with surviving inline comments."""


### PR DESCRIPTION
## Summary

- cap generated and fallback review summaries at 2,000 characters
- limit summary-generation responses to 512 output tokens
- truncate on a word boundary and add an explicit truncation marker
- apply the cap again when the final ReviewResult is assembled

Closes #256.

## Test plan

- `pytest tests/test_engine.py -k TestRegenerateSummary -q`
- `ruff check src/mira/core/passes.py src/mira/core/engine.py tests/test_engine.py`
- `ruff format --check src/mira/core/passes.py src/mira/core/engine.py tests/test_engine.py`
- `git diff --check`

The full local suite completed with 1,325 passing tests and 12 failures. All 12 failures reproduce unchanged on a clean `origin/main` checkout and are unrelated to this patch.

## Notes for reviewers

The 2,000-character cap is intentionally generous for the requested 2–3 sentence summary while preventing runaway model output. The 512-token generation limit provides an earlier bound, while the character cap remains authoritative for generated and fallback text.