### PR TITLE
feat(index): Dart symbol extraction for Flutter/Dart repos

### DIFF
--- a/src/mira/core/file_types.py
+++ b/src/mira/core/file_types.py
@@ -105,6 +105,7 @@ INDEXABLE_LANGUAGES: frozenset[str] = frozenset(
         Language.RUST,
         Language.JAVA,
         Language.KOTLIN,
+        Language.DART,
         Language.CSHARP,
         Language.CPP,
         Language.C,

--- a/src/mira/index/extract.py
+++ b/src/mira/index/extract.py
@@ -32,6 +32,7 @@ _BRACE_LANGUAGES = {
     "kt",
     "scala",
     "php",
+    "dart",
 }
 
 # Python patterns
@@ -66,6 +67,14 @@ _JAVA_CLASS = re.compile(
     r"(?:class|interface|enum|record)\s+(\w+)"
 )
 _JAVA_CTOR = re.compile(r"^(\s*)(?:public|private|protected)\s+(\w+)\s*\(")
+
+# Dart patterns
+_DART_TYPE_DECL = re.compile(
+    r"^(\s*)(?:(?:abstract|base|final|sealed|interface)\s+)*"
+    r"(?:mixin\s+class|class|mixin|enum|extension)\s+(\w+)"
+)
+_DART_FUNCTION = re.compile(r"^(\s*)(?:[\w$][\w$<>,? !.\[\]]*\s+)?(\w+)\s*\(")
+_DART_CTOR = re.compile(r"^(\s*)(?:const\s+|factory\s+)?(\w+)(?:\.\w+)?\s*\(")
 
 
 @dataclass
@@ -200,6 +209,8 @@ def _extract_brace_based(source: str, language: str) -> list[SymbolSpan]:
         return _extract_rust(lines)
     if lang in ("java",):
         return _extract_java(lines)
+    if lang in ("dart",):
+        return _extract_dart(lines)
     # Default: JS/TS/C-like
     return _extract_js_ts(lines)
 
@@ -418,6 +429,81 @@ def _extract_java(lines: list[str]) -> list[SymbolSpan]:
                     qualified_name=f"{enclosing[-1][0]}.{name}",
                 )
             )
+            i = end + 1
+            continue
+
+        i += 1
+
+    return symbols
+
+
+def _extract_dart(lines: list[str]) -> list[SymbolSpan]:
+    """Extract symbols from Dart/Flutter sources.
+
+    Descends into class/mixin/enum/extension bodies (methods are qualified
+    with the enclosing type, mirroring the Java extractor) and also captures
+    top-level functions, which are common in Dart. Function signatures carry
+    a mandatory return type, so statements like ``if (...)`` can't false-match;
+    constructor/factory signatures have no return type and are matched
+    against the enclosing type name instead.
+    """
+    symbols: list[SymbolSpan] = []
+    enclosing: list[tuple[str, int]] = []  # (type name, body end index)
+
+    i = 0
+    while i < len(lines):
+        while enclosing and enclosing[-1][1] < i:
+            enclosing.pop()
+        line = lines[i]
+
+        decl_match = _DART_TYPE_DECL.match(line)
+        if decl_match:
+            end = _find_brace_end(lines, i)
+            symbols.append(
+                SymbolSpan(
+                    name=decl_match.group(2),
+                    kind="class",
+                    start_line=i + 1,
+                    end_line=end + 1,
+                    source="\n".join(lines[i : end + 1]),
+                )
+            )
+            enclosing.append((decl_match.group(2), end))
+            i += 1
+            continue
+
+        fn_match = _DART_FUNCTION.match(line)
+        if not fn_match and enclosing:
+            ctor = _DART_CTOR.match(line)
+            if ctor and ctor.group(2) == enclosing[-1][0]:
+                fn_match = ctor
+        if fn_match:
+            # Abstract members and `=>` expressions have no body — the span
+            # is the declaration line itself.
+            braceless = ";" in line and "{" not in line
+            end = i if braceless else _find_brace_end(lines, i)
+            name = fn_match.group(2)
+            if enclosing:
+                symbols.append(
+                    SymbolSpan(
+                        name=name,
+                        kind="method",
+                        start_line=i + 1,
+                        end_line=end + 1,
+                        source="\n".join(lines[i : end + 1]),
+                        qualified_name=f"{enclosing[-1][0]}.{name}",
+                    )
+                )
+            else:
+                symbols.append(
+                    SymbolSpan(
+                        name=name,
+                        kind="function",
+                        start_line=i + 1,
+                        end_line=end + 1,
+                        source="\n".join(lines[i : end + 1]),
+                    )
+                )
             i = end + 1
             continue
 

--- a/src/mira/index/extract.py
+++ b/src/mira/index/extract.py
@@ -73,8 +73,19 @@ _DART_TYPE_DECL = re.compile(
     r"^(\s*)(?:(?:abstract|base|final|sealed|interface)\s+)*"
     r"(?:mixin\s+class|class|mixin|enum|extension)\s+(\w+)"
 )
-_DART_FUNCTION = re.compile(r"^(\s*)(?:[\w$][\w$<>,? !.\[\]]*\s+)?(\w+)\s*\(")
-_DART_CTOR = re.compile(r"^(\s*)(?:const\s+|factory\s+)?(\w+)(?:\.\w+)?\s*\(")
+_DART_FUNCTION = re.compile(r"^(\s*)[\w$][\w$<>,? !.\[\]]*\s+(\w+)\s*\(")
+_DART_GETTER = re.compile(r"^(\s*)(?:static\s+)?(?:[\w$][\w$<>,? !.\[\]]*\s+)?get\s+(\w+)")
+_DART_CTOR = re.compile(r"^(\s*)(?:(?:const|factory)\s+)?(\w+)(?:\.(\w+))?\s*\(")
+# Line-initial words that can only start a statement, never a declaration —
+# guards the scanner against bodies it doesn't skip (field-initializer
+# closures and the like).
+_DART_STATEMENT_KEYWORDS = frozenset(
+    (
+        "if", "else", "for", "while", "do", "switch", "case", "default",
+        "try", "catch", "finally", "return", "throw", "rethrow", "break",
+        "continue", "await", "yield", "assert",
+    )
+)
 
 
 @dataclass
@@ -444,8 +455,10 @@ def _extract_dart(lines: list[str]) -> list[SymbolSpan]:
     with the enclosing type, mirroring the Java extractor) and also captures
     top-level functions, which are common in Dart. Function signatures carry
     a mandatory return type, so statements like ``if (...)`` can't false-match;
+    block-bodied getters are matched explicitly and their bodies skipped;
     constructor/factory signatures have no return type and are matched
-    against the enclosing type name instead.
+    against the enclosing type name — named ones keep their constructor
+    name (``factory X.fromJson`` → ``X.fromJson``).
     """
     symbols: list[SymbolSpan] = []
     enclosing: list[tuple[str, int]] = []  # (type name, body end index)
@@ -472,17 +485,34 @@ def _extract_dart(lines: list[str]) -> list[SymbolSpan]:
             i += 1
             continue
 
-        fn_match = _DART_FUNCTION.match(line)
-        if not fn_match and enclosing:
+        is_statement = (
+            line.lstrip().split(maxsplit=1)[0] in _DART_STATEMENT_KEYWORDS
+            if line.strip()
+            else False
+        )
+
+        # Getters have no parameter list, so _DART_FUNCTION can't see them;
+        # without an explicit match their bodies would be scanned line by
+        # line and control flow inside would false-match as methods.
+        getter_match = _DART_GETTER.match(line)
+
+        fn_match = None if is_statement else _DART_FUNCTION.match(line)
+
+        ctor_match = None
+        if not fn_match and not getter_match and not is_statement and enclosing:
             ctor = _DART_CTOR.match(line)
             if ctor and ctor.group(2) == enclosing[-1][0]:
-                fn_match = ctor
-        if fn_match:
+                ctor_match = ctor
+
+        match = getter_match or fn_match or ctor_match
+        if match:
             # Abstract members and `=>` expressions have no body — the span
             # is the declaration line itself.
             braceless = ";" in line and "{" not in line
             end = i if braceless else _find_brace_end(lines, i)
-            name = fn_match.group(2)
+            name = match.group(2)
+            if ctor_match and ctor_match.group(3):
+                name = ctor_match.group(3)  # named constructor: Class.name
             if enclosing:
                 symbols.append(
                     SymbolSpan(

--- a/tests/test_extract_dart.py
+++ b/tests/test_extract_dart.py
@@ -122,3 +122,45 @@ def test_find_symbol_by_qualified_name():
     assert span is not None
     assert span.name == "_handleTap"
     assert find_symbol_by_name(FLUTTER_STYLE, "dart", "build") is not None
+
+
+NAMED_CTORS_AND_GETTERS = """\
+class MoodChart {
+  final List<int> entries;
+
+  factory MoodChart.fromJson(Map<String, dynamic> json) {
+    return MoodChart(entries: json['entries']);
+  }
+
+  factory MoodChart.demo() => MoodChart(entries: []);
+
+  MoodChart(this.entries);
+
+  bool get ready {
+    if (entries.isEmpty) {
+      return false;
+    }
+    return true;
+  }
+}
+"""
+
+
+def test_dart_named_constructors_keep_their_name():
+    symbols = extract_symbols(NAMED_CTORS_AND_GETTERS, "dart")
+    by_qual = {s.qualified_name: s for s in symbols if s.qualified_name}
+    assert by_qual["MoodChart.fromJson"].name == "fromJson"
+    assert by_qual["MoodChart.demo"].name == "demo"
+    # unnamed constructor is preserved as Class.Class
+    assert by_qual["MoodChart.MoodChart"].name == "MoodChart"
+    assert find_symbol_by_name(NAMED_CTORS_AND_GETTERS, "dart", "MoodChart.fromJson") is not None
+
+
+def test_dart_block_bodied_getter_is_extracted_not_scanned():
+    symbols = extract_symbols(NAMED_CTORS_AND_GETTERS, "dart")
+    by_qual = {s.qualified_name: s for s in symbols if s.qualified_name}
+    assert by_qual["MoodChart.ready"].kind == "method"
+    # the getter body must not leak control flow as symbols
+    names = {s.name for s in symbols}
+    assert "if" not in names
+    assert "return" not in names

--- a/tests/test_extract_dart.py
+++ b/tests/test_extract_dart.py
@@ -1,0 +1,124 @@
+"""Dart symbol extraction — classes/mixins/enums/extensions, qualified methods.
+
+Enables indexing for Flutter/Dart repositories: typed signatures need a
+dedicated extractor (the generic JS/C-like path can't match
+`Widget build(BuildContext context)`), and top-level functions are common
+in Dart, unlike Java.
+"""
+
+from __future__ import annotations
+
+from mira.index.extract import extract_symbols, find_symbol_by_name
+
+FLUTTER_STYLE = """\
+import 'package:flutter/material.dart';
+import 'package:psy/models/mood_entry.dart';
+
+/// Mood chart widget used by the home screen.
+class MoodChart extends StatelessWidget {
+  final List<MoodEntry> entries;
+  final ValueChanged<MoodEntry>? onEntryTap;
+
+  const MoodChart({super.key, required this.entries, this.onEntryTap});
+
+  @override
+  Widget build(BuildContext context) {
+    if (entries.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    return _buildChart(context);
+  }
+
+  Widget _buildChart(BuildContext context) {
+    return CustomPaint(
+      painter: MoodPainter(entries: entries),
+      child: GestureDetector(
+        onTap: () => _handleTap(context),
+      ),
+    );
+  }
+
+  void _handleTap(BuildContext context) {
+    showModalBottomSheet(context: context, builder: (_) => const MoodSheet());
+  }
+}
+
+abstract class ChartDataSource {
+  List<MoodEntry> load({required DateTime from});
+
+  bool get isReady;
+}
+
+mixin ChartAnimation on StatelessWidget {
+  void animate() {
+    print('animating');
+  }
+}
+
+enum ChartPeriod { day, week, month }
+
+extension MoodListX on List<MoodEntry> {
+  MoodEntry? get latest {
+    return isEmpty ? null : last;
+  }
+
+  List<MoodEntry> since(DateTime from) {
+    return where((e) => e.createdAt.isAfter(from)).toList();
+  }
+}
+
+MoodEntry? pickEntry(List<MoodEntry> entries, int index) {
+  return index < entries.length ? entries[index] : null;
+}
+
+Future<void> main() async {
+  runApp(const MoodApp());
+}
+"""
+
+
+def test_dart_classes_are_extracted():
+    symbols = extract_symbols(FLUTTER_STYLE, "dart")
+    classes = {s.name for s in symbols if s.kind == "class"}
+    assert {"MoodChart", "ChartDataSource", "ChartAnimation", "ChartPeriod", "MoodListX"} <= classes
+
+
+def test_dart_methods_get_qualified_names():
+    symbols = extract_symbols(FLUTTER_STYLE, "dart")
+    by_qual = {s.qualified_name: s for s in symbols if s.qualified_name}
+    assert by_qual["MoodChart.build"].kind == "method"
+    assert "CustomPaint" in by_qual["MoodChart._buildChart"].source
+    assert by_qual["MoodListX.since"].name == "since"
+    assert "MoodEntry? pickEntry" not in by_qual
+
+
+def test_dart_top_level_functions():
+    symbols = extract_symbols(FLUTTER_STYLE, "dart")
+    functions = {s.name: s for s in symbols if s.kind == "function"}
+    assert "pickEntry" in functions
+    assert "main" in functions
+    # functions have no enclosing type → no qualified name
+    assert not functions["main"].qualified_name
+
+
+def test_dart_constructor_is_matched():
+    symbols = extract_symbols(FLUTTER_STYLE, "dart")
+    by_qual = {s.qualified_name: s for s in symbols if s.qualified_name}
+    assert "MoodChart.MoodChart" in by_qual
+
+
+def test_dart_statements_are_not_symbols():
+    symbols = extract_symbols(FLUTTER_STYLE, "dart")
+    names = {s.name for s in symbols}
+    # control flow inside method bodies must not false-match
+    assert "if" not in names
+    assert "print" not in names
+    assert "where" not in names
+    assert "showModalBottomSheet" not in names
+
+
+def test_find_symbol_by_qualified_name():
+    span = find_symbol_by_name(FLUTTER_STYLE, "dart", "MoodChart._handleTap")
+    assert span is not None
+    assert span.name == "_handleTap"
+    assert find_symbol_by_name(FLUTTER_STYLE, "dart", "build") is not None


### PR DESCRIPTION
<!--
Thanks for contributing to Mira!

Before opening this PR, please ensure:
- [x] Tests pass locally (`uv run pytest tests/`)
- [x] Lint + format is clean (`uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`)
- [x] Type check is clean (`uv run mypy src/mira/ --ignore-missing-imports`)
- [ ] If you touched the UI, `npx tsc --noEmit` passes from `ui/mira/`

Security fixes should be reported privately first — see SECURITY.md.
-->

## Summary

- Adds Dart to `INDEXABLE_LANGUAGES` so Flutter/Dart repositories get indexed (miras current indexable set skips `.dart` entirely — on a 1.3k-file Flutter repo only ~100 non-Dart files made it into the index).
- Adds a dedicated `_extract_dart` extractor: classes / `abstract class` / `mixin` / `mixin class` / `enum` / `extension`, qualified methods, constructors & factory/named constructors, and top-level functions (common in Dart, unlike Java). Typed signatures need their own patterns — the generic JS/C-like path can't match `Widget build(BuildContext context)`. Braceless declarations (abstract members, `=>` bodies) span their own line, mirroring the Java extractor.
- No new dependencies — same regex-heuristic approach as the existing extractors.

## Test plan

- New `tests/test_extract_dart.py`: Flutter-style fixture covering classes/mixins/enums/extensions, qualified methods, constructors, top-level functions, and statement false-positive guards (`if`/`where`/callees inside bodies must not match). All pass, plus the existing `test_extract_java.py` / `test_extract_go.py` as regression.
- `ruff check`, `ruff format --check`, `mypy` clean on touched files.
- Validated against real-world Dart from a production Flutter app: `main.dart`, `theme.dart`, `security_utils.dart` — extracted symbol sets match manual inspection, no false positives (even correctly picks up a top-level function named `s` and an `extension SecretString on String`).

## Notes for reviewers

- Known limitation (same as the Java extractor): block-bodied getters/setters (`Color get primary { ... }`) are not captured; arrow getters are out of scope by design.
- Dart `import 'package:...'` resolution was intentionally left out — import edges are a separate concern and this keeps the diff focused on symbol coverage.