### PR TITLE
feat: add GPT-6 Astra to the model registry

### DIFF
--- a/src/mira/llm/models.json
+++ b/src/mira/llm/models.json
@@ -111,6 +111,17 @@
     "purposes": ["review"],
     "recommended_for": []
   },
+  "openai/gpt-6-astra": {
+    "label": "GPT-6 Astra",
+    "provider": "openai",
+    "max_input_tokens": 1050000,
+    "max_output_tokens": 128000,
+    "input_cost_per_1m": 10.00,
+    "output_cost_per_1m": 50.00,
+    "supports_json_mode": true,
+    "purposes": ["review"],
+    "recommended_for": []
+  },
   "openai/gpt-5.2": {
     "label": "GPT-5.2",
     "provider": "openai",


### PR DESCRIPTION
OpenAI released GPT-6 Astra (2026-09-03), which now backs Codex. Registers `openai/gpt-6-astra` in the model registry with its published specs: 1.05M input tokens, 128K max output, $10/$50 per 1M input/output tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)